### PR TITLE
refactor: share adapter method and scope types

### DIFF
--- a/.changeset/refactor-adapters-types.md
+++ b/.changeset/refactor-adapters-types.md
@@ -1,0 +1,6 @@
+---
+"@danceroutine/tango-adapters-core": patch
+"@danceroutine/tango-adapters-next": patch
+---
+
+Hoist shared HTTP method and action scope value types into adapters core so framework adapters stop re-declaring them.

--- a/packages/adapters/core/src/domain/index.ts
+++ b/packages/adapters/core/src/domain/index.ts
@@ -1,3 +1,3 @@
-export { InternalHttpMethod } from './internal/InternalHttpMethod';
-export { InternalActionScope } from './internal/InternalActionScope';
+export { InternalHttpMethod, type HttpMethod } from './internal/InternalHttpMethod';
+export { InternalActionScope, type ActionScope } from './internal/InternalActionScope';
 export { InternalActionMatchKind } from './internal/InternalActionMatchKind';

--- a/packages/adapters/core/src/domain/internal/InternalActionScope.ts
+++ b/packages/adapters/core/src/domain/internal/InternalActionScope.ts
@@ -2,3 +2,5 @@ export const InternalActionScope = {
     DETAIL: 'detail',
     COLLECTION: 'collection',
 } as const;
+
+export type ActionScope = (typeof InternalActionScope)[keyof typeof InternalActionScope];

--- a/packages/adapters/core/src/domain/internal/InternalHttpMethod.ts
+++ b/packages/adapters/core/src/domain/internal/InternalHttpMethod.ts
@@ -5,3 +5,5 @@ export const InternalHttpMethod = {
     PATCH: 'PATCH',
     DELETE: 'DELETE',
 } as const;
+
+export type HttpMethod = (typeof InternalHttpMethod)[keyof typeof InternalHttpMethod];

--- a/packages/adapters/core/src/index.ts
+++ b/packages/adapters/core/src/index.ts
@@ -8,4 +8,10 @@ export * as domain from './domain/index';
 export type { FrameworkAdapter, FrameworkAdapterOptions } from './adapter/index';
 export { FRAMEWORK_ADAPTER_BRAND, isFrameworkAdapter } from './adapter/index';
 // Exported because adapters-core is an internal package aimed at consumers that would act as the public interface
-export { InternalHttpMethod, InternalActionScope, InternalActionMatchKind } from './domain/index';
+export {
+    InternalHttpMethod,
+    InternalActionScope,
+    InternalActionMatchKind,
+    type HttpMethod,
+    type ActionScope,
+} from './domain/index';

--- a/packages/adapters/next/src/adapter/NextAdapter.ts
+++ b/packages/adapters/next/src/adapter/NextAdapter.ts
@@ -13,10 +13,13 @@ import {
     type FrameworkAdapter,
     type FrameworkAdapterOptions,
 } from '@danceroutine/tango-adapters-core/adapter';
-import { InternalHttpMethod, InternalActionScope, InternalActionMatchKind } from '@danceroutine/tango-adapters-core';
-
-type HttpMethod = (typeof InternalHttpMethod)[keyof typeof InternalHttpMethod];
-type ActionScope = (typeof InternalActionScope)[keyof typeof InternalActionScope];
+import {
+    InternalHttpMethod,
+    InternalActionScope,
+    InternalActionMatchKind,
+    type ActionScope,
+    type HttpMethod,
+} from '@danceroutine/tango-adapters-core';
 
 type ResolvedViewSetActionDescriptor = {
     name: string;


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk refactor limited to TypeScript type exports/imports plus a changeset; runtime behavior should be unchanged aside from potential build/type-check fallout.
> 
> **Overview**
> Hoists the shared `HttpMethod` and `ActionScope` value-union types into `@danceroutine/tango-adapters-core` (exported via `domain` and the package root) so framework adapters no longer re-declare them.
> 
> Updates `@danceroutine/tango-adapters-next` to import these types directly from core, and adds a changeset bumping both packages as patch releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76134aa2d8de77e7ea96213c66dcf0e49fc5a8de. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->