### PR TITLE
fix: add stable publish recovery path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ on:
                 options:
                     - alpha
                     - stable
+                    - stable-recovery
             branch:
                 description: 'Branch to release from (workflow_dispatch only)'
                 required: false
@@ -121,9 +122,9 @@ jobs:
                   pnpm test:integration:postgres
 
             - name: Validate stable branch selection
-              if: github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable' && inputs.branch != 'main'
+              if: github.event_name == 'workflow_dispatch' && (inputs.release_type == 'stable' || inputs.release_type == 'stable-recovery') && inputs.branch != 'main'
               run: |
-                  echo "Stable releases must run from main." >&2
+                  echo "Stable releases and stable recovery must run from main." >&2
                   exit 1
 
             - name: Version packages (stable)
@@ -141,8 +142,13 @@ jobs:
                     echo "mode=release" >> "$GITHUB_OUTPUT"
                   fi
 
+            - name: Resolve publish state
+              if: ((github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable')) && steps.stable-release.outputs.mode == 'release') || (github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable-recovery')
+              id: publish-state
+              run: pnpm exec tsx scripts/release/resolve-publish-state.ts
+
             - name: Generate release app token (stable)
-              if: (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable')) && steps.stable-release.outputs.mode == 'release'
+              if: (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable')) && steps.stable-release.outputs.mode == 'release' && steps.publish-state.outputs.mode == 'publish'
               id: release-app-token
               uses: actions/create-github-app-token@v2
               with:
@@ -151,7 +157,7 @@ jobs:
                   owner: ${{ github.repository_owner }}
 
             - name: Commit version changes to main (stable)
-              if: (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable')) && steps.stable-release.outputs.mode == 'release'
+              if: (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable')) && steps.stable-release.outputs.mode == 'release' && steps.publish-state.outputs.mode == 'publish'
               shell: bash
               env:
                   APP_TOKEN: ${{ steps.release-app-token.outputs.token }}
@@ -166,7 +172,7 @@ jobs:
                   git push origin HEAD:main
 
             - name: Publish packages (stable)
-              if: (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable')) && steps.stable-release.outputs.mode == 'release'
+              if: (((github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable')) && steps.stable-release.outputs.mode == 'release') || (github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable-recovery')) && steps.publish-state.outputs.mode == 'publish'
               run: pnpm changeset:publish
               env:
                   NPM_CONFIG_PROVENANCE: true

--- a/docs/contributors/releasing.md
+++ b/docs/contributors/releasing.md
@@ -2,7 +2,7 @@
 
 Releasing Tango publishes the fixed-version package set through the repository's trusted publishing workflow.
 
-We recommend completing the [Contributor setup](/contributors/setup) before you begin. Releases must also be performed by maintainers that have need permission to run the repository's GitHub Actions workflows and access to the `npm` environment that backs trusted publishing.
+We recommend completing the [Contributor setup](/contributors/setup) before you begin. Releases must also be performed by maintainers that have the necessary permission to run the repository's GitHub Actions workflows and access to the `npm` environment that backs trusted publishing.
 
 A typical release moves through the following stages:
 
@@ -66,6 +66,19 @@ The workflow performs these steps:
 The stable versioning command is `pnpm changeset:version`, which runs `scripts/release/version-with-root-changelog.ts`. That script executes `changeset version`, refreshes the lockfile, and prepends the new entry to the root `CHANGELOG.md`.
 
 If `pnpm changeset:version` produces no diff, the stable workflow becomes a no-op for publishing. That usually means there were no pending releasable changesets on `main`.
+
+Before publishing, the workflow compares the committed release versions against the npm registry. If the registry is already at the same version, the publish step becomes a no-op. If the registry is ahead of the committed version, the workflow fails hard because the repository is no longer the source of truth for the release state.
+
+## Recover a failed stable publish
+
+Stable releases commit the generated version changes before publishing. That keeps `main` as the source of truth for the release train, but it also means a publish outage can leave the repository ahead of npm.
+
+When that happens, do not create a second changeset just to force another publish. Instead, dispatch the workflow with:
+
+- `release_type=stable-recovery`
+- `branch=main`
+
+The recovery path skips changeset versioning, inspects the committed package versions on `main`, compares them to npm, and publishes the versions that are still missing from the registry. If npm already matches the committed versions, the recovery path becomes a no-op. If npm is somehow ahead of the repository, the recovery path fails so you can investigate the mismatch explicitly.
 
 ## Run an alpha release
 

--- a/scripts/release/resolve-publish-state.ts
+++ b/scripts/release/resolve-publish-state.ts
@@ -1,0 +1,341 @@
+import { appendFile, readFile, readdir } from 'node:fs/promises';
+import { join } from 'node:path';
+
+type ReleaseConfig = {
+    fixed?: string[][];
+    ignore?: string[];
+};
+
+type PackageEntry = {
+    name: string;
+    version: string;
+    private?: boolean;
+};
+
+type PublishMode = 'noop' | 'publish';
+
+type PackagePublishState =
+    | {
+          packageName: string;
+          repoVersion: string;
+          registryVersion: string | null;
+          relation: 'equal' | 'repo-ahead';
+      }
+    | {
+          packageName: string;
+          repoVersion: string;
+          registryVersion: string;
+          relation: 'registry-ahead';
+      };
+
+type ParsedVersion = {
+    major: number;
+    minor: number;
+    patch: number;
+    prerelease: string[];
+};
+
+const CHANGESET_CONFIG_PATH = '.changeset/config.json';
+const PACKAGES_DIRECTORY = 'packages';
+
+export async function resolvePublishState(rootDir: string): Promise<{
+    mode: PublishMode;
+    publishablePackages: string[];
+    packageStates: PackagePublishState[];
+}> {
+    const releaseConfig = await loadReleaseConfig(rootDir);
+    const fixedPackages = releaseConfig.fixed?.[0];
+
+    if (!fixedPackages || fixedPackages.length === 0) {
+        throw new Error('Expected .changeset/config.json to declare a fixed release group.');
+    }
+
+    const ignoredPackages = new Set(releaseConfig.ignore ?? []);
+    const releasablePackages = fixedPackages.filter((packageName) => !ignoredPackages.has(packageName));
+    const packageEntries = await loadPackageEntries(join(rootDir, PACKAGES_DIRECTORY));
+    const packageStates: PackagePublishState[] = [];
+
+    for (const packageName of releasablePackages) {
+        const packageEntry = packageEntries.get(packageName);
+
+        if (!packageEntry) {
+            throw new Error(`Could not find package.json for release package "${packageName}".`);
+        }
+
+        const registryVersion = await fetchRegistryVersion(packageName);
+
+        if (!registryVersion) {
+            packageStates.push({
+                packageName,
+                repoVersion: packageEntry.version,
+                registryVersion: null,
+                relation: 'repo-ahead',
+            });
+            continue;
+        }
+
+        const comparison = compareVersions(packageEntry.version, registryVersion);
+
+        if (comparison === 0) {
+            packageStates.push({
+                packageName,
+                repoVersion: packageEntry.version,
+                registryVersion,
+                relation: 'equal',
+            });
+            continue;
+        }
+
+        if (comparison > 0) {
+            packageStates.push({
+                packageName,
+                repoVersion: packageEntry.version,
+                registryVersion,
+                relation: 'repo-ahead',
+            });
+            continue;
+        }
+
+        packageStates.push({
+            packageName,
+            repoVersion: packageEntry.version,
+            registryVersion,
+            relation: 'registry-ahead',
+        });
+    }
+
+    const registryAheadPackages = packageStates.filter((state) => state.relation === 'registry-ahead');
+
+    if (registryAheadPackages.length > 0) {
+        const details = registryAheadPackages
+            .map(
+                (state) =>
+                    `- ${state.packageName}: repo=${state.repoVersion}, registry=${state.registryVersion ?? 'unpublished'}`
+            )
+            .join('\n');
+        throw new Error(
+            `Registry versions are ahead of the committed release state for one or more packages.\n${details}`
+        );
+    }
+
+    const publishablePackages = packageStates
+        .filter((state) => state.relation === 'repo-ahead')
+        .map((state) => state.packageName);
+
+    return {
+        mode: publishablePackages.length > 0 ? 'publish' : 'noop',
+        publishablePackages,
+        packageStates,
+    };
+}
+
+async function loadReleaseConfig(rootDir: string): Promise<ReleaseConfig> {
+    const configContent = await readFile(join(rootDir, CHANGESET_CONFIG_PATH), 'utf8');
+    return JSON.parse(configContent) as ReleaseConfig;
+}
+
+async function loadPackageEntries(directory: string): Promise<Map<string, PackageEntry>> {
+    const packageJsonPaths = await findPackageJsonPaths(directory);
+    const packageEntries = new Map<string, PackageEntry>();
+
+    for (const packageJsonPath of packageJsonPaths) {
+        const packageJsonContent = await readFile(packageJsonPath, 'utf8');
+        const packageJson = JSON.parse(packageJsonContent) as PackageEntry;
+
+        if (!packageJson.name || !packageJson.version || packageJson.private === true) {
+            continue;
+        }
+
+        packageEntries.set(packageJson.name, packageJson);
+    }
+
+    return packageEntries;
+}
+
+async function findPackageJsonPaths(directory: string): Promise<string[]> {
+    const entries = await readdir(directory, { withFileTypes: true });
+    const packageJsonPaths: string[] = [];
+
+    for (const entry of entries) {
+        if (entry.name === 'node_modules' || entry.name === 'dist') {
+            continue;
+        }
+
+        const entryPath = join(directory, entry.name);
+
+        if (entry.isDirectory()) {
+            packageJsonPaths.push(...(await findPackageJsonPaths(entryPath)));
+            continue;
+        }
+
+        if (entry.isFile() && entry.name === 'package.json') {
+            packageJsonPaths.push(entryPath);
+        }
+    }
+
+    return packageJsonPaths.sort();
+}
+
+async function fetchRegistryVersion(packageName: string): Promise<string | null> {
+    const encodedName = encodeURIComponent(packageName);
+    const response = await fetch(`https://registry.npmjs.org/${encodedName}`);
+
+    if (response.status === 404) {
+        return null;
+    }
+
+    if (!response.ok) {
+        throw new Error(
+            `Failed to read npm registry metadata for "${packageName}": ${response.status} ${response.statusText}`
+        );
+    }
+
+    const body = (await response.json()) as {
+        'dist-tags'?: {
+            latest?: string;
+        };
+    };
+
+    return body['dist-tags']?.latest ?? null;
+}
+
+function compareVersions(left: string, right: string): number {
+    const leftVersion = parseVersion(left);
+    const rightVersion = parseVersion(right);
+
+    if (leftVersion.major !== rightVersion.major) {
+        return leftVersion.major - rightVersion.major;
+    }
+
+    if (leftVersion.minor !== rightVersion.minor) {
+        return leftVersion.minor - rightVersion.minor;
+    }
+
+    if (leftVersion.patch !== rightVersion.patch) {
+        return leftVersion.patch - rightVersion.patch;
+    }
+
+    return comparePrerelease(leftVersion.prerelease, rightVersion.prerelease);
+}
+
+function parseVersion(version: string): ParsedVersion {
+    const [core, prerelease = ''] = version.split('-', 2);
+
+    if (!core) {
+        throw new Error(`Unsupported semver value "${version}".`);
+    }
+
+    const [major, minor, patch] = core.split('.');
+
+    if (!major || !minor || !patch) {
+        throw new Error(`Unsupported semver value "${version}".`);
+    }
+
+    return {
+        major: parseIntegerPart(major, version),
+        minor: parseIntegerPart(minor, version),
+        patch: parseIntegerPart(patch, version),
+        prerelease: prerelease.length === 0 ? [] : prerelease.split('.'),
+    };
+}
+
+function parseIntegerPart(value: string, version: string): number {
+    if (!/^\d+$/.test(value)) {
+        throw new Error(`Unsupported semver value "${version}".`);
+    }
+
+    return Number.parseInt(value, 10);
+}
+
+function comparePrerelease(left: string[], right: string[]): number {
+    if (left.length === 0 && right.length === 0) {
+        return 0;
+    }
+
+    if (left.length === 0) {
+        return 1;
+    }
+
+    if (right.length === 0) {
+        return -1;
+    }
+
+    const length = Math.max(left.length, right.length);
+
+    for (let index = 0; index < length; index += 1) {
+        const leftPart = left[index];
+        const rightPart = right[index];
+
+        if (leftPart === undefined) {
+            return -1;
+        }
+
+        if (rightPart === undefined) {
+            return 1;
+        }
+
+        const comparison = comparePrereleasePart(leftPart, rightPart);
+
+        if (comparison !== 0) {
+            return comparison;
+        }
+    }
+
+    return 0;
+}
+
+function comparePrereleasePart(left: string, right: string): number {
+    const leftIsNumeric = /^\d+$/.test(left);
+    const rightIsNumeric = /^\d+$/.test(right);
+
+    if (leftIsNumeric && rightIsNumeric) {
+        return Number.parseInt(left, 10) - Number.parseInt(right, 10);
+    }
+
+    if (leftIsNumeric) {
+        return -1;
+    }
+
+    if (rightIsNumeric) {
+        return 1;
+    }
+
+    return left.localeCompare(right);
+}
+
+async function writeGithubOutput(mode: PublishMode, publishablePackages: string[]): Promise<void> {
+    const githubOutput = process.env.GITHUB_OUTPUT;
+
+    if (!githubOutput) {
+        return;
+    }
+
+    const lines = [`mode=${mode}`, `packages=${publishablePackages.join(',')}`];
+
+    await appendFile(githubOutput, `${lines.join('\n')}\n`);
+}
+
+async function main(): Promise<void> {
+    const rootDir = process.cwd();
+    const publishState = await resolvePublishState(rootDir);
+
+    for (const state of publishState.packageStates) {
+        const registryVersion = state.registryVersion ?? 'unpublished';
+        console.log(
+            `${state.packageName}: repo=${state.repoVersion}, registry=${registryVersion}, relation=${state.relation}`
+        );
+    }
+
+    console.log(`publish-mode=${publishState.mode}`);
+    await writeGithubOutput(publishState.mode, publishState.publishablePackages);
+}
+
+const isDirectExecution = process.argv[1] ? import.meta.url === new URL(`file://${process.argv[1]}`).href : false;
+
+if (isDirectExecution) {
+    // oxlint-disable-next-line unicorn/prefer-top-level-await
+    main().catch((error: unknown) => {
+        console.error(error);
+        process.exit(1);
+    });
+}


### PR DESCRIPTION
## What changed

- adds a `stable-recovery` release path to `release.yml`
- adds a publish-state resolver that compares committed fixed-package versions against npm
- updates the maintainer release guide to document normal stable vs recovery behavior

## Why

A failed stable publish currently leaves `main` ahead of npm with no way to retry publishing without running versioning again. This PR keeps commit-before-publish as the source-of-truth model, but adds an explicit recovery path for already-versioned release commits.

## Impact

- normal stable releases still version, commit, and publish from `main`
- the workflow now validates repo-vs-registry state before publish
- maintainers can dispatch `release_type=stable-recovery` on `main` to publish missing versions without consuming another changeset

## Validation

- `pnpm exec tsx scripts/release/resolve-publish-state.ts`
- `pnpm exec eslint .github/workflows/release.yml scripts/release/resolve-publish-state.ts --quiet`
- `pnpm typecheck`
