### PR TITLE
feat: add django-shaped orm transactions

### DIFF
--- a/.changeset/atomic-transactions.md
+++ b/.changeset/atomic-transactions.md
@@ -1,0 +1,11 @@
+---
+"@danceroutine/tango-orm": minor
+"@danceroutine/tango-schema": minor
+"@danceroutine/tango-testing": minor
+---
+
+Add a supported ORM transaction API centered on `transaction.atomic(async (tx) => ...)`, nested savepoints, and `tx.onCommit(...)`.
+
+Extend schema write-hook args with a narrow transaction callback contract so hooks can register post-commit work without depending on ORM internals.
+
+Add testing fixtures and client contract updates needed to exercise the new runtime-backed transaction workflow.

--- a/docs/guide/supported-and-unsupported.md
+++ b/docs/guide/supported-and-unsupported.md
@@ -26,7 +26,9 @@ The ORM layer already includes model managers through `Model.objects`, immutable
 
 The ORM surface is designed for application code that wants a Django-shaped querying model without giving up TypeScript-native contracts. Collection filtering, ordering, slicing, existence checks, row shaping through `fetch(...)`, and manager-backed persistence are all part of the current story.
 
-The current unsupported ORM boundary includes nested relation traversal such as `author__profile`, related-row projection, many-to-many hydration, and a supported transaction workflow for application code.
+The current supported ORM contract also includes `transaction.atomic(async (tx) => ...)`, nested savepoints, and post-commit callback registration through `tx.onCommit(...)`.
+
+The remaining unsupported ORM boundary includes nested relation traversal such as `author__profile`, related-row projection, many-to-many hydration, request-wide transaction wrappers, and multi-database routing for transaction work.
 
 ### Database dialects
 
@@ -98,7 +100,7 @@ MariaDB is the SQL dialect currently called out on the roadmap, but it is not pa
 
 Several unsupported areas already have explicit follow-up work planned.
 
-At the ORM level, the roadmap includes deeper relation traversal, many-to-many hydration, related-row projection, and a supported transaction API for multi-step write workflows.
+At the ORM level, the roadmap includes deeper relation traversal, many-to-many hydration, related-row projection, and transaction ergonomics beyond the core `atomic(...)` API such as request-scoped wrappers and broader multi-database routing.
 
 At the platform level, the roadmap also includes MariaDB support, GraphQL support, custom Tango environments beyond `development`, `test`, and `production`, non-linear migration dependency chains for larger teams, agentic development support for AI-assisted workflows, and longer-term exploration of NoSQL support.
 

--- a/docs/reference/orm-query-api.md
+++ b/docs/reference/orm-query-api.md
@@ -131,6 +131,128 @@ VALUES (?, ?), (?, ?)
 RETURNING *
 ```
 
+## Transactions
+
+Some application workflows need several ORM writes to commit or roll back as one unit. `transaction.atomic(...)` defines that boundary.
+
+```ts
+import { transaction } from '@danceroutine/tango-orm';
+
+await transaction.atomic(async (tx) => {
+    const user = await UserModel.objects.create({
+        email: 'author@example.com',
+    });
+
+    await ProfileModel.objects.create({
+        userId: user.id,
+    });
+
+    tx.onCommit(() => {
+        invalidateUserCache(user.id);
+    });
+});
+```
+
+Outside `atomic(...)`, Tango uses the normal autocommit path. Inside `atomic(...)`, manager writes, querysets, and write hooks use the active transaction lease for the current async call chain.
+
+At the persistence layer, the outer block follows the usual SQL transaction shape:
+
+```sql
+BEGIN;
+-- manager-backed writes
+COMMIT;
+```
+
+If the callback throws, Tango rolls the transaction back and rejects the `atomic(...)` call with that failure.
+
+### Nested `atomic()` blocks
+
+Nested `atomic()` blocks create savepoints instead of opening unrelated transactions.
+
+```ts
+await transaction.atomic(async () => {
+    await AuditLogModel.objects.create({ event: 'outer-start' });
+
+    await transaction.atomic(async () => {
+        await DraftModel.objects.create({ title: 'temporary' });
+    });
+});
+```
+
+At the persistence layer, Tango uses a savepoint on the already-leased transaction client:
+
+```sql
+BEGIN;
+SAVEPOINT tango_sp_0;
+-- nested manager-backed writes
+RELEASE SAVEPOINT tango_sp_0;
+COMMIT;
+```
+
+A nested failure rolls work back only to that savepoint. If the error keeps propagating, the outer `atomic(...)` call fails as well.
+
+`tx.savepoint(...)` provides the same nested-savepoint behavior without requiring a local `try`/`catch` when the outer transaction should continue:
+
+```ts
+await transaction.atomic(async (tx) => {
+    const result = await tx.savepoint(async () => {
+        await DraftModel.objects.create({ title: 'temporary' });
+        throw new Error('discard this draft');
+    });
+
+    if (!result.ok) {
+        await AuditLogModel.objects.create({ event: 'draft-discarded' });
+    }
+});
+```
+
+By default, `tx.savepoint(...)` returns `{ ok: true, value }` on success and `{ ok: false, error }` on rollback. Pass `{ throwOnError: true }` when the nested savepoint should rethrow instead of returning a result object.
+
+### `tx.onCommit(callback, options?)`
+
+Some side effects should run only after the outermost commit succeeds. `tx.onCommit(...)` registers that work with the current transaction frame.
+
+```ts
+await transaction.atomic(async (tx) => {
+    const post = await PostModel.objects.create({
+        title: 'Queued publish',
+        slug: 'queued-publish',
+    });
+
+    tx.onCommit(() => {
+        publishPostEvent(post.id);
+    });
+});
+```
+
+The callback queue belongs to the current transaction frame:
+
+- callbacks run only after the outermost commit succeeds
+- callbacks registered in a nested block are discarded if that savepoint rolls back
+- successful nested blocks merge their callbacks into the parent in registration order
+
+`robust: false` is the default. In that mode, the first callback failure stops later callbacks and rejects `atomic(...)` after the database has already committed. With `robust: true`, Tango logs the callback failure and continues with later callbacks.
+
+### Why Tango uses `tx.onCommit(...)`
+
+Django exposes a package-level `transaction.on_commit(...)` helper because Python code often leans on ambient transaction context. Tango keeps ordinary ORM reads and writes ambient inside `atomic(...)`, but it keeps post-commit registration explicit.
+
+That split matters because the two concerns are different. Querysets, manager writes, and hooks should quietly join the active transaction once the boundary exists. Post-commit callbacks are different: they introduce new work that is tied to the commit outcome, so Tango makes that registration happen through the `tx` value that established the boundary. In practice, helper code that only reads or writes through the ORM needs no extra argument, while helper code that must enqueue commit-aware side effects can accept the narrow `AtomicTransaction` contract directly.
+
+### Backend notes
+
+The transaction contract stays the same across supported SQL backends. The runtime notes below are split by dialect because connection management and operational limits still vary.
+
+#### PostgreSQL
+
+PostgreSQL uses one shared pool for ordinary autocommit work and leases one dedicated `PoolClient` for each outer `atomic()` block.
+
+#### SQLite
+
+SQLite supports `transaction.atomic(...)` only on file-backed databases in this milestone. `:memory:` SQLite still works for ordinary autocommit queries, but `atomic(...)` rejects because the transaction workflow needs a second handle to the same database file.
+
+Concurrent outer SQLite transactions still follow normal SQLite file-locking semantics, so overlapping write transactions are not guaranteed to succeed together.
+
 ## `QuerySet<TModel, TBaseResult = TModel, TSourceModel = unknown, THydrated = Record<never, never>>`
 
 `QuerySet` represents a database query against one model. Each refinement returns a new queryset, leaving the earlier one unchanged. A queryset refinement only describes work. An execution method is a terminal call that sends SQL to the database and returns a promise, such as `fetch(...)`, `fetchOne(...)`, `count()`, or `exists()`.

--- a/docs/reference/schema-api.md
+++ b/docs/reference/schema-api.md
@@ -102,6 +102,28 @@ The supported hook names are:
 
 The `beforeCreate(...)` and `beforeUpdate(...)` hooks may return normalized values that Tango should persist. `beforeBulkCreate(...)` may return a replacement set of rows for Tango to persist. The `after*` hooks run after the write has completed.
 
+When a write hook runs inside `transaction.atomic(...)`, its args also receive an optional `transaction` handle with one narrow capability: `transaction?.onCommit(...)`.
+
+```ts
+const UserModel = Model({
+    namespace: 'blog',
+    name: 'User',
+    schema: z.object({
+        id: t.primaryKey(z.number().int()),
+        email: z.string().email(),
+    }),
+    hooks: {
+        afterCreate({ record, transaction }) {
+            transaction?.onCommit(() => {
+                invalidateUserCache(record.id);
+            });
+        },
+    },
+});
+```
+
+Hook code only needs a callback registrar, so the hook args expose that narrow `onCommit(...)` contract and nothing broader. Outside an active `atomic(...)` block, the `transaction` field is `undefined`.
+
 ## `RelationBuilder`
 
 Use `RelationBuilder` inside `relations: (builder) => ({ ... })` when your model needs named relation metadata at the model level. This is the place to describe how one model points at another in application-facing terms, such as `author`, `comments`, or `profile`.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -12,11 +12,11 @@ Tango supports one-level relation hydration for `belongsTo`, `hasOne`, and `hasM
 
 Future relation work should extend that foundation to nested traversal such as `author__profile`, related-row projection, many-to-many hydration, and ambient or generated typing that removes explicit target-model generics from reverse relation calls.
 
-### ORM transaction support
+### Transaction ergonomics beyond `atomic(...)`
 
-The ORM currently focuses on ordinary manager-driven reads and writes.
+The core ORM transaction boundary is now `transaction.atomic(async (tx) => ...)`, including nested savepoints and post-commit work through `tx.onCommit(...)`.
 
-Transaction support for application code is still missing from the supported ORM surface. A future transaction API needs to define how multi-step write workflows open a transaction boundary, how that boundary is scoped to the active runtime and database client, and how application code should use it without bypassing the normal model manager path.
+The base transaction contract is in place now, so the remaining work is mostly about fit and ergonomics. The main follow-up questions are request-scoped wrappers in host adapters, broader multi-database routing, and better SQLite ergonomics beyond the current file-backed transaction boundary.
 
 ### Agentic Development Support
 

--- a/docs/topics/orm-and-querysets.md
+++ b/docs/topics/orm-and-querysets.md
@@ -255,11 +255,134 @@ await PostModel.objects.delete(42);
 
 As with `create(...)`, these methods matter because they are the ordinary application path through model-owned persistence behavior. If the model applies defaults or lifecycle hooks during writes, manager-based writes keep that behavior consistent.
 
-## Transaction support
+## Transactions for multi-step workflows
 
-The ORM does not yet provide a supported transaction workflow for application code.
+Ordinary manager writes already work well for one-step create, update, and delete operations. When one workflow needs several writes to succeed or fail together, `transaction.atomic(...)` provides that boundary.
 
-Today, the model manager and queryset APIs cover ordinary reads and writes, but they do not yet expose a stable transaction boundary that application code can rely on for multi-step units of work.
+```ts
+import { transaction } from '@danceroutine/tango-orm';
+
+await transaction.atomic(async (tx) => {
+    const user = await UserModel.objects.create({
+        email: 'author@example.com',
+    });
+
+    await ProfileModel.objects.create({
+        userId: user.id,
+    });
+
+    tx.onCommit(() => {
+        sendWelcomeEmail(user.email);
+    });
+});
+```
+
+Outside `atomic(...)`, Tango uses the normal autocommit path. Inside `atomic(...)`, the same `Model.objects` and `QuerySet` code uses the active transaction lease for the current async chain.
+
+## Nested transactions use savepoints
+
+Nested `atomic()` blocks do not open independent transactions. They create savepoints inside the active outer transaction.
+
+```ts
+await transaction.atomic(async () => {
+    await AuditLogModel.objects.create({ event: 'outer-start' });
+
+    try {
+        await transaction.atomic(async () => {
+            await DraftModel.objects.create({ title: 'temporary draft' });
+            throw new Error('discard this draft');
+        });
+    } catch {
+        // The outer transaction is still active here.
+    }
+
+    await AuditLogModel.objects.create({ event: 'outer-finished' });
+});
+```
+
+If the nested block throws, Tango rolls back only to that savepoint. If that error keeps propagating, the outer `atomic(...)` call fails as well.
+
+When the outer transaction should continue without a local `try`/`catch`, use `tx.savepoint(...)`. It opens a nested savepoint and returns a structured result instead of throwing.
+
+```ts
+await transaction.atomic(async (tx) => {
+    const draft = await tx.savepoint(async (nested) => {
+        const post = await PostModel.objects.create({
+            title: 'Temporary draft',
+            slug: 'temporary-draft',
+        });
+
+        nested.onCommit(() => {
+            publishPostEvent(post.id);
+        });
+
+        throw new Error('discard this draft');
+    });
+
+    if (!draft.ok) {
+        await AuditLogModel.objects.create({ event: 'draft-discarded' });
+    }
+
+    await AuditLogModel.objects.create({ event: 'outer-finished' });
+});
+```
+
+In that form, the savepoint still rolls back the nested work, but the error comes back as `{ ok: false, error }` instead of aborting the outer transaction. Pass `{ throwOnError: true }` when the nested savepoint should rethrow instead.
+
+## Post-commit work uses `tx.onCommit(...)`
+
+Some side effects should happen only after the database commit is durable. Cache invalidation, background job enqueueing, and domain events are common examples. Register that work through `tx.onCommit(...)`.
+
+```ts
+await transaction.atomic(async (tx) => {
+    const post = await PostModel.objects.create({
+        title: 'Queued publish',
+        slug: 'queued-publish',
+    });
+
+    tx.onCommit(() => {
+        publishPostEvent(post.id);
+    });
+});
+```
+
+Nested `atomic()` blocks keep their own callback frame. If a nested savepoint rolls back, only that nested frame's callbacks are discarded. A successful nested block merges its callbacks into the parent in registration order.
+
+## Why Tango uses `tx.onCommit(...)` instead of a global helper
+
+Django exposes `transaction.on_commit(...)` as a package-level helper because ambient transaction state is a natural fit in Python code. Tango keeps reads and writes ambient inside `atomic(...)`, but it does not make post-commit registration ambient.
+
+Tango intentionally makes that tradeoff so the two concerns stay separate. Reads and writes already have a natural ambient behavior: once the transaction boundary exists, ORM calls should just use it. Post-commit callbacks are different because they register new work that depends on the commit outcome. Keeping `onCommit(...)` on `tx` means helper code that only talks to the ORM needs no extra argument, while helper code that must schedule commit-aware side effects can accept that narrow contract explicitly.
+
+## Hooks participate in the active transaction
+
+Model write hooks run on the same transactional client when they are triggered inside `atomic(...)`. Hook args also receive an optional `transaction` handle so model-owned write behavior can register post-commit work without importing ORM internals into the schema package.
+
+```ts
+hooks: {
+    afterCreate({ record, transaction }) {
+        transaction?.onCommit(() => {
+            auditUserCreation(record.id);
+        });
+    },
+}
+```
+
+Outside `atomic(...)`, hook args receive `transaction: undefined`.
+
+## Database notes
+
+The ORM transaction contract stays the same across supported SQL backends. The runtime notes below are split by dialect because connection handling and operational limits still differ.
+
+### PostgreSQL
+
+PostgreSQL leases one dedicated client for each outer `atomic()` block while ordinary autocommit work continues through the pool.
+
+### SQLite
+
+SQLite supports `transaction.atomic(...)` only on file-backed databases in this milestone.
+
+`:memory:` SQLite still works for ordinary autocommit queries and tests, but `atomic(...)` rejects because the transaction workflow needs a second handle to the same database file.
 
 ## Related pages
 

--- a/packages/orm/src/connection/adapters/dialects/PostgresAdapter.ts
+++ b/packages/orm/src/connection/adapters/dialects/PostgresAdapter.ts
@@ -52,6 +52,6 @@ export class PostgresAdapter implements Adapter {
         });
 
         const client = await pool.connect();
-        return new PostgresClient(pool, client);
+        return new PostgresClient(client);
     }
 }

--- a/packages/orm/src/connection/adapters/dialects/SqliteAdapter.ts
+++ b/packages/orm/src/connection/adapters/dialects/SqliteAdapter.ts
@@ -40,6 +40,7 @@ export class SqliteAdapter implements Adapter {
         const db = new Database(filename);
         db.pragma('journal_mode = WAL');
         db.pragma('foreign_keys = ON');
+        db.pragma('busy_timeout = 5000');
 
         return new SqliteClient(db);
     }

--- a/packages/orm/src/connection/clients/DBClient.ts
+++ b/packages/orm/src/connection/clients/DBClient.ts
@@ -10,6 +10,12 @@ export interface DBClient {
     commit(): Promise<void>;
     /** Roll back current transaction. */
     rollback(): Promise<void>;
+    /** Create a savepoint inside the current transaction. */
+    createSavepoint(name: string): Promise<void>;
+    /** Release a previously-created savepoint. */
+    releaseSavepoint(name: string): Promise<void>;
+    /** Roll back current transaction state to a savepoint. */
+    rollbackToSavepoint(name: string): Promise<void>;
     /** Close underlying connection resources. */
     close(): Promise<void>;
 }

--- a/packages/orm/src/connection/clients/dialects/PostgresClient.ts
+++ b/packages/orm/src/connection/clients/dialects/PostgresClient.ts
@@ -1,17 +1,18 @@
-import type pg from 'pg';
 import type { DBClient } from '../DBClient';
 
+export interface PostgresPoolClientLike {
+    query(sql: string, params?: readonly unknown[]): Promise<{ rows: unknown[] }>;
+    release(): void;
+}
+
 /**
- * `DBClient` implementation backed by a PostgreSQL pool client.
+ * Transaction-capable client backed by a PostgreSQL pool client.
  */
 export class PostgresClient implements DBClient {
     static readonly BRAND = 'tango.orm.postgres_client' as const;
     readonly __tangoBrand: typeof PostgresClient.BRAND = PostgresClient.BRAND;
 
-    constructor(
-        private pool: pg.Pool,
-        private client: pg.PoolClient
-    ) {}
+    constructor(private client: PostgresPoolClientLike) {}
 
     /**
      * Narrow an unknown value to `PostgresClient`.
@@ -54,10 +55,30 @@ export class PostgresClient implements DBClient {
     }
 
     /**
-     * Release client resources and close the associated pool.
+     * Create a savepoint inside the active transaction.
+     */
+    async createSavepoint(name: string): Promise<void> {
+        await this.client.query(`SAVEPOINT ${name}`);
+    }
+
+    /**
+     * Release a previously-created savepoint.
+     */
+    async releaseSavepoint(name: string): Promise<void> {
+        await this.client.query(`RELEASE SAVEPOINT ${name}`);
+    }
+
+    /**
+     * Roll back the active transaction to a savepoint.
+     */
+    async rollbackToSavepoint(name: string): Promise<void> {
+        await this.client.query(`ROLLBACK TO SAVEPOINT ${name}`);
+    }
+
+    /**
+     * Release the leased PostgreSQL client back to its owning pool.
      */
     async close(): Promise<void> {
         this.client.release();
-        await this.pool.end();
     }
 }

--- a/packages/orm/src/connection/clients/dialects/SqliteClient.ts
+++ b/packages/orm/src/connection/clients/dialects/SqliteClient.ts
@@ -2,7 +2,7 @@ import type Database from 'better-sqlite3';
 import type { DBClient } from '../DBClient';
 
 /**
- * `DBClient` implementation backed by a synchronous `better-sqlite3` handle.
+ * Transaction-capable client backed by a synchronous `better-sqlite3` handle.
  */
 export class SqliteClient implements DBClient {
     static readonly BRAND = 'tango.orm.sqlite_client' as const;
@@ -75,6 +75,27 @@ export class SqliteClient implements DBClient {
             this.db.prepare('ROLLBACK').run();
             this.inTransaction = false;
         }
+    }
+
+    /**
+     * Create a savepoint inside the active transaction.
+     */
+    async createSavepoint(name: string): Promise<void> {
+        this.db.prepare(`SAVEPOINT ${name}`).run();
+    }
+
+    /**
+     * Release a previously-created savepoint.
+     */
+    async releaseSavepoint(name: string): Promise<void> {
+        this.db.prepare(`RELEASE SAVEPOINT ${name}`).run();
+    }
+
+    /**
+     * Roll back the active transaction to a savepoint.
+     */
+    async rollbackToSavepoint(name: string): Promise<void> {
+        this.db.prepare(`ROLLBACK TO SAVEPOINT ${name}`).run();
     }
 
     /**

--- a/packages/orm/src/connection/clients/dialects/tests/PostgresClient.test.ts
+++ b/packages/orm/src/connection/clients/dialects/tests/PostgresClient.test.ts
@@ -1,37 +1,39 @@
 import { describe, expect, it, vi } from 'vitest';
+import type { PostgresPoolClientLike } from '../PostgresClient';
 import { PostgresClient } from '../PostgresClient';
 
 describe(PostgresClient, () => {
     it('executes queries and transaction methods', async () => {
         const query = vi.fn(async () => ({ rows: [{ id: 1 }] }));
         const release = vi.fn();
-        const end = vi.fn(async () => {});
-        const client = new PostgresClient(
-            { end } as unknown as ConstructorParameters<typeof PostgresClient>[0],
-            { query, release } as unknown as ConstructorParameters<typeof PostgresClient>[1]
-        );
+        const poolClient: PostgresPoolClientLike = { query, release };
+        const client = new PostgresClient(poolClient);
 
         await expect(client.query('SELECT 1')).resolves.toEqual({ rows: [{ id: 1 }] });
         await client.begin();
+        await client.createSavepoint('sp1');
+        await client.releaseSavepoint('sp1');
+        await client.rollbackToSavepoint('sp1');
         await client.commit();
         await client.rollback();
         await client.close();
 
         expect(query).toHaveBeenCalledWith('SELECT 1', undefined);
         expect(query).toHaveBeenCalledWith('BEGIN');
+        expect(query).toHaveBeenCalledWith('SAVEPOINT sp1');
+        expect(query).toHaveBeenCalledWith('RELEASE SAVEPOINT sp1');
+        expect(query).toHaveBeenCalledWith('ROLLBACK TO SAVEPOINT sp1');
         expect(query).toHaveBeenCalledWith('COMMIT');
         expect(query).toHaveBeenCalledWith('ROLLBACK');
         expect(release).toHaveBeenCalledOnce();
-        expect(end).toHaveBeenCalledOnce();
     });
 
     it('identifies matching instances', () => {
-        const client = new PostgresClient(
-            { end: vi.fn(async () => {}) } as unknown as ConstructorParameters<typeof PostgresClient>[0],
-            { query: vi.fn(async () => ({ rows: [] })), release: vi.fn() } as unknown as ConstructorParameters<
-                typeof PostgresClient
-            >[1]
-        );
+        const poolClient: PostgresPoolClientLike = {
+            query: vi.fn(async () => ({ rows: [] })),
+            release: vi.fn(),
+        };
+        const client = new PostgresClient(poolClient);
 
         expect(PostgresClient.isPostgresClient(client)).toBe(true);
         expect(PostgresClient.isPostgresClient({})).toBe(false);

--- a/packages/orm/src/connection/clients/dialects/tests/SqliteClient.test.ts
+++ b/packages/orm/src/connection/clients/dialects/tests/SqliteClient.test.ts
@@ -34,12 +34,18 @@ describe(SqliteClient, () => {
         const beginStmt = createStmt();
         const commitStmt = createStmt();
         const rollbackStmt = createStmt();
+        const savepointStmt = createStmt();
+        const releaseSavepointStmt = createStmt();
+        const rollbackSavepointStmt = createStmt();
         const updateStmt = createStmt();
         const deleteStmt = createStmt();
         const prepare = vi.fn((sql: string) => {
             if (sql === 'BEGIN') return beginStmt;
             if (sql === 'COMMIT') return commitStmt;
             if (sql === 'ROLLBACK') return rollbackStmt;
+            if (sql === 'SAVEPOINT sp1') return savepointStmt;
+            if (sql === 'RELEASE SAVEPOINT sp1') return releaseSavepointStmt;
+            if (sql === 'ROLLBACK TO SAVEPOINT sp1') return rollbackSavepointStmt;
             if (sql.startsWith('UPDATE')) return updateStmt;
             return deleteStmt;
         });
@@ -55,6 +61,9 @@ describe(SqliteClient, () => {
 
         await client.begin();
         await client.begin();
+        await client.createSavepoint('sp1');
+        await client.releaseSavepoint('sp1');
+        await client.rollbackToSavepoint('sp1');
         await client.commit();
         await client.commit();
         await client.begin();
@@ -63,6 +72,9 @@ describe(SqliteClient, () => {
         await client.close();
 
         expect(beginStmt.run).toHaveBeenCalledTimes(2);
+        expect(savepointStmt.run).toHaveBeenCalledOnce();
+        expect(releaseSavepointStmt.run).toHaveBeenCalledOnce();
+        expect(rollbackSavepointStmt.run).toHaveBeenCalledOnce();
         expect(commitStmt.run).toHaveBeenCalledTimes(1);
         expect(rollbackStmt.run).toHaveBeenCalledTimes(1);
         expect(close).toHaveBeenCalledOnce();

--- a/packages/orm/src/index.ts
+++ b/packages/orm/src/index.ts
@@ -36,4 +36,5 @@ export type {
 } from './query/domain/index';
 
 export { getTangoRuntime, initializeTangoRuntime, resetTangoRuntime, TangoRuntime } from './runtime/index';
-export { UnitOfWork } from './transaction/index';
+export { atomic, UnitOfWork } from './transaction/index';
+export type { AtomicTransaction, OnCommitOptions, SavepointOptions, SavepointResult } from './transaction/index';

--- a/packages/orm/src/manager/ModelManager.ts
+++ b/packages/orm/src/manager/ModelManager.ts
@@ -7,6 +7,7 @@ import { QuerySet as QuerySetClass } from '../query/index';
 import type { Dialect, QueryExecutor } from '../query/index';
 import type { TangoRuntime } from '../runtime/TangoRuntime';
 import { OrmSqlSafetyAdapter } from '../validation';
+import { TransactionEngine } from '../transaction/internal/context';
 import type { ManagerLike } from './ManagerLike';
 import { MutationCompiler } from './internal/MutationCompiler';
 import { RuntimeBoundClient } from './internal/RuntimeBoundClient';
@@ -45,9 +46,11 @@ export class ModelManager<TModelRow extends Record<string, unknown>, TSourceMode
     private readonly model: ModelLike<TModelRow>;
     private readonly client: RuntimeBoundClient;
     private readonly dialect: Dialect;
+    private readonly runtime: TangoRuntime;
 
     constructor(model: ModelLike<TModelRow>, runtime: TangoRuntime) {
         this.model = model;
+        this.runtime = runtime;
         this.client = new RuntimeBoundClient(runtime);
         this.dialect = runtime.getDialect() as Dialect;
         this.mutationCompiler = new MutationCompiler(this.dialect);
@@ -186,6 +189,7 @@ export class ModelManager<TModelRow extends Record<string, unknown>, TSourceMode
             record: created,
             model: this.model,
             manager: this,
+            transaction: this.getHookTransaction(),
         });
         return created;
     }
@@ -217,6 +221,7 @@ export class ModelManager<TModelRow extends Record<string, unknown>, TSourceMode
             record: updated,
             model: this.model,
             manager: this,
+            transaction: this.getHookTransaction(),
         });
         return updated;
     }
@@ -228,6 +233,7 @@ export class ModelManager<TModelRow extends Record<string, unknown>, TSourceMode
             current,
             model: this.model,
             manager: this,
+            transaction: this.getHookTransaction(),
         });
         const validatedPlan = sqlSafetyAdapter.validate({
             kind: 'delete',
@@ -240,6 +246,7 @@ export class ModelManager<TModelRow extends Record<string, unknown>, TSourceMode
             previous: current,
             model: this.model,
             manager: this,
+            transaction: this.getHookTransaction(),
         });
     }
 
@@ -254,6 +261,7 @@ export class ModelManager<TModelRow extends Record<string, unknown>, TSourceMode
                 rows: perRowPrepared,
                 model: this.model,
                 manager: this,
+                transaction: this.getHookTransaction(),
             })) ?? perRowPrepared;
         const preparedKeys = Object.keys(batchPrepared[0] ?? {});
         if (preparedKeys.length === 0) {
@@ -274,6 +282,7 @@ export class ModelManager<TModelRow extends Record<string, unknown>, TSourceMode
                     record,
                     model: this.model,
                     manager: this,
+                    transaction: this.getHookTransaction(),
                 })
             )
         );
@@ -281,6 +290,7 @@ export class ModelManager<TModelRow extends Record<string, unknown>, TSourceMode
             records: result.rows,
             model: this.model,
             manager: this,
+            transaction: this.getHookTransaction(),
         });
         return result.rows;
     }
@@ -291,6 +301,7 @@ export class ModelManager<TModelRow extends Record<string, unknown>, TSourceMode
                 data,
                 model: this.model,
                 manager: this,
+                transaction: this.getHookTransaction(),
             })) ?? data
         );
     }
@@ -307,7 +318,12 @@ export class ModelManager<TModelRow extends Record<string, unknown>, TSourceMode
                 current,
                 model: this.model,
                 manager: this,
+                transaction: this.getHookTransaction(),
             })) ?? patch
         );
+    }
+
+    private getHookTransaction() {
+        return TransactionEngine.forRuntime(this.runtime).getActiveTransaction();
     }
 }

--- a/packages/orm/src/manager/internal/RuntimeBoundClient.ts
+++ b/packages/orm/src/manager/internal/RuntimeBoundClient.ts
@@ -1,34 +1,62 @@
 import type { DBClient } from '../../connection/index';
 import type { TangoRuntime } from '../../runtime/index';
+import { TransactionEngine } from '../../transaction/internal/context';
 
 /**
- * DB client proxy that resolves the real Tango runtime client lazily.
+ * DB client proxy that resolves either the active transaction lease or the
+ * runtime autocommit path lazily.
  */
 export class RuntimeBoundClient implements DBClient {
     constructor(private readonly runtime: TangoRuntime) {}
 
     async query<T = unknown>(sql: string, params?: readonly unknown[]): Promise<{ rows: T[] }> {
+        const lease = TransactionEngine.forRuntime(this.runtime).getActiveLease();
+        if (lease) {
+            return lease.client.query<T>(sql, params);
+        }
+
+        const runtimeWithQuery = this.runtime as TangoRuntime & {
+            query?: <TResult = unknown>(sql: string, params?: readonly unknown[]) => Promise<{ rows: TResult[] }>;
+        };
+        if (typeof runtimeWithQuery.query === 'function') {
+            return runtimeWithQuery.query<T>(sql, params);
+        }
+
         const client = await this.runtime.getClient();
         return client.query<T>(sql, params);
     }
 
     async begin(): Promise<void> {
-        const client = await this.runtime.getClient();
-        await client.begin();
+        throw new Error('Runtime-bound clients do not support manual begin(). Use transaction.atomic(...) instead.');
     }
 
     async commit(): Promise<void> {
-        const client = await this.runtime.getClient();
-        await client.commit();
+        throw new Error('Runtime-bound clients do not support manual commit(). Use transaction.atomic(...) instead.');
     }
 
     async rollback(): Promise<void> {
-        const client = await this.runtime.getClient();
-        await client.rollback();
+        throw new Error('Runtime-bound clients do not support manual rollback(). Use transaction.atomic(...) instead.');
+    }
+
+    async createSavepoint(_name: string): Promise<void> {
+        throw new Error(
+            'Runtime-bound clients do not support manual savepoints. Use transaction.atomic(...) or tx.savepoint(...) instead.'
+        );
+    }
+
+    async releaseSavepoint(_name: string): Promise<void> {
+        throw new Error(
+            'Runtime-bound clients do not support manual savepoint release. Use transaction.atomic(...) or tx.savepoint(...) instead.'
+        );
+    }
+
+    async rollbackToSavepoint(_name: string): Promise<void> {
+        throw new Error(
+            'Runtime-bound clients do not support manual savepoint rollback. Use transaction.atomic(...) or tx.savepoint(...) instead.'
+        );
     }
 
     async close(): Promise<void> {
-        const client = await this.runtime.getClient();
-        await client.close();
+        throw new Error('Runtime-bound clients do not support manual close(). Use TangoRuntime.reset() instead.');
     }
 }

--- a/packages/orm/src/manager/internal/tests/RuntimeBoundClient.test.ts
+++ b/packages/orm/src/manager/internal/tests/RuntimeBoundClient.test.ts
@@ -1,28 +1,68 @@
 import { describe, expect, it, vi } from 'vitest';
 import { aDBClient } from '@danceroutine/tango-testing';
 import type { TangoRuntime } from '../../../runtime';
+import { TransactionEngine } from '../../../transaction/internal/context';
 import { RuntimeBoundClient } from '../RuntimeBoundClient';
 
 describe(RuntimeBoundClient, () => {
-    it('delegates every operation through the runtime client', async () => {
-        const client = aDBClient();
+    it('delegates queries through the runtime autocommit path', async () => {
+        const runtime = {
+            query: vi.fn(async () => ({ rows: [{ id: 1 }] })),
+            getClient: vi.fn(),
+        } as unknown as TangoRuntime;
+
+        const boundClient = new RuntimeBoundClient(runtime);
+        await expect(boundClient.query('SELECT 1', [1])).resolves.toEqual({ rows: [{ id: 1 }] });
+
+        expect(runtime.query).toHaveBeenCalledWith('SELECT 1', [1]);
+    });
+
+    it('falls back to a mocked runtime client in older test doubles', async () => {
+        const client = aDBClient({
+            query: vi.fn(async () => ({ rows: [{ ok: true }] })),
+        });
         const runtime = {
             getClient: vi.fn(async () => client),
         } as unknown as TangoRuntime;
 
         const boundClient = new RuntimeBoundClient(runtime);
+        await expect(boundClient.query('SELECT 1')).resolves.toEqual({ rows: [{ ok: true }] });
+        expect(runtime.getClient).toHaveBeenCalledOnce();
+    });
 
-        await boundClient.query('SELECT 1', [1]);
-        await boundClient.begin();
-        await boundClient.commit();
-        await boundClient.rollback();
-        await boundClient.close();
+    it('rejects manual transaction control on the runtime-bound facade', async () => {
+        const runtime = { query: vi.fn(async () => ({ rows: [] })), getClient: vi.fn() } as unknown as TangoRuntime;
+        const boundClient = new RuntimeBoundClient(runtime);
 
-        expect(runtime.getClient).toHaveBeenCalledTimes(5);
-        expect(client.query).toHaveBeenCalledWith('SELECT 1', [1]);
-        expect(client.begin).toHaveBeenCalled();
-        expect(client.commit).toHaveBeenCalled();
-        expect(client.rollback).toHaveBeenCalled();
-        expect(client.close).toHaveBeenCalled();
+        await expect(boundClient.begin()).rejects.toThrow(/transaction\.atomic/);
+        await expect(boundClient.commit()).rejects.toThrow(/transaction\.atomic/);
+        await expect(boundClient.rollback()).rejects.toThrow(/transaction\.atomic/);
+        await expect(boundClient.createSavepoint('sp')).rejects.toThrow(/tx\.savepoint/);
+        await expect(boundClient.releaseSavepoint('sp')).rejects.toThrow(/tx\.savepoint/);
+        await expect(boundClient.rollbackToSavepoint('sp')).rejects.toThrow(/tx\.savepoint/);
+        await expect(boundClient.close()).rejects.toThrow(/TangoRuntime\.reset/);
+    });
+
+    it('routes queries through the active transaction lease for the matching runtime', async () => {
+        const leasedClient = aDBClient({
+            query: vi.fn(async () => ({ rows: [{ via: 'lease' }] })),
+        });
+        const release = vi.fn(async () => {});
+        const runtime = {
+            query: vi.fn(async () => ({ rows: [{ via: 'runtime' }] })),
+            getClient: vi.fn(),
+            leaseTransactionClient: vi.fn(async () => ({ client: leasedClient, release })),
+        } as unknown as TangoRuntime;
+
+        const boundClient = new RuntimeBoundClient(runtime);
+        await expect(
+            TransactionEngine.forRuntime(runtime).atomic(async () => boundClient.query('SELECT 1'))
+        ).resolves.toEqual({
+            rows: [{ via: 'lease' }],
+        });
+
+        expect(leasedClient.query).toHaveBeenCalledWith('SELECT 1', undefined);
+        expect(runtime.query).not.toHaveBeenCalled();
+        expect(release).toHaveBeenCalledOnce();
     });
 });

--- a/packages/orm/src/manager/tests/ModelManager.test.ts
+++ b/packages/orm/src/manager/tests/ModelManager.test.ts
@@ -1,9 +1,12 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NotFoundError } from '@danceroutine/tango-core';
-import { aDBClient, setupTestTangoRuntime } from '@danceroutine/tango-testing';
-import type { TangoRuntime } from '../../runtime/TangoRuntime';
+import { aDBClient, aTangoRuntime, setupTestTangoRuntime } from '@danceroutine/tango-testing';
 import { ModelManager } from '../ModelManager';
 import { getTangoRuntime } from '../../runtime/index';
+import { atomic } from '../../transaction';
 import { sqlInjectionRejectCases, sqlInjectionValueCases } from '../../validation/tests/sqlInjectionCorpus';
 import { expectPayloadIsParameterized } from '../../validation/tests/expectPayloadIsParameterized';
 
@@ -117,10 +120,8 @@ describe(ModelManager, () => {
                 rows: [{ id: 1, email: 'user@example.com', active: true }] as T[],
             }),
         });
-        const runtime = {
-            getDialect: () => 'postgres',
-            getClient: vi.fn(async () => client),
-        } as unknown as TangoRuntime;
+        const runtime = aTangoRuntime({ adapter: 'postgres' });
+        vi.spyOn(runtime, 'query').mockImplementation((sql, params) => client.query(sql, params));
         const manager = new ModelManager(UserModel, runtime);
 
         await manager.create({ email: 'user@example.com', active: true });
@@ -311,16 +312,50 @@ describe(ModelManager, () => {
         );
     });
 
+    it('passes the active transaction handle into hooks only while running inside atomic(...)', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'tango-orm-hooks-'));
+
+        try {
+            await setupTestTangoRuntime({ sqliteFilename: join(tempDir, 'hooks.sqlite') });
+
+            const seenTransactions: unknown[] = [];
+            const manager = new ModelManager(
+                {
+                    ...UserModel,
+                    hooks: {
+                        afterCreate: vi.fn(({ transaction }) => {
+                            seenTransactions.push(transaction);
+                        }),
+                    },
+                },
+                getTangoRuntime()
+            );
+            const client = await getTangoRuntime().getClient();
+            await client.query('CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, active INTEGER)');
+
+            await manager.create({ id: 1, email: 'outside@example.com', active: true });
+
+            await atomic(async () => {
+                await manager.create({ id: 2, email: 'inside@example.com', active: true });
+            });
+
+            expect(seenTransactions[0]).toBeUndefined();
+            expect(seenTransactions[1]).toBeDefined();
+            expect(typeof (seenTransactions[1] as { onCommit?: unknown }).onCommit).toBe('function');
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
     it.each(sqlInjectionValueCases)('$id keeps $category payloads bound during create', async (testCase) => {
         const client = aDBClient({
             query: async <T = unknown>(_sql: string, _params?: readonly unknown[]) => ({
                 rows: [{ id: 'token', email: testCase.payload }] as T[],
             }),
         });
-        const manager = new ModelManager(TokenModel, {
-            getDialect: () => 'postgres',
-            getClient: async () => client,
-        } as TangoRuntime);
+        const runtime = aTangoRuntime({ adapter: 'postgres' });
+        vi.spyOn(runtime, 'query').mockImplementation((sql, params) => client.query(sql, params));
+        const manager = new ModelManager(TokenModel, runtime);
 
         await manager.create({ id: 'token', email: testCase.payload });
 
@@ -334,10 +369,9 @@ describe(ModelManager, () => {
                 rows: [{ id: 'token', email: testCase.payload }] as T[],
             }),
         });
-        const manager = new ModelManager(TokenModel, {
-            getDialect: () => 'postgres',
-            getClient: async () => client,
-        } as TangoRuntime);
+        const runtime = aTangoRuntime({ adapter: 'postgres' });
+        vi.spyOn(runtime, 'query').mockImplementation((sql, params) => client.query(sql, params));
+        const manager = new ModelManager(TokenModel, runtime);
 
         await manager.update('token', { email: testCase.payload });
 
@@ -351,10 +385,9 @@ describe(ModelManager, () => {
                 rows: [{ id: testCase.payload, email: 'bound@example.com' }] as T[],
             }),
         });
-        const manager = new ModelManager(TokenModel, {
-            getDialect: () => 'postgres',
-            getClient: async () => client,
-        } as TangoRuntime);
+        const runtime = aTangoRuntime({ adapter: 'postgres' });
+        vi.spyOn(runtime, 'query').mockImplementation((sql, params) => client.query(sql, params));
+        const manager = new ModelManager(TokenModel, runtime);
 
         await manager.delete(testCase.payload);
 
@@ -368,10 +401,9 @@ describe(ModelManager, () => {
                 rows: [{ id: 'token', email: testCase.payload }] as T[],
             }),
         });
-        const manager = new ModelManager(TokenModel, {
-            getDialect: () => 'postgres',
-            getClient: async () => client,
-        } as TangoRuntime);
+        const runtime = aTangoRuntime({ adapter: 'postgres' });
+        vi.spyOn(runtime, 'query').mockImplementation((sql, params) => client.query(sql, params));
+        const manager = new ModelManager(TokenModel, runtime);
 
         await manager.bulkCreate([{ id: 'token', email: testCase.payload }]);
 

--- a/packages/orm/src/runtime/TangoRuntime.ts
+++ b/packages/orm/src/runtime/TangoRuntime.ts
@@ -1,17 +1,20 @@
 import type { LoadedConfig } from '@danceroutine/tango-config';
 import type { DBClient } from '../connection/index';
-import { connectDB } from '../connection/index';
 import type { Dialect } from '../query/domain/index';
+import { RuntimeBoundClient } from '../manager/internal/RuntimeBoundClient';
+import type { DBClientProvider, TransactionClientLease } from './internal/DBClientProvider';
+import { createDBClientProvider } from './internal/createDBClientProvider';
 
 /**
  * Framework-owned database runtime that resolves Tango config and lazily
- * creates the shared DB client used by manager-backed models.
+ * creates the shared connection provider used by manager-backed models.
  */
 export class TangoRuntime {
     static readonly BRAND = 'tango.orm.runtime' as const;
     readonly __tangoBrand: typeof TangoRuntime.BRAND = TangoRuntime.BRAND;
     private readonly loadedConfig: LoadedConfig;
-    private clientPromise: Promise<DBClient> | null = null;
+    private providerPromise: Promise<DBClientProvider> | null = null;
+    private runtimeClientPromise: Promise<DBClient> | null = null;
 
     constructor(loadLoadedConfig: () => LoadedConfig) {
         this.loadedConfig = loadLoadedConfig();
@@ -43,37 +46,65 @@ export class TangoRuntime {
     }
 
     /**
-     * Return the shared DB client, creating it once on first access.
+     * Return the runtime-bound DB client facade used by manager-backed code.
      */
     async getClient(): Promise<DBClient> {
-        if (!this.clientPromise) {
-            const db = this.loadedConfig.current.db;
-            this.clientPromise = connectDB({
-                adapter: db.adapter,
-                url: db.url,
-                host: db.host,
-                port: db.port,
-                database: db.database,
-                user: db.user,
-                password: db.password,
-                filename: db.filename,
-                maxConnections: db.maxConnections,
-            });
+        if (!this.runtimeClientPromise) {
+            this.runtimeClientPromise = Promise.resolve(new RuntimeBoundClient(this));
         }
 
-        return this.clientPromise;
+        return this.runtimeClientPromise;
     }
 
     /**
-     * Close and clear the cached DB client so tests can start fresh.
+     * Execute SQL through the autocommit path owned by this runtime.
+     */
+    async query<T = unknown>(sql: string, params?: readonly unknown[]): Promise<{ rows: T[] }> {
+        const provider = await this.getProvider();
+        return provider.query<T>(sql, params);
+    }
+
+    /**
+     * Lease a transaction-scoped client for `transaction.atomic(...)`.
+     */
+    async leaseTransactionClient(): Promise<TransactionClientLease> {
+        const provider = await this.getProvider();
+        return provider.leaseTransactionClient();
+    }
+
+    /**
+     * Close and clear the cached runtime resources so tests can start fresh.
      */
     async reset(): Promise<void> {
-        if (!this.clientPromise) {
+        if (!this.providerPromise) {
+            this.runtimeClientPromise = null;
             return;
         }
 
-        const client = await this.clientPromise;
-        this.clientPromise = null;
-        await client.close();
+        const provider = await this.providerPromise;
+        this.providerPromise = null;
+        this.runtimeClientPromise = null;
+        await provider.reset();
+    }
+
+    private async getProvider(): Promise<DBClientProvider> {
+        if (!this.providerPromise) {
+            const db = this.loadedConfig.current.db;
+            this.providerPromise = Promise.resolve(
+                createDBClientProvider({
+                    adapter: db.adapter,
+                    url: db.url,
+                    host: db.host,
+                    port: db.port,
+                    database: db.database,
+                    user: db.user,
+                    password: db.password,
+                    filename: db.filename,
+                    maxConnections: db.maxConnections,
+                })
+            );
+        }
+
+        return this.providerPromise;
     }
 }

--- a/packages/orm/src/runtime/internal/DBClientProvider.ts
+++ b/packages/orm/src/runtime/internal/DBClientProvider.ts
@@ -1,0 +1,12 @@
+import type { DBClient } from '../../connection/clients/DBClient';
+
+export interface TransactionClientLease {
+    readonly client: DBClient;
+    release(): Promise<void>;
+}
+
+export interface DBClientProvider {
+    query<T = unknown>(sql: string, params?: readonly unknown[]): Promise<{ rows: T[] }>;
+    leaseTransactionClient(): Promise<TransactionClientLease>;
+    reset(): Promise<void>;
+}

--- a/packages/orm/src/runtime/internal/PostgresDBClientProvider.ts
+++ b/packages/orm/src/runtime/internal/PostgresDBClientProvider.ts
@@ -1,0 +1,55 @@
+import pg from 'pg';
+import type { AdapterConfig } from '../../connection/adapters/Adapter';
+import { PostgresClient } from '../../connection/clients/dialects/PostgresClient';
+import type { DBClientProvider, TransactionClientLease } from './DBClientProvider';
+
+const { Pool } = pg;
+
+export class PostgresDBClientProvider implements DBClientProvider {
+    private readonly pool: pg.Pool;
+    private activeLeaseCount = 0;
+
+    constructor(config: AdapterConfig) {
+        this.pool = new Pool({
+            connectionString: config.url,
+            host: config.host,
+            port: config.port,
+            database: config.database,
+            user: config.user,
+            password: config.password,
+            max: config.maxConnections || 10,
+        });
+    }
+
+    async query<T = unknown>(sql: string, params?: readonly unknown[]): Promise<{ rows: T[] }> {
+        const result = await this.pool.query(sql, params as unknown[]);
+        return { rows: result.rows as T[] };
+    }
+
+    async leaseTransactionClient(): Promise<TransactionClientLease> {
+        const client = await this.pool.connect();
+        this.activeLeaseCount += 1;
+        let released = false;
+
+        return {
+            client: new PostgresClient(client),
+            release: async () => {
+                if (released) {
+                    return;
+                }
+
+                released = true;
+                this.activeLeaseCount -= 1;
+                client.release();
+            },
+        };
+    }
+
+    async reset(): Promise<void> {
+        if (this.activeLeaseCount > 0) {
+            throw new Error('Cannot reset Tango runtime while transaction leases are still active.');
+        }
+
+        await this.pool.end();
+    }
+}

--- a/packages/orm/src/runtime/internal/SqliteDBClientProvider.ts
+++ b/packages/orm/src/runtime/internal/SqliteDBClientProvider.ts
@@ -1,0 +1,79 @@
+import { createRequire } from 'node:module';
+import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
+import type { AdapterConfig } from '../../connection/adapters/Adapter';
+import { SqliteClient } from '../../connection/clients/dialects/SqliteClient';
+import type { DBClientProvider, TransactionClientLease } from './DBClientProvider';
+
+type BetterSqliteCtor = new (filename: string, options?: unknown) => BetterSqliteDatabase;
+
+export class SqliteDBClientProvider implements DBClientProvider {
+    private readonly filename: string;
+    private readonly Database: BetterSqliteCtor;
+    private readonly autocommitClient: SqliteClient;
+    private activeLeaseCount = 0;
+
+    constructor(config: AdapterConfig = {}) {
+        this.Database = this.getDatabaseCtor();
+        this.filename =
+            typeof config.filename === 'string' && config.filename.length > 0 ? config.filename : ':memory:';
+        this.autocommitClient = this.openClient(this.filename);
+    }
+
+    async query<T = unknown>(sql: string, params?: readonly unknown[]): Promise<{ rows: T[] }> {
+        return this.autocommitClient.query<T>(sql, params);
+    }
+
+    async leaseTransactionClient(): Promise<TransactionClientLease> {
+        if (this.filename === ':memory:') {
+            throw new Error('transaction.atomic(...) requires a file-backed SQLite database. :memory: is unsupported.');
+        }
+
+        const client = this.openClient(this.filename);
+        this.activeLeaseCount += 1;
+        let released = false;
+
+        return {
+            client,
+            release: async () => {
+                if (released) {
+                    return;
+                }
+
+                released = true;
+                this.activeLeaseCount -= 1;
+                await client.close();
+            },
+        };
+    }
+
+    async reset(): Promise<void> {
+        if (this.activeLeaseCount > 0) {
+            throw new Error('Cannot reset Tango runtime while transaction leases are still active.');
+        }
+
+        await this.autocommitClient.close();
+    }
+
+    private openClient(filename: string): SqliteClient {
+        const db = new this.Database(filename);
+        db.pragma('journal_mode = WAL');
+        db.pragma('foreign_keys = ON');
+        db.pragma('busy_timeout = 5000');
+        return new SqliteClient(db);
+    }
+
+    private getDatabaseCtor(): BetterSqliteCtor {
+        const require = createRequire(import.meta.url);
+        const moduleValue = require('better-sqlite3') as unknown;
+        if (typeof moduleValue === 'function') {
+            return moduleValue as BetterSqliteCtor;
+        }
+
+        const defaultExport = (moduleValue as { default?: unknown }).default;
+        if (typeof defaultExport === 'function') {
+            return defaultExport as BetterSqliteCtor;
+        }
+
+        throw new TypeError('Failed to load better-sqlite3 constructor.');
+    }
+}

--- a/packages/orm/src/runtime/internal/createDBClientProvider.ts
+++ b/packages/orm/src/runtime/internal/createDBClientProvider.ts
@@ -1,0 +1,15 @@
+import type { AdapterConfig } from '../../connection/adapters/Adapter';
+import type { DBClientProvider } from './DBClientProvider';
+import { PostgresDBClientProvider } from './PostgresDBClientProvider';
+import { SqliteDBClientProvider } from './SqliteDBClientProvider';
+
+export function createDBClientProvider(config: AdapterConfig & { adapter: string }): DBClientProvider {
+    switch (config.adapter) {
+        case 'postgres':
+            return new PostgresDBClientProvider(config);
+        case 'sqlite':
+            return new SqliteDBClientProvider(config);
+        default:
+            throw new Error(`Unsupported adapter for Tango runtime provider: ${config.adapter}`);
+    }
+}

--- a/packages/orm/src/runtime/internal/tests/PostgresDBClientProvider.test.ts
+++ b/packages/orm/src/runtime/internal/tests/PostgresDBClientProvider.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const poolQuery = vi.fn(async () => ({ rows: [{ id: 1 }] }));
+const clientQuery = vi.fn(async () => ({ rows: [{ id: 2 }] }));
+const clientRelease = vi.fn();
+const poolConnect = vi.fn(async () => ({ query: clientQuery, release: clientRelease }));
+const poolEnd = vi.fn(async () => {});
+
+vi.mock('pg', () => ({
+    default: {
+        Pool: class {
+            query = poolQuery;
+            connect = poolConnect;
+            end = poolEnd;
+        },
+    },
+}));
+
+import { PostgresClient } from '../../../connection/clients/dialects/PostgresClient';
+import { PostgresDBClientProvider } from '../PostgresDBClientProvider';
+
+describe(PostgresDBClientProvider, () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('runs autocommit queries through the pool', async () => {
+        const provider = new PostgresDBClientProvider({ url: 'postgres://example' });
+
+        await expect(provider.query('SELECT 1', [1])).resolves.toEqual({ rows: [{ id: 1 }] });
+        expect(poolQuery).toHaveBeenCalledWith('SELECT 1', [1]);
+
+        await provider.reset();
+        expect(poolEnd).toHaveBeenCalledOnce();
+    });
+
+    it('leases transactional clients and releases them idempotently', async () => {
+        const provider = new PostgresDBClientProvider({ url: 'postgres://example' });
+
+        const lease = await provider.leaseTransactionClient();
+        expect(lease.client).toBeInstanceOf(PostgresClient);
+        await expect(lease.client.query('SELECT tx')).resolves.toEqual({ rows: [{ id: 2 }] });
+
+        await lease.release();
+        await lease.release();
+
+        expect(clientRelease).toHaveBeenCalledOnce();
+
+        await provider.reset();
+        expect(poolEnd).toHaveBeenCalledOnce();
+    });
+
+    it('rejects reset while a transaction lease is still active', async () => {
+        const provider = new PostgresDBClientProvider({ url: 'postgres://example' });
+        const lease = await provider.leaseTransactionClient();
+
+        await expect(provider.reset()).rejects.toThrow(/transaction leases are still active/i);
+
+        await lease.release();
+        await expect(provider.reset()).resolves.toBeUndefined();
+    });
+});

--- a/packages/orm/src/runtime/internal/tests/SqliteDBClientProvider.branches.test.ts
+++ b/packages/orm/src/runtime/internal/tests/SqliteDBClientProvider.branches.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('SqliteDBClientProvider constructor branches', () => {
+    afterEach(() => {
+        vi.resetModules();
+        vi.unmock('node:module');
+    });
+
+    it('accepts a default-export constructor from createRequire', async () => {
+        class FakeDatabase {
+            pragma(): void {}
+            prepare() {
+                return {
+                    reader: false,
+                    all: vi.fn(() => []),
+                    run: vi.fn(() => undefined),
+                };
+            }
+            close(): void {}
+        }
+
+        vi.doMock('node:module', () => ({
+            createRequire: () => () => ({ default: FakeDatabase }),
+        }));
+
+        const { SqliteDBClientProvider } = await import('../SqliteDBClientProvider');
+        const provider = new SqliteDBClientProvider({ filename: 'fake.sqlite' });
+        await expect(provider.reset()).resolves.toBeUndefined();
+    });
+
+    it('throws when createRequire does not expose a usable constructor', async () => {
+        vi.doMock('node:module', () => ({
+            createRequire: () => () => ({}),
+        }));
+
+        const { SqliteDBClientProvider } = await import('../SqliteDBClientProvider');
+        expect(() => new SqliteDBClientProvider({ filename: 'fake.sqlite' })).toThrow(/Failed to load better-sqlite3/);
+    });
+});

--- a/packages/orm/src/runtime/internal/tests/SqliteDBClientProvider.test.ts
+++ b/packages/orm/src/runtime/internal/tests/SqliteDBClientProvider.test.ts
@@ -1,0 +1,64 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SqliteDBClientProvider } from '../SqliteDBClientProvider';
+
+async function createFilename(): Promise<{ dir: string; filename: string }> {
+    const dir = await mkdtemp(join(tmpdir(), 'tango-sqlite-provider-'));
+    return { dir, filename: join(dir, 'db.sqlite') };
+}
+
+describe(SqliteDBClientProvider, () => {
+    const dirs: string[] = [];
+
+    afterEach(async () => {
+        await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+    });
+
+    it('runs file-backed autocommit queries and transaction leases against the same database', async () => {
+        const { dir, filename } = await createFilename();
+        dirs.push(dir);
+        const provider = new SqliteDBClientProvider({ filename });
+
+        await provider.query('CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT NOT NULL)');
+        const lease = await provider.leaseTransactionClient();
+        await lease.client.begin();
+        await lease.client.query('INSERT INTO posts (id, title) VALUES (?, ?)', [1, 'first']);
+        await lease.client.commit();
+        await lease.release();
+        await lease.release();
+
+        await expect(provider.query<{ id: number }>('SELECT id FROM posts ORDER BY id')).resolves.toEqual({
+            rows: [{ id: 1 }],
+        });
+
+        await expect(provider.reset()).resolves.toBeUndefined();
+    });
+
+    it('rejects transaction leasing for :memory: sqlite', async () => {
+        const provider = new SqliteDBClientProvider({ filename: ':memory:' });
+
+        await expect(provider.leaseTransactionClient()).rejects.toThrow(/file-backed SQLite/);
+        await provider.reset();
+    });
+
+    it('falls back to :memory: when sqlite filename is empty', async () => {
+        const provider = new SqliteDBClientProvider({ filename: '' });
+
+        await expect(provider.leaseTransactionClient()).rejects.toThrow(/file-backed SQLite/);
+        await provider.reset();
+    });
+
+    it('rejects reset while a transaction lease is still active', async () => {
+        const { dir, filename } = await createFilename();
+        dirs.push(dir);
+        const provider = new SqliteDBClientProvider({ filename });
+        const lease = await provider.leaseTransactionClient();
+
+        await expect(provider.reset()).rejects.toThrow(/transaction leases are still active/i);
+
+        await lease.release();
+        await expect(provider.reset()).resolves.toBeUndefined();
+    });
+});

--- a/packages/orm/src/runtime/internal/tests/createDBClientProvider.test.ts
+++ b/packages/orm/src/runtime/internal/tests/createDBClientProvider.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('pg', () => ({
+    default: {
+        Pool: class {
+            query = vi.fn(async () => ({ rows: [] }));
+            connect = vi.fn(async () => ({ query: vi.fn(async () => ({ rows: [] })), release: vi.fn() }));
+            end = vi.fn(async () => {});
+        },
+    },
+}));
+
+import { PostgresDBClientProvider } from '../PostgresDBClientProvider';
+import { SqliteDBClientProvider } from '../SqliteDBClientProvider';
+import { createDBClientProvider } from '../createDBClientProvider';
+
+describe(createDBClientProvider, () => {
+    it('creates the postgres provider when configured for postgres', async () => {
+        const provider = createDBClientProvider({ adapter: 'postgres', url: 'postgres://example' });
+        expect(provider).toBeInstanceOf(PostgresDBClientProvider);
+        await provider.reset();
+    });
+
+    it('creates the sqlite provider when configured for sqlite', async () => {
+        const provider = createDBClientProvider({ adapter: 'sqlite', filename: ':memory:' });
+        expect(provider).toBeInstanceOf(SqliteDBClientProvider);
+        await provider.reset();
+    });
+
+    it('rejects unsupported adapters', () => {
+        expect(() => createDBClientProvider({ adapter: 'mysql' })).toThrow(/Unsupported adapter/);
+    });
+});

--- a/packages/orm/src/runtime/tests/TangoRuntime.provider.test.ts
+++ b/packages/orm/src/runtime/tests/TangoRuntime.provider.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { aTangoConfig } from '@danceroutine/tango-testing';
+import { loadConfig } from '@danceroutine/tango-config';
+
+const provider = {
+    query: vi.fn(async () => ({ rows: [{ id: 1 }] })),
+    leaseTransactionClient: vi.fn(async () => ({ client: {} as never, release: vi.fn(async () => {}) })),
+    reset: vi.fn(async () => {}),
+};
+
+vi.mock('../internal/createDBClientProvider', () => ({
+    createDBClientProvider: vi.fn(() => provider),
+}));
+
+import { TangoRuntime } from '../TangoRuntime';
+
+describe('TangoRuntime provider wiring', () => {
+    it('delegates autocommit queries, transaction leasing, and reset through the cached provider', async () => {
+        const runtime = new TangoRuntime(() => loadConfig(() => aTangoConfig()));
+
+        await expect(runtime.query('SELECT 1')).resolves.toEqual({ rows: [{ id: 1 }] });
+        const lease = await runtime.leaseTransactionClient();
+        expect(lease.client).toBeDefined();
+        await runtime.reset();
+
+        expect(provider.query).toHaveBeenCalledWith('SELECT 1', undefined);
+        expect(provider.leaseTransactionClient).toHaveBeenCalledOnce();
+        expect(provider.reset).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/orm/src/transaction/AtomicTransaction.ts
+++ b/packages/orm/src/transaction/AtomicTransaction.ts
@@ -1,0 +1,37 @@
+export interface OnCommitOptions {
+    robust?: boolean;
+}
+
+export interface SavepointOptions {
+    throwOnError?: boolean;
+}
+
+/**
+ * Result returned by `tx.savepoint(...)`.
+ */
+export type SavepointResult<T> =
+    | {
+          ok: true;
+          value: T;
+      }
+    | {
+          ok: false;
+          error: unknown;
+      };
+
+export interface AtomicTransaction {
+    /**
+     * Register a callback that should run only after the outermost transaction commit succeeds.
+     */
+    onCommit(callback: () => void, options?: OnCommitOptions): void;
+
+    /**
+     * Run work inside a nested savepoint and, by default, capture rollback as a result object instead of throwing.
+     */
+    savepoint<T>(work: (tx: AtomicTransaction) => Promise<T> | T): Promise<SavepointResult<T>>;
+    savepoint<T>(
+        work: (tx: AtomicTransaction) => Promise<T> | T,
+        options: { throwOnError: false }
+    ): Promise<SavepointResult<T>>;
+    savepoint<T>(work: (tx: AtomicTransaction) => Promise<T> | T, options: { throwOnError: true }): Promise<T>;
+}

--- a/packages/orm/src/transaction/UnitOfWork.ts
+++ b/packages/orm/src/transaction/UnitOfWork.ts
@@ -1,4 +1,5 @@
 import type { DBClient } from '../connection/clients/DBClient';
+import { TransactionEngine } from './internal/context';
 
 /**
  * Unit of Work pattern implementation for managing database transactions.
@@ -16,6 +17,9 @@ import type { DBClient } from '../connection/clients/DBClient';
  *   throw error;
  * }
  * ```
+ *
+ * @deprecated Use `transaction.atomic(async (tx) => { ... })` for application
+ * transaction workflows. `UnitOfWork` remains exported only for compatibility.
  */
 export class UnitOfWork {
     static readonly BRAND = 'tango.orm.unit_of_work' as const;
@@ -42,6 +46,7 @@ export class UnitOfWork {
      * Convenience factory that constructs and begins a unit of work.
      */
     static async start(client: DBClient): Promise<UnitOfWork> {
+        TransactionEngine.assertNoActiveAtomicTransaction();
         const uow = new UnitOfWork(client);
         await uow.begin();
         return uow;
@@ -51,6 +56,7 @@ export class UnitOfWork {
      * Begin a transaction if one is not already active.
      */
     async begin(): Promise<void> {
+        TransactionEngine.assertNoActiveAtomicTransaction();
         if (!this.isActive) {
             await this.client.begin();
             this.isActive = true;

--- a/packages/orm/src/transaction/atomic.ts
+++ b/packages/orm/src/transaction/atomic.ts
@@ -1,0 +1,7 @@
+import { getTangoRuntime } from '../runtime/defaultRuntime';
+import type { AtomicTransaction } from './AtomicTransaction';
+import { TransactionEngine } from './internal/context';
+
+export async function atomic<T>(work: (tx: AtomicTransaction) => Promise<T> | T): Promise<T> {
+    return TransactionEngine.forRuntime(getTangoRuntime()).atomic(work);
+}

--- a/packages/orm/src/transaction/index.ts
+++ b/packages/orm/src/transaction/index.ts
@@ -2,4 +2,6 @@
  * Domain boundary barrel: centralizes this subdomain's public contract.
  */
 
+export { atomic } from './atomic';
+export type { AtomicTransaction, OnCommitOptions, SavepointOptions, SavepointResult } from './AtomicTransaction';
 export { UnitOfWork } from './UnitOfWork';

--- a/packages/orm/src/transaction/internal/context/AsyncLocalTransactionEngine.ts
+++ b/packages/orm/src/transaction/internal/context/AsyncLocalTransactionEngine.ts
@@ -1,0 +1,220 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+import { getLogger } from '@danceroutine/tango-core';
+import type { TangoRuntime } from '../../../runtime/TangoRuntime';
+import type { TransactionClientLease } from '../../../runtime/internal/DBClientProvider';
+import type { AtomicTransaction, SavepointOptions, SavepointResult } from '../../AtomicTransaction';
+import type { CallbackRecord } from './CallbackRecord';
+import { FrameBoundTransaction } from './FrameBoundTransaction';
+import type { TransactionFrame } from './TransactionFrame';
+import type { TransactionState } from './TransactionState';
+
+export class AsyncLocalTransactionEngine {
+    private readonly logger = getLogger('tango.orm.transaction');
+    private readonly storage = new AsyncLocalStorage<TransactionState>();
+
+    assertNoActiveAtomicTransaction(): void {
+        if (this.storage.getStore()) {
+            throw new Error('UnitOfWork is unsupported inside transaction.atomic(...).');
+        }
+    }
+
+    getActiveTransaction(runtime: TangoRuntime): AtomicTransaction | undefined {
+        const state = this.storage.getStore();
+        if (!state || state.runtime !== runtime) {
+            return undefined;
+        }
+
+        return state.frames.at(-1)?.facade;
+    }
+
+    getActiveLease(runtime: TangoRuntime): TransactionClientLease | undefined {
+        const state = this.storage.getStore();
+        if (!state || state.runtime !== runtime) {
+            return undefined;
+        }
+
+        return state.lease;
+    }
+
+    async atomic<T>(runtime: TangoRuntime, work: (tx: AtomicTransaction) => Promise<T> | T): Promise<T> {
+        const existing = this.storage.getStore();
+        if (existing) {
+            if (existing.runtime !== runtime) {
+                throw new Error(
+                    'Cannot open a transaction for one Tango runtime while another runtime transaction is active.'
+                );
+            }
+
+            return this.runNested(existing, work);
+        }
+
+        const lease = await runtime.leaseTransactionClient();
+        const state: TransactionState = {
+            runtime,
+            lease,
+            frames: [],
+            nextCallbackOrder: 0,
+            nextSavepointId: 0,
+        };
+
+        try {
+            return await this.storage.run(state, async () => {
+                await lease.client.begin();
+                const frame = this.pushFrame(state);
+
+                try {
+                    const result = await work(frame.facade);
+                    await lease.client.commit();
+                    const root = this.popFrame(state);
+                    root.facade.deactivate();
+                    await this.runCommittedCallbacks(root.callbacks);
+                    return result;
+                } catch (error) {
+                    await this.rollbackOuter(state, error);
+                    throw error;
+                }
+            });
+        } finally {
+            this.deactivateAllFrames(state);
+            await lease.release();
+        }
+    }
+
+    async runSavepoint<T>(
+        state: TransactionState,
+        work: (tx: AtomicTransaction) => Promise<T> | T,
+        options: SavepointOptions
+    ): Promise<T | SavepointResult<T>> {
+        try {
+            const value = await this.runNested(state, work);
+            if (options.throwOnError) {
+                return value;
+            }
+
+            return {
+                ok: true,
+                value,
+            };
+        } catch (error) {
+            if (options.throwOnError) {
+                throw error;
+            }
+
+            return {
+                ok: false,
+                error,
+            };
+        }
+    }
+
+    private async runNested<T>(state: TransactionState, work: (tx: AtomicTransaction) => Promise<T> | T): Promise<T> {
+        const savepointName = `tango_sp_${state.nextSavepointId++}`;
+        await state.lease.client.createSavepoint(savepointName);
+        const frame = this.pushFrame(state, savepointName);
+
+        try {
+            const result = await work(frame.facade);
+            await state.lease.client.releaseSavepoint(savepointName);
+            const completed = this.popFrame(state);
+            completed.facade.deactivate();
+            const parent = state.frames.at(-1);
+            if (!parent) {
+                throw new Error('Nested transaction frame completed without a parent frame.');
+            }
+
+            parent.callbacks.push(...completed.callbacks);
+            parent.callbacks.sort((left, right) => left.order - right.order);
+            return result;
+        } catch (error) {
+            try {
+                await state.lease.client.rollbackToSavepoint(savepointName);
+            } catch (rollbackError) {
+                throw this.attachCause(rollbackError, error);
+            } finally {
+                const discarded = this.popFrame(state);
+                discarded.facade.deactivate();
+            }
+
+            throw error;
+        }
+    }
+
+    private pushFrame(state: TransactionState, savepointName?: string): TransactionFrame {
+        const frame = {} as TransactionFrame;
+        const facade = new FrameBoundTransaction(this, state, frame);
+        frame.callbacks = [];
+        frame.facade = facade;
+        frame.savepointName = savepointName;
+        state.frames.push(frame);
+        return frame;
+    }
+
+    private popFrame(state: TransactionState): TransactionFrame {
+        const frame = state.frames.pop();
+        if (!frame) {
+            throw new Error('Transaction frame stack underflow.');
+        }
+
+        return frame;
+    }
+
+    private async rollbackOuter(state: TransactionState, error: unknown): Promise<void> {
+        try {
+            await state.lease.client.rollback();
+        } catch (rollbackError) {
+            throw this.attachCause(rollbackError, error);
+        } finally {
+            while (state.frames.length > 0) {
+                const frame = this.popFrame(state);
+                frame.facade.deactivate();
+            }
+        }
+    }
+
+    private async runCommittedCallbacks(callbacks: readonly CallbackRecord[]): Promise<void> {
+        for (const record of callbacks) {
+            try {
+                await record.callback();
+            } catch (error) {
+                if (!record.robust) {
+                    throw error;
+                }
+
+                try {
+                    this.logger.error('Post-commit callback failed.', error);
+                } catch {
+                    // A logging backend failure cannot change the already-committed outcome.
+                }
+            }
+        }
+    }
+
+    private deactivateAllFrames(state: TransactionState): void {
+        state.frames.length = 0;
+    }
+
+    private attachCause(error: unknown, cause: unknown): unknown {
+        if (!this.isErrorValue(error)) {
+            return error;
+        }
+
+        if ('cause' in error && error.cause !== undefined) {
+            return error;
+        }
+
+        try {
+            return new Error(error.message, { cause });
+        } catch {
+            return error;
+        }
+    }
+
+    private isErrorValue(value: unknown): value is Error {
+        return (
+            typeof value === 'object' &&
+            value !== null &&
+            typeof (value as { message?: unknown }).message === 'string' &&
+            typeof (value as { name?: unknown }).name === 'string'
+        );
+    }
+}

--- a/packages/orm/src/transaction/internal/context/CallbackRecord.ts
+++ b/packages/orm/src/transaction/internal/context/CallbackRecord.ts
@@ -1,0 +1,5 @@
+export type CallbackRecord = {
+    order: number;
+    callback: () => void;
+    robust: boolean;
+};

--- a/packages/orm/src/transaction/internal/context/FrameBoundTransaction.ts
+++ b/packages/orm/src/transaction/internal/context/FrameBoundTransaction.ts
@@ -1,0 +1,47 @@
+import type { AtomicTransaction, OnCommitOptions, SavepointOptions, SavepointResult } from '../../AtomicTransaction';
+import type { AsyncLocalTransactionEngine } from './AsyncLocalTransactionEngine';
+import type { TransactionFrame } from './TransactionFrame';
+import type { TransactionState } from './TransactionState';
+
+export class FrameBoundTransaction implements AtomicTransaction {
+    private active = true;
+
+    constructor(
+        private readonly engine: AsyncLocalTransactionEngine,
+        private readonly state: TransactionState,
+        private readonly frame: TransactionFrame
+    ) {}
+
+    onCommit(callback: () => void, options: OnCommitOptions = {}): void {
+        if (!this.active) {
+            throw new Error('Cannot register an on-commit callback on an inactive transaction frame.');
+        }
+
+        this.frame.callbacks.push({
+            order: this.state.nextCallbackOrder++,
+            callback,
+            robust: options.robust ?? false,
+        });
+    }
+
+    savepoint<T>(work: (tx: AtomicTransaction) => Promise<T> | T): Promise<SavepointResult<T>>;
+    savepoint<T>(
+        work: (tx: AtomicTransaction) => Promise<T> | T,
+        options: { throwOnError: false }
+    ): Promise<SavepointResult<T>>;
+    savepoint<T>(work: (tx: AtomicTransaction) => Promise<T> | T, options: { throwOnError: true }): Promise<T>;
+    async savepoint<T>(
+        work: (tx: AtomicTransaction) => Promise<T> | T,
+        options: SavepointOptions = {}
+    ): Promise<T | SavepointResult<T>> {
+        if (!this.active) {
+            throw new Error('Cannot open a savepoint from an inactive transaction frame.');
+        }
+
+        return this.engine.runSavepoint(this.state, work, options);
+    }
+
+    deactivate(): void {
+        this.active = false;
+    }
+}

--- a/packages/orm/src/transaction/internal/context/FrameTransactionHandle.ts
+++ b/packages/orm/src/transaction/internal/context/FrameTransactionHandle.ts
@@ -1,0 +1,5 @@
+import type { AtomicTransaction } from '../../AtomicTransaction';
+
+export interface FrameTransactionHandle extends AtomicTransaction {
+    deactivate(): void;
+}

--- a/packages/orm/src/transaction/internal/context/TransactionEngine.ts
+++ b/packages/orm/src/transaction/internal/context/TransactionEngine.ts
@@ -1,0 +1,33 @@
+import type { TangoRuntime } from '../../../runtime/TangoRuntime';
+import type { TransactionClientLease } from '../../../runtime/internal/DBClientProvider';
+import type { AtomicTransaction } from '../../AtomicTransaction';
+import { AsyncLocalTransactionEngine } from './AsyncLocalTransactionEngine';
+
+/**
+ * Runtime-bound transaction facade used by internal ORM/runtime components.
+ */
+export class TransactionEngine {
+    private static readonly engine = new AsyncLocalTransactionEngine();
+
+    private constructor(private readonly runtime: TangoRuntime) {}
+
+    static forRuntime(runtime: TangoRuntime): TransactionEngine {
+        return new TransactionEngine(runtime);
+    }
+
+    static assertNoActiveAtomicTransaction(): void {
+        this.engine.assertNoActiveAtomicTransaction();
+    }
+
+    getActiveTransaction(): AtomicTransaction | undefined {
+        return TransactionEngine.engine.getActiveTransaction(this.runtime);
+    }
+
+    getActiveLease(): TransactionClientLease | undefined {
+        return TransactionEngine.engine.getActiveLease(this.runtime);
+    }
+
+    async atomic<T>(work: (tx: AtomicTransaction) => Promise<T> | T): Promise<T> {
+        return TransactionEngine.engine.atomic(this.runtime, work);
+    }
+}

--- a/packages/orm/src/transaction/internal/context/TransactionFrame.ts
+++ b/packages/orm/src/transaction/internal/context/TransactionFrame.ts
@@ -1,0 +1,8 @@
+import type { CallbackRecord } from './CallbackRecord';
+import type { FrameTransactionHandle } from './FrameTransactionHandle';
+
+export type TransactionFrame = {
+    callbacks: CallbackRecord[];
+    facade: FrameTransactionHandle;
+    savepointName?: string;
+};

--- a/packages/orm/src/transaction/internal/context/TransactionState.ts
+++ b/packages/orm/src/transaction/internal/context/TransactionState.ts
@@ -1,0 +1,11 @@
+import type { TangoRuntime } from '../../../runtime/TangoRuntime';
+import type { TransactionClientLease } from '../../../runtime/internal/DBClientProvider';
+import type { TransactionFrame } from './TransactionFrame';
+
+export type TransactionState = {
+    runtime: TangoRuntime;
+    lease: TransactionClientLease;
+    frames: TransactionFrame[];
+    nextCallbackOrder: number;
+    nextSavepointId: number;
+};

--- a/packages/orm/src/transaction/internal/context/index.ts
+++ b/packages/orm/src/transaction/internal/context/index.ts
@@ -1,0 +1,1 @@
+export { TransactionEngine } from './TransactionEngine';

--- a/packages/orm/src/transaction/tests/atomic.public.test.ts
+++ b/packages/orm/src/transaction/tests/atomic.public.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest';
+import { aDBClient } from '@danceroutine/tango-testing';
+
+const runtime = {
+    leaseTransactionClient: vi.fn(async () => ({ client: aDBClient(), release: vi.fn(async () => {}) })),
+};
+
+vi.mock('../../runtime/defaultRuntime', () => ({
+    getTangoRuntime: vi.fn(() => runtime),
+}));
+
+import { atomic } from '../atomic';
+
+describe('public transaction.atomic', () => {
+    it('binds the package-level API to the default runtime', async () => {
+        await expect(atomic(async () => 'ok')).resolves.toBe('ok');
+        expect(runtime.leaseTransactionClient).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/orm/src/transaction/tests/atomic.test.ts
+++ b/packages/orm/src/transaction/tests/atomic.test.ts
@@ -1,0 +1,399 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { aDBClient, aTangoRuntime } from '@danceroutine/tango-testing';
+import type { DBClient } from '../../connection/clients/DBClient';
+import { TangoRuntime } from '../../runtime/TangoRuntime';
+import type { AtomicTransaction } from '../AtomicTransaction';
+import { UnitOfWork } from '../UnitOfWork';
+import { TransactionEngine } from '../internal/context';
+
+vi.mock('@danceroutine/tango-core', async () => {
+    const actual = await vi.importActual<typeof import('@danceroutine/tango-core')>('@danceroutine/tango-core');
+    return {
+        ...actual,
+        getLogger: vi.fn(() => ({
+            error: vi.fn(),
+            warn: vi.fn(),
+            info: vi.fn(),
+            debug: vi.fn(),
+        })),
+    };
+});
+
+type MockLease = {
+    client: DBClient;
+    release: ReturnType<typeof vi.fn>;
+};
+
+function createRuntime(): { runtime: TangoRuntime; lease: MockLease } {
+    const client: DBClient = aDBClient();
+    const release = vi.fn(async () => {});
+    const runtime = aTangoRuntime();
+    vi.spyOn(runtime, 'leaseTransactionClient').mockResolvedValue({ client, release });
+
+    return { runtime, lease: { client, release } };
+}
+
+describe('transaction.atomic', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('begins, commits, and releases the outer transaction lease', async () => {
+        const { runtime, lease } = createRuntime();
+        const callbacks: string[] = [];
+
+        const result = await TransactionEngine.forRuntime(runtime).atomic(async (tx) => {
+            tx.onCommit(() => {
+                callbacks.push('commit');
+            });
+            return 42;
+        });
+
+        expect(result).toBe(42);
+        expect(lease.client.begin).toHaveBeenCalledOnce();
+        expect(lease.client.commit).toHaveBeenCalledOnce();
+        expect(lease.client.rollback).not.toHaveBeenCalled();
+        expect(lease.release).toHaveBeenCalledOnce();
+        expect(callbacks).toEqual(['commit']);
+    });
+
+    it('rolls back and discards callbacks when outer work throws', async () => {
+        const { runtime, lease } = createRuntime();
+        const callbacks: string[] = [];
+
+        await expect(
+            TransactionEngine.forRuntime(runtime).atomic(async (tx) => {
+                tx.onCommit(() => {
+                    callbacks.push('commit');
+                });
+                throw new Error('boom');
+            })
+        ).rejects.toThrow('boom');
+
+        expect(lease.client.begin).toHaveBeenCalledOnce();
+        expect(lease.client.rollback).toHaveBeenCalledOnce();
+        expect(lease.client.commit).not.toHaveBeenCalled();
+        expect(callbacks).toEqual([]);
+    });
+
+    it('uses savepoints for nested atomic blocks and discards rolled-back nested callbacks only', async () => {
+        const { runtime, lease } = createRuntime();
+        const callbacks: string[] = [];
+
+        await TransactionEngine.forRuntime(runtime).atomic(async (outer) => {
+            outer.onCommit(() => {
+                callbacks.push('outer-before');
+            });
+
+            await expect(
+                TransactionEngine.forRuntime(runtime).atomic(async (inner) => {
+                    inner.onCommit(() => {
+                        callbacks.push('inner');
+                    });
+                    throw new Error('nested');
+                })
+            ).rejects.toThrow('nested');
+
+            outer.onCommit(() => {
+                callbacks.push('outer-after');
+            });
+        });
+
+        expect(lease.client.createSavepoint).toHaveBeenCalledWith('tango_sp_0');
+        expect(lease.client.rollbackToSavepoint).toHaveBeenCalledWith('tango_sp_0');
+        expect(lease.client.releaseSavepoint).not.toHaveBeenCalled();
+        expect(callbacks).toEqual(['outer-before', 'outer-after']);
+    });
+
+    it('returns a failed result from tx.savepoint without aborting the outer transaction by default', async () => {
+        const { runtime, lease } = createRuntime();
+        const callbacks: string[] = [];
+
+        await TransactionEngine.forRuntime(runtime).atomic(async (tx) => {
+            const result = await tx.savepoint(async () => {
+                throw new Error('nested');
+            });
+
+            expect(result).toEqual({
+                ok: false,
+                error: expect.any(Error),
+            });
+
+            tx.onCommit(() => {
+                callbacks.push('outer');
+            });
+        });
+
+        expect(lease.client.createSavepoint).toHaveBeenCalledWith('tango_sp_0');
+        expect(lease.client.rollbackToSavepoint).toHaveBeenCalledWith('tango_sp_0');
+        expect(lease.client.commit).toHaveBeenCalledOnce();
+        expect(callbacks).toEqual(['outer']);
+    });
+
+    it('rethrows tx.savepoint failures when throwOnError is enabled', async () => {
+        const { runtime, lease } = createRuntime();
+
+        await expect(
+            TransactionEngine.forRuntime(runtime).atomic(async (tx) => {
+                await tx.savepoint(
+                    async () => {
+                        throw new Error('nested');
+                    },
+                    { throwOnError: true }
+                );
+            })
+        ).rejects.toThrow('nested');
+
+        expect(lease.client.createSavepoint).toHaveBeenCalledWith('tango_sp_0');
+        expect(lease.client.rollbackToSavepoint).toHaveBeenCalledWith('tango_sp_0');
+        expect(lease.client.commit).not.toHaveBeenCalled();
+    });
+
+    it('returns a successful result from tx.savepoint and keeps callback order', async () => {
+        const { runtime } = createRuntime();
+        const callbacks: string[] = [];
+
+        await TransactionEngine.forRuntime(runtime).atomic(async (tx) => {
+            tx.onCommit(() => {
+                callbacks.push('outer-before');
+            });
+
+            const result = await tx.savepoint(async (nested) => {
+                nested.onCommit(() => {
+                    callbacks.push('inner');
+                });
+                return 'inner';
+            });
+
+            expect(result).toEqual({ ok: true, value: 'inner' });
+
+            tx.onCommit(() => {
+                callbacks.push('outer-after');
+            });
+        });
+
+        expect(callbacks).toEqual(['outer-before', 'inner', 'outer-after']);
+    });
+
+    it('returns the raw nested value when tx.savepoint succeeds with throwOnError enabled', async () => {
+        const { runtime } = createRuntime();
+
+        await TransactionEngine.forRuntime(runtime).atomic(async (tx) => {
+            const value = await tx.savepoint(
+                async () => {
+                    return 'inner';
+                },
+                { throwOnError: true }
+            );
+
+            expect(value).toBe('inner');
+        });
+    });
+
+    it('merges successful nested callbacks in global registration order', async () => {
+        const { runtime } = createRuntime();
+        const callbacks: string[] = [];
+
+        await TransactionEngine.forRuntime(runtime).atomic(async (outer) => {
+            outer.onCommit(() => {
+                callbacks.push('outer-before');
+            });
+
+            await TransactionEngine.forRuntime(runtime).atomic(async (inner) => {
+                inner.onCommit(() => {
+                    callbacks.push('inner');
+                });
+            });
+
+            outer.onCommit(() => {
+                callbacks.push('outer-after');
+            });
+        });
+
+        expect(callbacks).toEqual(['outer-before', 'inner', 'outer-after']);
+    });
+
+    it('rejects after commit when a non-robust callback throws', async () => {
+        const { runtime, lease } = createRuntime();
+        const later = vi.fn();
+
+        await expect(
+            TransactionEngine.forRuntime(runtime).atomic(async (tx) => {
+                tx.onCommit(() => {
+                    throw new Error('callback failed');
+                });
+                tx.onCommit(later);
+            })
+        ).rejects.toThrow('callback failed');
+
+        expect(lease.client.commit).toHaveBeenCalledOnce();
+        expect(later).not.toHaveBeenCalled();
+    });
+
+    it('swallows robust callback failures and continues later callbacks', async () => {
+        const { runtime, lease } = createRuntime();
+        const later = vi.fn();
+
+        await expect(
+            TransactionEngine.forRuntime(runtime).atomic(async (tx) => {
+                tx.onCommit(
+                    () => {
+                        throw new Error('callback failed');
+                    },
+                    { robust: true }
+                );
+                tx.onCommit(later);
+            })
+        ).resolves.toBeUndefined();
+
+        expect(lease.client.commit).toHaveBeenCalledOnce();
+        expect(later).toHaveBeenCalledOnce();
+    });
+
+    it('rejects retained transaction facades after the frame completes', async () => {
+        const { runtime } = createRuntime();
+        let retained: AtomicTransaction | undefined;
+
+        await TransactionEngine.forRuntime(runtime).atomic(async (tx) => {
+            retained = tx;
+        });
+
+        expect(() => retained?.onCommit(() => {})).toThrow(/inactive transaction frame/i);
+        await expect(retained?.savepoint(async () => undefined)).rejects.toThrow(/inactive transaction frame/i);
+    });
+
+    it('rejects UnitOfWork inside an active atomic block', async () => {
+        const { runtime } = createRuntime();
+
+        await expect(
+            TransactionEngine.forRuntime(runtime).atomic(async () => {
+                await UnitOfWork.start(aDBClient());
+            })
+        ).rejects.toThrow(/UnitOfWork is unsupported/);
+    });
+
+    it('exposes the current transaction facade for the matching runtime only while a frame is active', async () => {
+        const { runtime } = createRuntime();
+        const otherRuntime = createRuntime().runtime;
+
+        await TransactionEngine.forRuntime(runtime)
+            .atomic(async (tx) => {
+                expect(TransactionEngine.forRuntime(runtime).getActiveTransaction()).toBe(tx);
+                expect(TransactionEngine.forRuntime(otherRuntime).getActiveTransaction()).toBeUndefined();
+
+                (tx as unknown as { state: { frames: unknown[] } }).state.frames.length = 0;
+                expect(TransactionEngine.forRuntime(runtime).getActiveTransaction()).toBeUndefined();
+            })
+            .catch(() => undefined);
+    });
+
+    it('rejects nested atomic blocks that target a different runtime', async () => {
+        const { runtime } = createRuntime();
+        const other = createRuntime().runtime;
+
+        await expect(
+            TransactionEngine.forRuntime(runtime).atomic(async () => {
+                await TransactionEngine.forRuntime(other).atomic(async () => undefined);
+            })
+        ).rejects.toThrow(/another runtime transaction is active/i);
+    });
+
+    it('surfaces rollback failures with the application error as cause when outer rollback fails', async () => {
+        const { runtime, lease } = createRuntime();
+        vi.mocked(lease.client.rollback).mockRejectedValueOnce(new Error('rollback failed'));
+
+        await expect(
+            TransactionEngine.forRuntime(runtime).atomic(async () => {
+                throw new Error('boom');
+            })
+        ).rejects.toThrow('rollback failed');
+    });
+
+    it('surfaces savepoint rollback failures with the nested error as cause', async () => {
+        const { runtime, lease } = createRuntime();
+        vi.mocked(lease.client.rollbackToSavepoint).mockRejectedValueOnce(new Error('savepoint rollback failed'));
+
+        await expect(
+            TransactionEngine.forRuntime(runtime).atomic(async () => {
+                await TransactionEngine.forRuntime(runtime).atomic(async () => {
+                    throw new Error('nested');
+                });
+            })
+        ).rejects.toThrow('savepoint rollback failed');
+    });
+
+    it('passes through non-Error rollback failures unchanged', async () => {
+        const { runtime, lease } = createRuntime();
+        vi.mocked(lease.client.rollbackToSavepoint).mockRejectedValueOnce('savepoint rollback failed');
+
+        await expect(
+            TransactionEngine.forRuntime(runtime).atomic(async () => {
+                await TransactionEngine.forRuntime(runtime).atomic(async () => {
+                    throw new Error('nested');
+                });
+            })
+        ).rejects.toBe('savepoint rollback failed');
+    });
+
+    it('preserves rollback errors that already carry a cause', async () => {
+        const { runtime, lease } = createRuntime();
+        const rollbackError = new Error('rollback failed', { cause: new Error('original') });
+        vi.mocked(lease.client.rollback).mockRejectedValueOnce(rollbackError);
+
+        await expect(
+            TransactionEngine.forRuntime(runtime).atomic(async () => {
+                throw new Error('boom');
+            })
+        ).rejects.toBe(rollbackError);
+    });
+
+    it('fails defensively if a nested frame loses its parent before merge', async () => {
+        const { runtime } = createRuntime();
+
+        await expect(
+            TransactionEngine.forRuntime(runtime).atomic(async () => {
+                await TransactionEngine.forRuntime(runtime).atomic(async (inner) => {
+                    (inner as unknown as { state: { frames: unknown[] } }).state.frames.splice(0, 1);
+                });
+            })
+        ).rejects.toThrow(/stack underflow/);
+    });
+
+    it('fails defensively if the outer frame stack is cleared before commit merge', async () => {
+        const { runtime } = createRuntime();
+
+        await expect(
+            TransactionEngine.forRuntime(runtime).atomic(async (tx) => {
+                (tx as unknown as { state: { frames: unknown[] } }).state.frames.length = 0;
+            })
+        ).rejects.toThrow(/stack underflow/);
+    });
+
+    it('returns the original rollback error if attaching a cause throws', async () => {
+        const { runtime, lease } = createRuntime();
+        const OriginalError = globalThis.Error;
+
+        class ThrowingError extends OriginalError {
+            constructor(message?: string, options?: ErrorOptions) {
+                if (options && 'cause' in options) {
+                    throw new OriginalError('cause unsupported');
+                }
+                super(message);
+            }
+        }
+
+        const rollbackError = new ThrowingError('rollback failed');
+        vi.mocked(lease.client.rollback).mockRejectedValueOnce(rollbackError);
+        globalThis.Error = ThrowingError as ErrorConstructor;
+
+        try {
+            await expect(
+                TransactionEngine.forRuntime(runtime).atomic(async () => {
+                    throw new ThrowingError('boom');
+                })
+            ).rejects.toBe(rollbackError);
+        } finally {
+            globalThis.Error = OriginalError;
+        }
+    });
+});

--- a/packages/schema/src/domain/ModelWriteHooks.ts
+++ b/packages/schema/src/domain/ModelWriteHooks.ts
@@ -5,6 +5,14 @@ export interface ModelWriteHookManager<TModel extends Record<string, unknown>> {
     bulkCreate(inputs: Partial<TModel>[]): Promise<TModel[]>;
 }
 
+export interface ModelWriteHookOnCommitOptions {
+    robust?: boolean;
+}
+
+export interface ModelWriteHookTransaction {
+    onCommit(callback: () => void, options?: ModelWriteHookOnCommitOptions): void;
+}
+
 /**
  * Structural model contract passed into write lifecycle hooks.
  */
@@ -22,12 +30,14 @@ export interface BeforeCreateHookArgs<TModel extends Record<string, unknown>> {
     data: Partial<TModel>;
     model: ModelHookModel<TModel>;
     manager: ModelWriteHookManager<TModel>;
+    transaction?: ModelWriteHookTransaction;
 }
 
 export interface AfterCreateHookArgs<TModel extends Record<string, unknown>> {
     record: TModel;
     model: ModelHookModel<TModel>;
     manager: ModelWriteHookManager<TModel>;
+    transaction?: ModelWriteHookTransaction;
 }
 
 export interface BeforeUpdateHookArgs<TModel extends Record<string, unknown>> {
@@ -36,6 +46,7 @@ export interface BeforeUpdateHookArgs<TModel extends Record<string, unknown>> {
     current: TModel;
     model: ModelHookModel<TModel>;
     manager: ModelWriteHookManager<TModel>;
+    transaction?: ModelWriteHookTransaction;
 }
 
 export interface AfterUpdateHookArgs<TModel extends Record<string, unknown>> {
@@ -45,6 +56,7 @@ export interface AfterUpdateHookArgs<TModel extends Record<string, unknown>> {
     record: TModel;
     model: ModelHookModel<TModel>;
     manager: ModelWriteHookManager<TModel>;
+    transaction?: ModelWriteHookTransaction;
 }
 
 export interface BeforeDeleteHookArgs<TModel extends Record<string, unknown>> {
@@ -52,6 +64,7 @@ export interface BeforeDeleteHookArgs<TModel extends Record<string, unknown>> {
     current: TModel;
     model: ModelHookModel<TModel>;
     manager: ModelWriteHookManager<TModel>;
+    transaction?: ModelWriteHookTransaction;
 }
 
 export interface AfterDeleteHookArgs<TModel extends Record<string, unknown>> {
@@ -59,18 +72,21 @@ export interface AfterDeleteHookArgs<TModel extends Record<string, unknown>> {
     previous: TModel;
     model: ModelHookModel<TModel>;
     manager: ModelWriteHookManager<TModel>;
+    transaction?: ModelWriteHookTransaction;
 }
 
 export interface BeforeBulkCreateHookArgs<TModel extends Record<string, unknown>> {
     rows: Partial<TModel>[];
     model: ModelHookModel<TModel>;
     manager: ModelWriteHookManager<TModel>;
+    transaction?: ModelWriteHookTransaction;
 }
 
 export interface AfterBulkCreateHookArgs<TModel extends Record<string, unknown>> {
     records: TModel[];
     model: ModelHookModel<TModel>;
     manager: ModelWriteHookManager<TModel>;
+    transaction?: ModelWriteHookTransaction;
 }
 
 /**

--- a/packages/schema/src/domain/index.ts
+++ b/packages/schema/src/domain/index.ts
@@ -13,7 +13,9 @@ export type { ModelMetadata } from './ModelMetadata';
 export type { Model, ModelAugmentations, ModelKeyOf, PersistedModelOutput } from './Model';
 export type {
     ModelHookModel,
+    ModelWriteHookOnCommitOptions,
     ModelWriteHookManager,
+    ModelWriteHookTransaction,
     ModelWriteHooks,
     BeforeCreateHookArgs,
     AfterCreateHookArgs,

--- a/packages/testing/src/integration/runtime/aTangoConfig.ts
+++ b/packages/testing/src/integration/runtime/aTangoConfig.ts
@@ -2,6 +2,7 @@ import { defineConfig, type TangoConfig } from '@danceroutine/tango-config';
 
 export type TestTangoConfigOptions = {
     adapter?: 'sqlite' | 'postgres';
+    sqliteFilename?: string;
 };
 
 /**
@@ -9,6 +10,7 @@ export type TestTangoConfigOptions = {
  */
 export function aTangoConfig(options: TestTangoConfigOptions = {}): TangoConfig {
     const adapter = options.adapter ?? 'sqlite';
+    const sqliteFilename = options.sqliteFilename ?? ':memory:';
 
     return defineConfig({
         current: 'test',
@@ -17,7 +19,7 @@ export function aTangoConfig(options: TestTangoConfigOptions = {}): TangoConfig 
                 name: 'development',
                 db:
                     adapter === 'sqlite'
-                        ? { adapter: 'sqlite', filename: ':memory:', maxConnections: 1 }
+                        ? { adapter: 'sqlite', filename: sqliteFilename, maxConnections: 1 }
                         : {
                               adapter: 'postgres',
                               url: 'postgres://postgres:postgres@localhost:5432/tango',
@@ -29,7 +31,7 @@ export function aTangoConfig(options: TestTangoConfigOptions = {}): TangoConfig 
                 name: 'test',
                 db:
                     adapter === 'sqlite'
-                        ? { adapter: 'sqlite', filename: ':memory:', maxConnections: 1 }
+                        ? { adapter: 'sqlite', filename: sqliteFilename, maxConnections: 1 }
                         : {
                               adapter: 'postgres',
                               url: 'postgres://postgres:postgres@localhost:5432/tango_test',
@@ -41,7 +43,7 @@ export function aTangoConfig(options: TestTangoConfigOptions = {}): TangoConfig 
                 name: 'production',
                 db:
                     adapter === 'sqlite'
-                        ? { adapter: 'sqlite', filename: ':memory:', maxConnections: 1 }
+                        ? { adapter: 'sqlite', filename: sqliteFilename, maxConnections: 1 }
                         : {
                               adapter: 'postgres',
                               url: 'postgres://postgres:postgres@localhost:5432/tango',

--- a/packages/testing/src/integration/runtime/aTangoRuntime.ts
+++ b/packages/testing/src/integration/runtime/aTangoRuntime.ts
@@ -1,0 +1,10 @@
+import { loadConfig } from '@danceroutine/tango-config';
+import { TangoRuntime } from '@danceroutine/tango-orm';
+import { aTangoConfig, type TestTangoConfigOptions } from './aTangoConfig';
+
+/**
+ * Create a standalone Tango runtime for tests without mutating the process-default runtime.
+ */
+export function aTangoRuntime(options: TestTangoConfigOptions = {}): TangoRuntime {
+    return new TangoRuntime(() => loadConfig(() => aTangoConfig(options)));
+}

--- a/packages/testing/src/integration/runtime/index.ts
+++ b/packages/testing/src/integration/runtime/index.ts
@@ -4,4 +4,5 @@
 
 export { aTangoConfig } from './aTangoConfig';
 export type { TestTangoConfigOptions } from './aTangoConfig';
+export { aTangoRuntime } from './aTangoRuntime';
 export { setupTestTangoRuntime } from './setupTestTangoRuntime';

--- a/packages/testing/src/integration/runtime/tests/aTangoRuntime.test.ts
+++ b/packages/testing/src/integration/runtime/tests/aTangoRuntime.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { aTangoRuntime } from '../aTangoRuntime';
+
+describe(aTangoRuntime, () => {
+    it('builds a standalone runtime from the generated config', () => {
+        const runtime = aTangoRuntime({ adapter: 'postgres' });
+
+        expect(runtime.getDialect()).toBe('postgres');
+        expect(runtime.getConfig().current.db.adapter).toBe('postgres');
+    });
+});

--- a/packages/testing/src/mocks/aDBClient.ts
+++ b/packages/testing/src/mocks/aDBClient.ts
@@ -12,6 +12,9 @@ type DBClientOverrides = {
     commit?: () => Promise<void>;
     rollback?: () => Promise<void>;
     close?: () => Promise<void>;
+    createSavepoint?: (name: string) => Promise<void>;
+    releaseSavepoint?: (name: string) => Promise<void>;
+    rollbackToSavepoint?: (name: string) => Promise<void>;
 };
 
 /**
@@ -27,12 +30,20 @@ export function aDBClient(overrides: DBClientOverrides = {}): DBClient {
     const commitImpl = overrides.commit ?? (async () => {});
     const rollbackImpl = overrides.rollback ?? (async () => {});
     const closeImpl = overrides.close ?? (async () => {});
+    const createSavepointImpl = overrides.createSavepoint ?? (async (_name: string) => {});
+    const releaseSavepointImpl = overrides.releaseSavepoint ?? (async (_name: string) => {});
+    const rollbackToSavepointImpl = overrides.rollbackToSavepoint ?? (async (_name: string) => {});
 
-    return {
+    const client: DBClient = {
         query: vi.fn((sql: string, params?: readonly unknown[]) => queryImpl(sql, params)) as DBClient['query'],
         begin: vi.fn(() => beginImpl()),
         commit: vi.fn(() => commitImpl()),
         rollback: vi.fn(() => rollbackImpl()),
         close: vi.fn(() => closeImpl()),
+        createSavepoint: vi.fn((name: string) => createSavepointImpl(name)),
+        releaseSavepoint: vi.fn((name: string) => releaseSavepointImpl(name)),
+        rollbackToSavepoint: vi.fn((name: string) => rollbackToSavepointImpl(name)),
     };
+
+    return client;
 }

--- a/packages/testing/src/tests/index.test.ts
+++ b/packages/testing/src/tests/index.test.ts
@@ -13,6 +13,9 @@ describe('@danceroutine/tango-testing', () => {
             expect(client.commit).toBeInstanceOf(Function);
             expect(client.rollback).toBeInstanceOf(Function);
             expect(client.close).toBeInstanceOf(Function);
+            expect(client.createSavepoint).toBeInstanceOf(Function);
+            expect(client.releaseSavepoint).toBeInstanceOf(Function);
+            expect(client.rollbackToSavepoint).toBeInstanceOf(Function);
         });
 
         it('query returns empty rows by default', async () => {
@@ -29,6 +32,9 @@ describe('@danceroutine/tango-testing', () => {
             await expect(client.commit()).resolves.toBeUndefined();
             await expect(client.rollback()).resolves.toBeUndefined();
             await expect(client.close()).resolves.toBeUndefined();
+            await expect(client.createSavepoint('sp')).resolves.toBeUndefined();
+            await expect(client.releaseSavepoint('sp')).resolves.toBeUndefined();
+            await expect(client.rollbackToSavepoint('sp')).resolves.toBeUndefined();
         });
     });
 


### PR DESCRIPTION
## Summary
- add a supported `transaction.atomic(async (tx) => ...)` API with nested savepoints and `tx.onCommit(...)`
- refactor runtime client ownership around provider/lease abstractions and route ORM work through the active transaction lease
- extend write hook args with a narrow transaction callback contract and update ORM docs around the new transaction model

## Why
This turns ORM transactions into a supported application-facing contract instead of leaving transaction workflows to `UnitOfWork` or direct client usage.

## Validation
- `pnpm run lint:eslint`
- `pnpm run lint:ox`
- `pnpm typecheck`
- `pnpm test`
- `pnpm build`
