### PR TITLE
fix: bootstrap npm 11 for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,8 +74,24 @@ jobs:
             - name: Setup pnpm
               uses: pnpm/action-setup@v4
 
-            - name: Upgrade npm for OIDC trusted publishing
-              run: npm install -g npm@11
+            - name: Setup npm 11 for trusted publishing
+              shell: bash
+              run: |
+                  NPM_VERSION=11.11.0
+                  NPM_ROOT="$RUNNER_TEMP/npm-cli"
+                  NPM_BIN="$NPM_ROOT/bin"
+                  curl -fsSL "https://registry.npmjs.org/npm/-/npm-${NPM_VERSION}.tgz" -o "$RUNNER_TEMP/npm.tgz"
+                  rm -rf "$NPM_ROOT"
+                  mkdir -p "$NPM_ROOT" "$NPM_BIN"
+                  tar -xzf "$RUNNER_TEMP/npm.tgz" -C "$NPM_ROOT"
+                  cat > "$NPM_BIN/npm" <<EOF
+                  #!/usr/bin/env bash
+                  exec node "$NPM_ROOT/package/bin/npm-cli.js" "\$@"
+                  EOF
+                  chmod +x "$NPM_BIN/npm"
+                  echo "$NPM_BIN" >> "$GITHUB_PATH"
+                  export PATH="$NPM_BIN:$PATH"
+                  npm --version
 
             - name: Get pnpm store directory
               id: pnpm-cache


### PR DESCRIPTION
## Summary
- replace the fragile global npm self-upgrade in the release workflow
- bootstrap npm 11 from the official tarball instead
- keep later release steps on a trusted-publishing-compatible npm without mutating the runner

## Validation
- pnpm exec eslint .github/workflows/release.yml --quiet
- local npm 11 bootstrap smoke check