### PR TITLE
fix: harden stable release state checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,9 @@ on:
                 default: main
                 type: string
 
-concurrency: ${{ github.workflow }}-${{ github.ref }}
+concurrency:
+    group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.branch || github.ref_name }}
+    cancel-in-progress: false
 
 permissions:
     contents: write
@@ -69,30 +71,17 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version-file: '.nvmrc'
+                  node-version: '24.11.1'
                   registry-url: 'https://registry.npmjs.org'
 
             - name: Setup pnpm
               uses: pnpm/action-setup@v4
 
-            - name: Setup npm 11 for trusted publishing
-              shell: bash
+            - name: Log release toolchain
               run: |
-                  NPM_VERSION=11.11.0
-                  NPM_ROOT="$RUNNER_TEMP/npm-cli"
-                  NPM_BIN="$NPM_ROOT/bin"
-                  curl -fsSL "https://registry.npmjs.org/npm/-/npm-${NPM_VERSION}.tgz" -o "$RUNNER_TEMP/npm.tgz"
-                  rm -rf "$NPM_ROOT"
-                  mkdir -p "$NPM_ROOT" "$NPM_BIN"
-                  tar -xzf "$RUNNER_TEMP/npm.tgz" -C "$NPM_ROOT"
-                  cat > "$NPM_BIN/npm" <<EOF
-                  #!/usr/bin/env bash
-                  exec node "$NPM_ROOT/package/bin/npm-cli.js" "\$@"
-                  EOF
-                  chmod +x "$NPM_BIN/npm"
-                  echo "$NPM_BIN" >> "$GITHUB_PATH"
-                  export PATH="$NPM_BIN:$PATH"
+                  node --version
                   npm --version
+                  pnpm --version
 
             - name: Get pnpm store directory
               id: pnpm-cache
@@ -126,6 +115,10 @@ jobs:
               run: |
                   echo "Stable releases and stable recovery must run from main." >&2
                   exit 1
+
+            - name: Validate committed stable release state
+              if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable')
+              run: pnpm exec tsx scripts/release/resolve-publish-state.ts --mode=stable-input
 
             - name: Version packages (stable)
               if: github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable')

--- a/docs/contributors/releasing.md
+++ b/docs/contributors/releasing.md
@@ -1,19 +1,10 @@
 # Releasing packages
 
-Releasing Tango publishes the fixed-version package set through the repository's trusted publishing workflow.
+Tango publishes stable and alpha packages through the repository's trusted publishing workflow.
 
-We recommend completing the [Contributor setup](/contributors/setup) before you begin. Releases must also be performed by maintainers that have the necessary permission to run the repository's GitHub Actions workflows and access to the `npm` environment that backs trusted publishing.
+Complete the [Contributor setup](/contributors/setup) before you begin. Maintainers need permission to run the repository's GitHub Actions workflows and, when required, approve deployments into the protected `npm` environment. The repository owns the release app settings such as `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`; maintainers do not supply those values manually during a normal release.
 
-A typical release moves through the following stages:
-
-- validating the branch you intend to release
-- confirming whether the release is stable or alpha
-- making sure changesets are present for stable release work
-- letting the release workflow run versioning, tests, and publishing
-- verifying the published result
-- updating the release contract files when the release system itself changes
-
-## Understand the release channels
+## Release channels
 
 Tango ships through two release channels.
 
@@ -21,9 +12,21 @@ Stable releases publish the normal package versions that advance the fixed Tango
 
 Alpha releases publish snapshot builds under the `alpha` dist-tag. They support testing and early feedback, and they leave the root changelog unchanged.
 
+## Release invariant
+
+`main` is the source of truth for intended stable releases.
+
+That leads to three normal release states:
+
+- `repo == registry`: npm already matches the committed release state, so the workflow does nothing.
+- `repo > registry`: the repository is ahead of npm, so the workflow publishes the missing versions.
+- `registry > repo`: npm is ahead of the committed release state, so the workflow fails and requires maintainer intervention.
+
+The workspace remains a fixed release group in git. Every stable release still advances the public Tango packages in lockstep. npm can drift out of lockstep temporarily if a publish fails partway through, so the release workflow and recovery path evaluate registry state per package before deciding what to do next.
+
 ## Validate the branch before you release
 
-The release workflow runs database-backed integration checks before publishing, but maintainers should still validate the branch locally before merging releasable work or dispatching a manual run. That keeps release debugging separate from normal branch validation.
+The release workflow runs the database-backed integration suites before publishing, but maintainers should still validate the branch locally before merging releasable work or dispatching a manual run. That keeps release debugging separate from ordinary branch validation.
 
 Run the same quality gates expected by the repository:
 
@@ -35,50 +38,100 @@ pnpm build
 pnpm test:integration:all
 ```
 
-If one of those commands fails, it _will_ block your release, so you must resolve it before you publish.
+A failing gate will block the release. Resolve it before you publish.
 
 ## Prepare a stable release
 
-Stable releases are changeset-driven. Each pull request that changes releasable package behavior should include a changeset so the release workflow knows which version bump to apply and which release notes to generate.
+Stable releases are changeset-driven. Before you expect a stable publish to happen, make sure the merged pull requests on `main` already contain the changesets you intend to release.
 
-Create a changeset during development with:
+In normal operation, a push to `main` triggers the stable workflow automatically. If you need to rerun the stable path manually, dispatch the workflow with `release_type=stable` and `branch=main`.
 
-```bash
-pnpm changeset
-```
+## Stable workflow behavior
 
-Once the releasable pull requests are merged to `main`, the stable release path is ready. In normal operation, a push to `main` triggers the stable workflow automatically. If you need to rerun the stable path manually, dispatch the workflow with `release_type=stable` and `branch=main`.
-
-## What the stable workflow does
-
-The stable release workflow versions packages, tests the release candidate, commits generated version changes, and publishes the resulting packages.
+The stable workflow validates the current release state before it mutates any versions.
 
 The workflow performs these steps:
 
 1. checks out `main`
 2. installs dependencies and waits for PostgreSQL
 3. runs the SQLite and PostgreSQL integration suites
-4. runs `pnpm changeset:version`
-5. checks whether versioning produced a diff
-6. commits generated version changes to `main` with a bot-authored `[skip ci]` commit when a release is pending
-7. publishes the packages through trusted publishing
+4. compares the committed release state on `main` against npm
+5. stops immediately if any existing published package no longer matches npm
+6. runs `pnpm changeset:version`
+7. checks whether versioning produced a diff
+8. classifies each releasable package against npm again from the versioned release candidate state
+9. commits generated version changes to `main` with a bot-authored `[skip ci]` commit when a release is pending
+10. publishes the packages that are still missing from npm
 
 The stable versioning command is `pnpm changeset:version`, which runs `scripts/release/version-with-root-changelog.ts`. That script executes `changeset version`, refreshes the lockfile, and prepends the new entry to the root `CHANGELOG.md`.
 
+The release job pins Node 24 so trusted publishing can use the bundled npm 11 toolchain without a custom bootstrap layer in the workflow.
+
 If `pnpm changeset:version` produces no diff, the stable workflow becomes a no-op for publishing. That usually means there were no pending releasable changesets on `main`.
 
-Before publishing, the workflow compares the committed release versions against the npm registry. If the registry is already at the same version, the publish step becomes a no-op. If the registry is ahead of the committed version, the workflow fails hard because the repository is no longer the source of truth for the release state.
+## How Tango classifies stable publish state
+
+You only need these labels when you are reading release logs or deciding whether `stable-recovery` is the right next move.
+
+The release workflow checks each releasable package against npm and places it into one of four buckets:
+
+- `already-published`: the committed package version already exists on npm
+- `publish-missing`: the package exists on npm, but the committed version has not been published yet
+- `unpublished-package`: the package has not been published to npm yet
+- `registry-ahead`: npm already has a newer stable version than the committed repository state
+
+The workflow makes those decisions from actual published versions, not only from the `latest` dist-tag. Stable publishing proceeds only when every package is either `already-published`, `publish-missing`, or `unpublished-package`. Any `registry-ahead` package fails the workflow because the repository is no longer the authoritative release state.
 
 ## Recover a failed stable publish
 
 Stable releases commit the generated version changes before publishing. That keeps `main` as the source of truth for the release train, but it also means a publish outage can leave the repository ahead of npm.
 
-When that happens, do not create a second changeset just to force another publish. Instead, dispatch the workflow with:
+When that happens, do not create a second changeset just to force another publish. Dispatch the workflow with:
 
 - `release_type=stable-recovery`
 - `branch=main`
 
-The recovery path skips changeset versioning, inspects the committed package versions on `main`, compares them to npm, and publishes the versions that are still missing from the registry. If npm already matches the committed versions, the recovery path becomes a no-op. If npm is somehow ahead of the repository, the recovery path fails so you can investigate the mismatch explicitly.
+The recovery path skips changeset versioning, inspects the committed package versions on `main`, classifies the npm state per package, and publishes only the versions that are still missing from the registry.
+
+Wait a few minutes before rerunning recovery if the previous publish may have partially succeeded. A good rule is to wait until `npm view @danceroutine/tango-core version` and one or two other affected packages stop changing between checks. The recovery path relies on live registry reads, so it works best after npm metadata has settled.
+
+## Operator decision guide
+
+Use these rules when the stable workflow or stable recovery reports a mismatch.
+
+### `repo == registry`
+
+The committed stable state already matches npm. No recovery work is needed.
+
+### `repo > registry`
+
+The repository is ahead of npm. Use `stable-recovery` to publish the missing versions from `main`.
+
+### `registry > repo`
+
+npm is ahead of the committed repository state. Stop and investigate before you merge or dispatch anything else. Stable versioning must not continue until the mismatch is understood.
+
+Check these first:
+
+1. the most recent successful or partially successful `Release` workflow run on `main`
+2. `npm view <package> version` for the packages reported as ahead
+3. the package versions committed on `main`
+
+If npm really is ahead, reconcile the repository with the published version before you dispatch another stable run.
+
+### Partial publish
+
+A partial publish means some packages from the fixed train reached npm and others did not. The repository stays lockstep, but npm no longer does. Use `stable-recovery` after registry state settles so the missing packages catch up to the committed repo version.
+
+### Version commit succeeded, publish failed
+
+The repository is now ahead of npm. Do not create another changeset. Run `stable-recovery` against `main`.
+
+### Publish succeeded, commit failed
+
+Treat this as a release emergency because npm is now ahead of the committed repository state. Do not dispatch another stable run until the repository is reconciled with the published version.
+
+Start by identifying the workflow run that published successfully, confirming the published package version on npm, and then restoring `main` so it matches that versioned release state.
 
 ## Run an alpha release
 
@@ -99,9 +152,20 @@ Alpha releases preserve the existing root changelog. The workflow publishes the 
 
 After a release completes, confirm that the published packages match the intended channel and version shape.
 
-For stable releases, the published Tango packages should share one version because the workspace is configured as a fixed release group. Internal `workspace:*` dependencies are rewritten to concrete published versions during release, so the generated version commit should show a consistent version across the releasable workspace packages.
+For stable releases, the public Tango packages should share one version because the workspace is configured as a fixed release group. Internal `workspace:*` dependencies are rewritten to concrete published versions during release, so the generated version commit should show a consistent version across the releasable workspace packages.
 
 For alpha releases, confirm that the published versions carry the snapshot suffix and use the `alpha` dist-tag.
+
+These commands are usually enough for a spot check:
+
+```bash
+npm view @danceroutine/tango-core version
+npm view @danceroutine/tango-cli version
+npm view @danceroutine/tango-core dist-tags --json
+npm view @danceroutine/tango-cli dist-tags --json
+```
+
+For a stable release, the stable package versions should agree with the version committed on `main`. For an alpha release, the `alpha` dist-tag should point at the new snapshot version.
 
 ## Updating the release system
 
@@ -111,12 +175,13 @@ When the release system changes, update these files and settings in the same pul
 
 - `.github/workflows/release.yml`
 - `.changeset/config.json`
+- `scripts/release/resolve-publish-state.ts`
 - `scripts/release/version-with-root-changelog.ts`
 - root `package.json` scripts for `changeset:version` and `changeset:publish`
 - repository Actions configuration for `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`
 - this page
 
-Those files govern branch eligibility, release channel behavior, version generation, changelog generation, and publish authentication. Keep them aligned in the same pull request whenever the release process changes.
+Those files govern branch eligibility, release channel behavior, version generation, changelog generation, registry-state reconciliation, and publish authentication. Keep them aligned in the same pull request whenever the release process changes.
 
 ## Where to go next
 

--- a/docs/how-to/auto-document-your-api.md
+++ b/docs/how-to/auto-document-your-api.md
@@ -166,7 +166,6 @@ The default generation is strongest when the API surface is already described by
 - use per-method metadata on `describeAPIView()` for custom endpoints
 - use `actions` overrides on `describeViewSet()` when a custom action needs richer request or response documentation than the default route entry
 
-
 ## Related pages
 
 - [OpenAPI API](/reference/openapi-api)

--- a/docs/how-to/ci-cd-pipelines.md
+++ b/docs/how-to/ci-cd-pipelines.md
@@ -297,7 +297,7 @@ verify:
 
 integration:postgres:
     stage: integration
-    needs: ["verify"]
+    needs: ['verify']
     services:
         - name: postgres:16
           alias: postgres
@@ -314,7 +314,7 @@ integration:postgres:
 
 deploy:
     stage: deploy
-    needs: ["integration:postgres"]
+    needs: ['integration:postgres']
     rules:
         - if: '$CI_COMMIT_BRANCH == "main"'
     variables:

--- a/docs/topics/models-and-schema.md
+++ b/docs/topics/models-and-schema.md
@@ -125,7 +125,6 @@ Tango adds those missing capabilities on top of Zod. Field helpers such as `t.pr
 
 This structure also makes it practical to keep model and serializer work dry. A team can define shared Zod fragments for a blog post once, derive `PostCreateSchema` and `PostUpdateSchema` from those fragments for serializer use, and derive the stored record schema for `Model(...)` from the same family of Zod definitions. The model still carries database-specific metadata that serializers do not need, and serializers still remain free to shape request and response contracts differently, but the underlying field vocabulary can be shared instead of rewritten by hand in each layer.
 
-
 ## Related pages
 
 - [Work with models](/how-to/work-with-models)

--- a/docs/topics/orm-and-querysets.md
+++ b/docs/topics/orm-and-querysets.md
@@ -77,11 +77,7 @@ Most queryset work comes down to refining that base query.
 For example:
 
 ```ts
-const recentPosts = PostModel.objects
-    .query()
-    .filter({ published: true })
-    .orderBy('-createdAt')
-    .limit(20);
+const recentPosts = PostModel.objects.query().filter({ published: true }).orderBy('-createdAt').limit(20);
 ```
 
 You can read that queryset from top to bottom as one sentence about the data the application wants: start from posts, keep the published ones, order them by newest first, and return the first twenty.
@@ -107,11 +103,7 @@ Creating and refining a queryset does not execute a database query by itself.
 Tango waits until application code asks for results. In everyday use, that means the database is queried when code calls methods such as `fetch()`, `fetchOne()`, `count()`, or `exists()`.
 
 ```ts
-const queryset = PostModel.objects
-    .query()
-    .filter({ published: true })
-    .orderBy('-createdAt')
-    .limit(10);
+const queryset = PostModel.objects.query().filter({ published: true }).orderBy('-createdAt').limit(10);
 
 const posts = await queryset.fetch();
 ```
@@ -125,20 +117,13 @@ Different retrieval methods communicate different expectations about the result.
 If you want a flexible query that may return many rows, start with `query()` and finish with `fetch()`:
 
 ```ts
-const publishedPosts = await PostModel.objects
-    .query()
-    .filter({ published: true })
-    .fetch();
+const publishedPosts = await PostModel.objects.query().filter({ published: true }).fetch();
 ```
 
 If you expect at most one row from a refined queryset, use `fetchOne()`:
 
 ```ts
-const latestPost = await PostModel.objects
-    .query()
-    .filter({ published: true })
-    .orderBy('-createdAt')
-    .fetchOne();
+const latestPost = await PostModel.objects.query().filter({ published: true }).orderBy('-createdAt').fetchOne();
 ```
 
 If you already know the identifier of the row you want, `findById(...)` or `getOrThrow(...)` often expresses that intent more directly:
@@ -161,12 +146,7 @@ import { Q } from '@danceroutine/tango-orm';
 
 const searchResults = await PostModel.objects
     .query()
-    .filter(
-        Q.or(
-            { title__icontains: 'tango' },
-            { content__icontains: 'tango' }
-        )
-    )
+    .filter(Q.or({ title__icontains: 'tango' }, { content__icontains: 'tango' }))
     .fetch();
 ```
 
@@ -179,11 +159,7 @@ Sometimes application code wants the full model row. Sometimes it only needs a f
 `select(...)` narrows the selected columns:
 
 ```ts
-const postHeaders = await PostModel.objects
-    .query()
-    .select(['id', 'title', 'slug'])
-    .orderBy('-createdAt')
-    .fetch();
+const postHeaders = await PostModel.objects.query().select(['id', 'title', 'slug']).orderBy('-createdAt').fetch();
 ```
 
 At execution time, that changes the SQL projection, so the database returns only the selected columns. In other words, `postHeaders` contains rows with `id`, `title`, and `slug`, not complete post records with every model field still present.

--- a/scripts/release/resolve-publish-state.ts
+++ b/scripts/release/resolve-publish-state.ts
@@ -12,21 +12,37 @@ type PackageEntry = {
     private?: boolean;
 };
 
-type PublishMode = 'noop' | 'publish';
+type ResolutionMode = 'publish' | 'stable-input';
+type WorkflowMode = 'noop' | 'publish' | 'ready';
 
-type PackagePublishState =
-    | {
-          packageName: string;
-          repoVersion: string;
-          registryVersion: string | null;
-          relation: 'equal' | 'repo-ahead';
-      }
-    | {
-          packageName: string;
-          repoVersion: string;
-          registryVersion: string;
-          relation: 'registry-ahead';
-      };
+type PackageRelation = 'already-published' | 'publish-missing' | 'registry-ahead' | 'unpublished-package';
+
+type PackagePublishState = {
+    packageName: string;
+    repoVersion: string;
+    highestPublishedStableVersion: string | null;
+    relation: PackageRelation;
+};
+
+type RegistryPackageMetadata = {
+    highestPublishedStableVersion: string | null;
+    publishedVersions: Set<string>;
+};
+
+type ResolveStateOptions = {
+    readRegistryMetadata?: (packageName: string) => Promise<RegistryPackageMetadata>;
+};
+
+type ResolvePublishStateResult = {
+    mode: Extract<WorkflowMode, 'noop' | 'publish'>;
+    publishablePackages: string[];
+    packageStates: PackagePublishState[];
+};
+
+type ResolveStableInputStateResult = {
+    mode: Extract<WorkflowMode, 'ready'>;
+    packageStates: PackagePublishState[];
+};
 
 type ParsedVersion = {
     major: number;
@@ -38,11 +54,51 @@ type ParsedVersion = {
 const CHANGESET_CONFIG_PATH = '.changeset/config.json';
 const PACKAGES_DIRECTORY = 'packages';
 
-export async function resolvePublishState(rootDir: string): Promise<{
-    mode: PublishMode;
-    publishablePackages: string[];
-    packageStates: PackagePublishState[];
-}> {
+export async function resolvePublishState(
+    rootDir: string,
+    options: ResolveStateOptions = {}
+): Promise<ResolvePublishStateResult> {
+    const packageStates = await collectPackageStates(rootDir, options);
+    assertNoRegistryAheadPackages(packageStates);
+
+    const publishablePackages = packageStates
+        .filter((state) => state.relation === 'publish-missing' || state.relation === 'unpublished-package')
+        .map((state) => state.packageName);
+
+    return {
+        mode: publishablePackages.length > 0 ? 'publish' : 'noop',
+        publishablePackages,
+        packageStates,
+    };
+}
+
+export async function resolveStableInputState(
+    rootDir: string,
+    options: ResolveStateOptions = {}
+): Promise<ResolveStableInputStateResult> {
+    const packageStates = await collectPackageStates(rootDir, options);
+    assertNoRegistryAheadPackages(packageStates);
+
+    const repoAheadPackages = packageStates.filter((state) => state.relation === 'publish-missing');
+
+    if (repoAheadPackages.length > 0) {
+        const details = formatPackageStateDetails(repoAheadPackages);
+        throw new Error(
+            [
+                'The committed stable release state is ahead of npm for one or more existing packages.',
+                'Run stable-recovery before attempting a new stable version bump.',
+                details,
+            ].join('\n')
+        );
+    }
+
+    return {
+        mode: 'ready',
+        packageStates,
+    };
+}
+
+async function collectPackageStates(rootDir: string, options: ResolveStateOptions): Promise<PackagePublishState[]> {
     const releaseConfig = await loadReleaseConfig(rootDir);
     const fixedPackages = releaseConfig.fixed?.[0];
 
@@ -54,6 +110,7 @@ export async function resolvePublishState(rootDir: string): Promise<{
     const releasablePackages = fixedPackages.filter((packageName) => !ignoredPackages.has(packageName));
     const packageEntries = await loadPackageEntries(join(rootDir, PACKAGES_DIRECTORY));
     const packageStates: PackagePublishState[] = [];
+    const readRegistryMetadata = options.readRegistryMetadata ?? fetchRegistryMetadata;
 
     for (const packageName of releasablePackages) {
         const packageEntry = packageEntries.get(packageName);
@@ -62,71 +119,72 @@ export async function resolvePublishState(rootDir: string): Promise<{
             throw new Error(`Could not find package.json for release package "${packageName}".`);
         }
 
-        const registryVersion = await fetchRegistryVersion(packageName);
+        const registryMetadata = await readRegistryMetadata(packageName);
+        packageStates.push(classifyPackageState(packageEntry, registryMetadata));
+    }
 
-        if (!registryVersion) {
-            packageStates.push({
-                packageName,
-                repoVersion: packageEntry.version,
-                registryVersion: null,
-                relation: 'repo-ahead',
-            });
-            continue;
-        }
+    return packageStates;
+}
 
-        const comparison = compareVersions(packageEntry.version, registryVersion);
-
-        if (comparison === 0) {
-            packageStates.push({
-                packageName,
-                repoVersion: packageEntry.version,
-                registryVersion,
-                relation: 'equal',
-            });
-            continue;
-        }
-
-        if (comparison > 0) {
-            packageStates.push({
-                packageName,
-                repoVersion: packageEntry.version,
-                registryVersion,
-                relation: 'repo-ahead',
-            });
-            continue;
-        }
-
-        packageStates.push({
-            packageName,
+function classifyPackageState(
+    packageEntry: PackageEntry,
+    registryMetadata: RegistryPackageMetadata
+): PackagePublishState {
+    if (!registryMetadata.highestPublishedStableVersion) {
+        return {
+            packageName: packageEntry.name,
             repoVersion: packageEntry.version,
-            registryVersion,
+            highestPublishedStableVersion: null,
+            relation: 'unpublished-package',
+        };
+    }
+
+    const comparison = compareVersions(packageEntry.version, registryMetadata.highestPublishedStableVersion);
+
+    if (comparison < 0) {
+        return {
+            packageName: packageEntry.name,
+            repoVersion: packageEntry.version,
+            highestPublishedStableVersion: registryMetadata.highestPublishedStableVersion,
             relation: 'registry-ahead',
-        });
+        };
     }
 
-    const registryAheadPackages = packageStates.filter((state) => state.relation === 'registry-ahead');
-
-    if (registryAheadPackages.length > 0) {
-        const details = registryAheadPackages
-            .map(
-                (state) =>
-                    `- ${state.packageName}: repo=${state.repoVersion}, registry=${state.registryVersion ?? 'unpublished'}`
-            )
-            .join('\n');
-        throw new Error(
-            `Registry versions are ahead of the committed release state for one or more packages.\n${details}`
-        );
+    if (registryMetadata.publishedVersions.has(packageEntry.version)) {
+        return {
+            packageName: packageEntry.name,
+            repoVersion: packageEntry.version,
+            highestPublishedStableVersion: registryMetadata.highestPublishedStableVersion,
+            relation: 'already-published',
+        };
     }
-
-    const publishablePackages = packageStates
-        .filter((state) => state.relation === 'repo-ahead')
-        .map((state) => state.packageName);
 
     return {
-        mode: publishablePackages.length > 0 ? 'publish' : 'noop',
-        publishablePackages,
-        packageStates,
+        packageName: packageEntry.name,
+        repoVersion: packageEntry.version,
+        highestPublishedStableVersion: registryMetadata.highestPublishedStableVersion,
+        relation: 'publish-missing',
     };
+}
+
+function assertNoRegistryAheadPackages(packageStates: PackagePublishState[]): void {
+    const registryAheadPackages = packageStates.filter((state) => state.relation === 'registry-ahead');
+
+    if (registryAheadPackages.length === 0) {
+        return;
+    }
+
+    const details = formatPackageStateDetails(registryAheadPackages);
+    throw new Error(`Registry versions are ahead of the committed release state for one or more packages.\n${details}`);
+}
+
+function formatPackageStateDetails(packageStates: PackagePublishState[]): string {
+    return packageStates
+        .map(
+            (state) =>
+                `- ${state.packageName}: repo=${state.repoVersion}, registry=${state.highestPublishedStableVersion ?? 'unpublished'}`
+        )
+        .join('\n');
 }
 
 async function loadReleaseConfig(rootDir: string): Promise<ReleaseConfig> {
@@ -176,12 +234,15 @@ async function findPackageJsonPaths(directory: string): Promise<string[]> {
     return packageJsonPaths.sort();
 }
 
-async function fetchRegistryVersion(packageName: string): Promise<string | null> {
+async function fetchRegistryMetadata(packageName: string): Promise<RegistryPackageMetadata> {
     const encodedName = encodeURIComponent(packageName);
     const response = await fetch(`https://registry.npmjs.org/${encodedName}`);
 
     if (response.status === 404) {
-        return null;
+        return {
+            highestPublishedStableVersion: null,
+            publishedVersions: new Set(),
+        };
     }
 
     if (!response.ok) {
@@ -191,12 +252,30 @@ async function fetchRegistryVersion(packageName: string): Promise<string | null>
     }
 
     const body = (await response.json()) as {
-        'dist-tags'?: {
-            latest?: string;
-        };
+        versions?: Record<string, unknown>;
     };
+    const publishedVersions = new Set(Object.keys(body.versions ?? {}));
 
-    return body['dist-tags']?.latest ?? null;
+    return {
+        highestPublishedStableVersion: findHighestPublishedStableVersion(publishedVersions),
+        publishedVersions,
+    };
+}
+
+function findHighestPublishedStableVersion(publishedVersions: Set<string>): string | null {
+    let highestVersion: string | null = null;
+
+    for (const version of publishedVersions) {
+        if (parseVersion(version).prerelease.length > 0) {
+            continue;
+        }
+
+        if (!highestVersion || compareVersions(version, highestVersion) > 0) {
+            highestVersion = version;
+        }
+    }
+
+    return highestVersion;
 }
 
 function compareVersions(left: string, right: string): number {
@@ -303,31 +382,94 @@ function comparePrereleasePart(left: string, right: string): number {
     return left.localeCompare(right);
 }
 
-async function writeGithubOutput(mode: PublishMode, publishablePackages: string[]): Promise<void> {
+async function writeGithubOutput(
+    mode: WorkflowMode,
+    packageStates: PackagePublishState[],
+    publishablePackages: string[]
+): Promise<void> {
     const githubOutput = process.env.GITHUB_OUTPUT;
 
     if (!githubOutput) {
         return;
     }
 
-    const lines = [`mode=${mode}`, `packages=${publishablePackages.join(',')}`];
+    const counts = {
+        alreadyPublished: packageStates.filter((state) => state.relation === 'already-published').length,
+        publishMissing: packageStates.filter((state) => state.relation === 'publish-missing').length,
+        unpublishedPackages: packageStates.filter((state) => state.relation === 'unpublished-package').length,
+        registryAhead: packageStates.filter((state) => state.relation === 'registry-ahead').length,
+    };
+    const lines = [
+        `mode=${mode}`,
+        `packages=${publishablePackages.join(',')}`,
+        `already_published=${counts.alreadyPublished}`,
+        `publish_missing=${counts.publishMissing}`,
+        `unpublished_packages=${counts.unpublishedPackages}`,
+        `registry_ahead=${counts.registryAhead}`,
+    ];
 
     await appendFile(githubOutput, `${lines.join('\n')}\n`);
 }
 
+function parseExecutionMode(argv: string[]): ResolutionMode {
+    const modeArgument = argv.find((argument) => argument.startsWith('--mode='));
+    const mode = modeArgument?.slice('--mode='.length) ?? 'publish';
+
+    if (mode !== 'publish' && mode !== 'stable-input') {
+        throw new Error(`Unsupported resolver mode "${mode}".`);
+    }
+
+    return mode;
+}
+
 async function main(): Promise<void> {
     const rootDir = process.cwd();
-    const publishState = await resolvePublishState(rootDir);
+    const mode = parseExecutionMode(process.argv.slice(2));
 
-    for (const state of publishState.packageStates) {
-        const registryVersion = state.registryVersion ?? 'unpublished';
+    if (mode === 'stable-input') {
+        const resolution = await resolveStableInputState(rootDir);
+
+        for (const state of resolution.packageStates) {
+            const registryVersion = state.highestPublishedStableVersion ?? 'unpublished';
+            console.log(
+                `${state.packageName}: repo=${state.repoVersion}, registry=${registryVersion}, relation=${state.relation}`
+            );
+        }
+
+        console.log(
+            [
+                `resolution-mode=${mode}`,
+                `workflow-mode=${resolution.mode}`,
+                `already-published=${resolution.packageStates.filter((state) => state.relation === 'already-published').length}`,
+                `publish-missing=${resolution.packageStates.filter((state) => state.relation === 'publish-missing').length}`,
+                `unpublished-packages=${resolution.packageStates.filter((state) => state.relation === 'unpublished-package').length}`,
+                `registry-ahead=${resolution.packageStates.filter((state) => state.relation === 'registry-ahead').length}`,
+            ].join('\n')
+        );
+        await writeGithubOutput(resolution.mode, resolution.packageStates, []);
+        return;
+    }
+
+    const resolution = await resolvePublishState(rootDir);
+
+    for (const state of resolution.packageStates) {
+        const registryVersion = state.highestPublishedStableVersion ?? 'unpublished';
         console.log(
             `${state.packageName}: repo=${state.repoVersion}, registry=${registryVersion}, relation=${state.relation}`
         );
     }
 
-    console.log(`publish-mode=${publishState.mode}`);
-    await writeGithubOutput(publishState.mode, publishState.publishablePackages);
+    console.log(
+        [
+            `resolution-mode=${mode}`,
+            `workflow-mode=${resolution.mode}`,
+            `already-published=${resolution.packageStates.filter((state) => state.relation === 'already-published').length}`,
+            `publish-missing=${resolution.packageStates.filter((state) => state.relation === 'publish-missing').length}`,
+            `unpublished-packages=${resolution.packageStates.filter((state) => state.relation === 'unpublished-package').length}`,
+            `registry-ahead=${resolution.packageStates.filter((state) => state.relation === 'registry-ahead').length}`,
+        ].join('\n')
+    );
+    await writeGithubOutput(resolution.mode, resolution.packageStates, resolution.publishablePackages);
 }
 
 const isDirectExecution = process.argv[1] ? import.meta.url === new URL(`file://${process.argv[1]}`).href : false;

--- a/tests/release/resolve-publish-state.test.ts
+++ b/tests/release/resolve-publish-state.test.ts
@@ -1,0 +1,216 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { resolvePublishState, resolveStableInputState } from '../../scripts/release/resolve-publish-state';
+
+type RegistryFixture = {
+    highestPublishedStableVersion: string | null;
+    publishedVersions: string[];
+};
+
+async function createFixtureRepository(packageVersions: Record<string, string>): Promise<string> {
+    const rootDir = await mkdtemp(join(tmpdir(), 'tango-release-state-'));
+
+    await mkdir(join(rootDir, '.changeset'), { recursive: true });
+    await mkdir(join(rootDir, 'packages/core'), { recursive: true });
+    await mkdir(join(rootDir, 'packages/schema'), { recursive: true });
+    await writeFile(
+        join(rootDir, '.changeset/config.json'),
+        JSON.stringify(
+            {
+                fixed: [['@danceroutine/tango-core', '@danceroutine/tango-schema']],
+            },
+            null,
+            4
+        )
+    );
+    await writeFile(
+        join(rootDir, 'packages/core/package.json'),
+        JSON.stringify(
+            { name: '@danceroutine/tango-core', version: packageVersions['@danceroutine/tango-core'] },
+            null,
+            4
+        )
+    );
+    await writeFile(
+        join(rootDir, 'packages/schema/package.json'),
+        JSON.stringify(
+            { name: '@danceroutine/tango-schema', version: packageVersions['@danceroutine/tango-schema'] },
+            null,
+            4
+        )
+    );
+
+    return rootDir;
+}
+
+function createRegistryReader(fixtures: Record<string, RegistryFixture>) {
+    return async (packageName: string) => {
+        const fixture = fixtures[packageName];
+
+        if (!fixture) {
+            throw new Error(`Missing registry fixture for ${packageName}`);
+        }
+
+        return {
+            highestPublishedStableVersion: fixture.highestPublishedStableVersion,
+            publishedVersions: new Set(fixture.publishedVersions),
+        };
+    };
+}
+
+describe('resolve-publish-state', () => {
+    const temporaryDirectories: string[] = [];
+
+    afterEach(async () => {
+        await Promise.all(temporaryDirectories.map((directory) => rm(directory, { recursive: true, force: true })));
+        temporaryDirectories.length = 0;
+    });
+
+    it('no-ops when every repo version is already published even if the latest tag is stale', async () => {
+        const rootDir = await createFixtureRepository({
+            '@danceroutine/tango-core': '1.1.2',
+            '@danceroutine/tango-schema': '1.1.2',
+        });
+        temporaryDirectories.push(rootDir);
+
+        const result = await resolvePublishState(rootDir, {
+            readRegistryMetadata: createRegistryReader({
+                '@danceroutine/tango-core': {
+                    highestPublishedStableVersion: '1.1.1',
+                    publishedVersions: ['1.1.1', '1.1.2'],
+                },
+                '@danceroutine/tango-schema': {
+                    highestPublishedStableVersion: '1.1.2',
+                    publishedVersions: ['1.1.0', '1.1.2'],
+                },
+            }),
+        });
+
+        expect(result.mode).toBe('noop');
+        expect(result.publishablePackages).toEqual([]);
+        expect(result.packageStates.map((state) => state.relation)).toEqual(['already-published', 'already-published']);
+    });
+
+    it('publishes missing existing packages and first-time unpublished packages', async () => {
+        const rootDir = await createFixtureRepository({
+            '@danceroutine/tango-core': '1.1.2',
+            '@danceroutine/tango-schema': '1.1.2',
+        });
+        temporaryDirectories.push(rootDir);
+
+        const result = await resolvePublishState(rootDir, {
+            readRegistryMetadata: createRegistryReader({
+                '@danceroutine/tango-core': {
+                    highestPublishedStableVersion: '1.1.1',
+                    publishedVersions: ['1.1.0', '1.1.1'],
+                },
+                '@danceroutine/tango-schema': {
+                    highestPublishedStableVersion: null,
+                    publishedVersions: [],
+                },
+            }),
+        });
+
+        expect(result.mode).toBe('publish');
+        expect(result.publishablePackages).toEqual(['@danceroutine/tango-core', '@danceroutine/tango-schema']);
+        expect(result.packageStates.map((state) => state.relation)).toEqual(['publish-missing', 'unpublished-package']);
+    });
+
+    it('fails when the registry is ahead of the committed repo version', async () => {
+        const rootDir = await createFixtureRepository({
+            '@danceroutine/tango-core': '1.1.2',
+            '@danceroutine/tango-schema': '1.1.2',
+        });
+        temporaryDirectories.push(rootDir);
+
+        await expect(
+            resolvePublishState(rootDir, {
+                readRegistryMetadata: createRegistryReader({
+                    '@danceroutine/tango-core': {
+                        highestPublishedStableVersion: '1.1.3',
+                        publishedVersions: ['1.1.1', '1.1.3'],
+                    },
+                    '@danceroutine/tango-schema': {
+                        highestPublishedStableVersion: '1.1.2',
+                        publishedVersions: ['1.1.2'],
+                    },
+                }),
+            })
+        ).rejects.toThrow('Registry versions are ahead');
+    });
+
+    it('treats a newer published stable version as registry-ahead even when the repo version also exists', async () => {
+        const rootDir = await createFixtureRepository({
+            '@danceroutine/tango-core': '1.1.2',
+            '@danceroutine/tango-schema': '1.1.2',
+        });
+        temporaryDirectories.push(rootDir);
+
+        await expect(
+            resolvePublishState(rootDir, {
+                readRegistryMetadata: createRegistryReader({
+                    '@danceroutine/tango-core': {
+                        highestPublishedStableVersion: '1.1.3',
+                        publishedVersions: ['1.1.2', '1.1.3'],
+                    },
+                    '@danceroutine/tango-schema': {
+                        highestPublishedStableVersion: '1.1.2',
+                        publishedVersions: ['1.1.2'],
+                    },
+                }),
+            })
+        ).rejects.toThrow('Registry versions are ahead');
+    });
+
+    it('allows stable input when committed packages match npm or are brand-new unpublished packages', async () => {
+        const rootDir = await createFixtureRepository({
+            '@danceroutine/tango-core': '1.1.2',
+            '@danceroutine/tango-schema': '1.1.2',
+        });
+        temporaryDirectories.push(rootDir);
+
+        const result = await resolveStableInputState(rootDir, {
+            readRegistryMetadata: createRegistryReader({
+                '@danceroutine/tango-core': {
+                    highestPublishedStableVersion: '1.1.2',
+                    publishedVersions: ['1.1.2'],
+                },
+                '@danceroutine/tango-schema': {
+                    highestPublishedStableVersion: null,
+                    publishedVersions: [],
+                },
+            }),
+        });
+
+        expect(result.mode).toBe('ready');
+        expect(result.packageStates.map((state) => state.relation)).toEqual([
+            'already-published',
+            'unpublished-package',
+        ]);
+    });
+
+    it('blocks a new stable version bump when committed main is already ahead of npm', async () => {
+        const rootDir = await createFixtureRepository({
+            '@danceroutine/tango-core': '1.1.2',
+            '@danceroutine/tango-schema': '1.1.2',
+        });
+        temporaryDirectories.push(rootDir);
+
+        await expect(
+            resolveStableInputState(rootDir, {
+                readRegistryMetadata: createRegistryReader({
+                    '@danceroutine/tango-core': {
+                        highestPublishedStableVersion: '1.1.1',
+                        publishedVersions: ['1.1.1'],
+                    },
+                    '@danceroutine/tango-schema': {
+                        highestPublishedStableVersion: '1.1.1',
+                        publishedVersions: ['1.1.1'],
+                    },
+                }),
+            })
+        ).rejects.toThrow('Run stable-recovery before attempting a new stable version bump.');
+    });
+});


### PR DESCRIPTION
## What changed

This hardens the stable release workflow around the repo-versus-registry invariant.

- move the `Release` workflow to Node `24.11.1` and remove the custom npm bootstrap
- add a pre-version stable-input guard so a new stable bump cannot proceed while `main` is already ahead of npm
- strengthen the publish-state resolver to classify packages by actual published versions instead of relying on `dist-tags.latest`
- add per-package release-state tests
- document the stable invariant, recovery path, and operator decision flow in contributor docs
- keep the formatter-only doc updates produced by `pnpm lint`

## Why

The release pipeline already had a recovery path, but it still had three gaps:

1. it depended on a custom npm 11 bootstrap
2. it could detect repo/registry mismatch only after stable version mutation
3. it inferred publish state from `latest` rather than actual published versions

This change moves the guard earlier, makes the resolver package-aware, and simplifies the release toolchain.

## Validation

- `pnpm exec vitest run tests/release`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm exec tsx scripts/release/resolve-publish-state.ts`
- `pnpm exec tsx scripts/release/resolve-publish-state.ts --mode=stable-input`
