### PR TITLE
ci: deploy docs after stable releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,7 +218,7 @@ jobs:
               run: pnpm build
 
     smoke-test:
-        name: Smoke Test (Express + Next)
+        name: Smoke Test (Host Frameworks)
         runs-on: ubuntu-latest
         steps:
             - name: Checkout

--- a/.github/workflows/docs-pages.reusable.yml
+++ b/.github/workflows/docs-pages.reusable.yml
@@ -1,0 +1,65 @@
+name: Docs Pages (reusable)
+
+on:
+    workflow_call:
+
+concurrency:
+    group: docs-pages
+    cancel-in-progress: true
+
+jobs:
+    build:
+        name: Build docs
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v4
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+              with:
+                  node-version-file: '.nvmrc'
+
+            - name: Setup pnpm
+              uses: pnpm/action-setup@v4
+
+            - name: Get pnpm store directory
+              id: pnpm-cache
+              shell: bash
+              run: echo "STORE_PATH=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+            - name: Setup pnpm cache
+              uses: actions/cache@v4
+              with:
+                  path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+                  restore-keys: |
+                      ${{ runner.os }}-pnpm-store-
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Setup Pages
+              uses: actions/configure-pages@v5
+
+            - name: Build docs
+              env:
+                  TANGO_DOCS_BASE: /
+              run: pnpm docs:build
+
+            - name: Upload Pages artifact
+              uses: actions/upload-pages-artifact@v3
+              with:
+                  path: docs/.vitepress/dist
+
+    deploy:
+        name: Deploy docs
+        needs: build
+        runs-on: ubuntu-latest
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.page_url }}
+        steps:
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
         paths:
             - 'docs/**'
             - '.github/workflows/docs.yml'
+            - '.github/workflows/docs-pages.reusable.yml'
     workflow_dispatch:
 
 permissions:
@@ -19,58 +20,6 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    build:
-        name: Build docs
-        runs-on: ubuntu-latest
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v4
-
-            - name: Setup Node.js
-              uses: actions/setup-node@v4
-              with:
-                  node-version-file: '.nvmrc'
-
-            - name: Setup pnpm
-              uses: pnpm/action-setup@v4
-
-            - name: Get pnpm store directory
-              id: pnpm-cache
-              shell: bash
-              run: echo "STORE_PATH=$(pnpm store path)" >> "$GITHUB_OUTPUT"
-
-            - name: Setup pnpm cache
-              uses: actions/cache@v4
-              with:
-                  path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
-                  key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-                  restore-keys: |
-                      ${{ runner.os }}-pnpm-store-
-
-            - name: Install dependencies
-              run: pnpm install --frozen-lockfile
-
-            - name: Setup Pages
-              uses: actions/configure-pages@v5
-
-            - name: Build docs
-              env:
-                  TANGO_DOCS_BASE: /
-              run: pnpm docs:build
-
-            - name: Upload Pages artifact
-              uses: actions/upload-pages-artifact@v3
-              with:
-                  path: docs/.vitepress/dist
-
-    deploy:
-        name: Deploy docs
-        needs: build
-        runs-on: ubuntu-latest
-        environment:
-            name: github-pages
-            url: ${{ steps.deployment.outputs.page_url }}
-        steps:
-            - name: Deploy to GitHub Pages
-              id: deployment
-              uses: actions/deploy-pages@v4
+    pages:
+        name: Docs Pages
+        uses: ./.github/workflows/docs-pages.reusable.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ concurrency:
 
 permissions:
     contents: write
+    pages: write
     id-token: write
 
 jobs:
@@ -34,6 +35,9 @@ jobs:
         name: Release
         runs-on: ubuntu-latest
         environment: npm
+        outputs:
+            stable_release_mode: ${{ steps.stable-release.outputs.mode }}
+            publish_state_mode: ${{ steps.publish-state.outputs.mode }}
         services:
             postgres:
                 image: postgres:16
@@ -188,3 +192,19 @@ jobs:
               run: pnpm changeset publish --no-git-tag --snapshot --tag alpha
               env:
                   NPM_CONFIG_PROVENANCE: true
+
+    docs:
+        name: Deploy docs (stable publish)
+        needs: release
+        if: |
+            (
+              (github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable'))
+              && needs.release.outputs.stable_release_mode == 'release'
+              && needs.release.outputs.publish_state_mode == 'publish'
+            )
+            || (
+              github.event_name == 'workflow_dispatch'
+              && inputs.release_type == 'stable-recovery'
+              && needs.release.outputs.publish_state_mode == 'publish'
+            )
+        uses: ./.github/workflows/docs-pages.reusable.yml

--- a/docs/contributors/releasing.md
+++ b/docs/contributors/releasing.md
@@ -46,6 +46,8 @@ Stable releases are changeset-driven. Before you expect a stable publish to happ
 
 In normal operation, a push to `main` triggers the stable workflow automatically. If you need to rerun the stable path manually, dispatch the workflow with `release_type=stable` and `branch=main`.
 
+After a successful stable publish (including `stable-recovery`), the workflow also rebuilds and deploys the documentation site so the docs navigation version stays in sync with the latest release.
+
 ## Stable workflow behavior
 
 The stable workflow validates the current release state before it mutates any versions.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -16,7 +16,7 @@ Most Tango applications are built from the same set of concerns.
 - `@danceroutine/tango-orm` provides you the same QuerySet based ORM contract you're used to from Django, backed by an extensible adapter system to enable onboarding new database management systems.
 - `@danceroutine/tango-migrations` provides the same onion-skin automatic migration process for deterministically evolving your database schema as you change your models.
 - `@danceroutine/tango-resources` exposes familiar DRF-style capabilities such as APIViews, Viewsets, and Serializers to integrate your application business logic to your API layer with minimal boilerplate.
-- An adapter package resposible for connecting your resources to the host framework you are using.
+- An adapter package responsible for connecting your resources to the host framework you are using.
 
 ## Start with a working Tango application
 
@@ -142,7 +142,7 @@ When the app is running, open:
 - `http://localhost:3002/api/posts?limit=20&offset=0`
 - `http://localhost:3002/api/openapi`
 
-The root page shows the Nuxt application as a user sees it, powered by the same ORM layer. If you'r interested in the Nitro API side, check out the posts endpoint to learn about Tango's API behavior in Nuxt. Additionally, the OpenAPI endpoint shows how Tango's API layer can also drive machine-readable self-documenting API output in the same application.
+The root page shows the Nuxt application as a user sees it, powered by the same ORM layer. If you're interested in the Nitro API side, check out the posts endpoint to learn about Tango's API behavior in Nuxt. Additionally, the OpenAPI endpoint shows how Tango's API layer can also drive machine-readable self-documenting API output in the same application.
 
 After that, inspect `nuxt.config.ts`, the Tango server handlers, the post serializer, the post viewset, and the Nuxt pages. That path shows how Tango can power the data and API layer while Nuxt continues to shape the user-facing application.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ hero:
 
 features:
     - title: Type-safe ORM
-      details: Tango integrates Zod into your model definitions, combining the best of DRF Serializers with Django models, with the declarative interface and type-inferrence of Zod.
+      details: Tango integrates Zod into your model definitions, combining the best of DRF Serializers with Django models, with the declarative interface and type inference of Zod.
     - title: Django + DRF inspired API layer
       details: Expose your datalayer through your API with minimal boilerplate, utilizing the same viewset and API patterns you're used to from DRF
     - title: Framework interoperability

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,433 @@ importers:
         specifier: ^4.0.6
         version: 4.0.6(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
 
+  .temp/dogfood-runner: {}
+
+  .temp/express-dogfood-1773544911:
+    dependencies:
+      '@danceroutine/tango-adapters-express':
+        specifier: workspace:*
+        version: link:../../packages/adapters/express
+      '@danceroutine/tango-config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@danceroutine/tango-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@danceroutine/tango-migrations':
+        specifier: workspace:*
+        version: link:../../packages/migrations
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../packages/orm
+      '@danceroutine/tango-resources':
+        specifier: workspace:*
+        version: link:../../packages/resources
+      '@danceroutine/tango-schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      express:
+        specifier: ^4.21.2
+        version: 4.22.1
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  .temp/express-hardening-1773546487:
+    dependencies:
+      '@danceroutine/tango-adapters-express':
+        specifier: workspace:*
+        version: link:../../packages/adapters/express
+      '@danceroutine/tango-config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@danceroutine/tango-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@danceroutine/tango-migrations':
+        specifier: workspace:*
+        version: link:../../packages/migrations
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../packages/orm
+      '@danceroutine/tango-resources':
+        specifier: workspace:*
+        version: link:../../packages/resources
+      '@danceroutine/tango-schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      express:
+        specifier: ^4.21.2
+        version: 4.22.1
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  .temp/express-hardening-1773546506:
+    dependencies:
+      '@danceroutine/tango-adapters-express':
+        specifier: workspace:*
+        version: link:../../packages/adapters/express
+      '@danceroutine/tango-config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@danceroutine/tango-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@danceroutine/tango-migrations':
+        specifier: workspace:*
+        version: link:../../packages/migrations
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../packages/orm
+      '@danceroutine/tango-resources':
+        specifier: workspace:*
+        version: link:../../packages/resources
+      '@danceroutine/tango-schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      express:
+        specifier: ^4.21.2
+        version: 4.22.1
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  .temp/express-hardening-1773546629:
+    dependencies:
+      '@danceroutine/tango-adapters-express':
+        specifier: workspace:*
+        version: link:../../packages/adapters/express
+      '@danceroutine/tango-config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@danceroutine/tango-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@danceroutine/tango-migrations':
+        specifier: workspace:*
+        version: link:../../packages/migrations
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../packages/orm
+      '@danceroutine/tango-resources':
+        specifier: workspace:*
+        version: link:../../packages/resources
+      '@danceroutine/tango-schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      express:
+        specifier: ^4.21.2
+        version: 4.22.1
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  .temp/express-todo:
+    dependencies:
+      '@danceroutine/tango-adapters-express':
+        specifier: workspace:*
+        version: link:../../packages/adapters/express
+      '@danceroutine/tango-config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@danceroutine/tango-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@danceroutine/tango-migrations':
+        specifier: workspace:*
+        version: link:../../packages/migrations
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../packages/orm
+      '@danceroutine/tango-resources':
+        specifier: workspace:*
+        version: link:../../packages/resources
+      '@danceroutine/tango-schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      express:
+        specifier: ^4.21.2
+        version: 4.22.1
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  .temp/next-hardening-1773546649:
+    dependencies:
+      '@danceroutine/tango-adapters-next':
+        specifier: workspace:*
+        version: link:../../packages/adapters/next
+      '@danceroutine/tango-config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@danceroutine/tango-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@danceroutine/tango-migrations':
+        specifier: workspace:*
+        version: link:../../packages/migrations
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../packages/orm
+      '@danceroutine/tango-resources':
+        specifier: workspace:*
+        version: link:../../packages/resources
+      '@danceroutine/tango-schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      next:
+        specifier: ^15.1.6
+        version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      '@types/react':
+        specifier: ^19.0.6
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.2
+        version: 19.2.3(@types/react@19.2.14)
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  .temp/next-hardening-1773546702:
+    dependencies:
+      '@danceroutine/tango-adapters-next':
+        specifier: workspace:*
+        version: link:../../packages/adapters/next
+      '@danceroutine/tango-config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@danceroutine/tango-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@danceroutine/tango-migrations':
+        specifier: workspace:*
+        version: link:../../packages/migrations
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../packages/orm
+      '@danceroutine/tango-resources':
+        specifier: workspace:*
+        version: link:../../packages/resources
+      '@danceroutine/tango-schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      next:
+        specifier: ^15.1.6
+        version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      '@types/react':
+        specifier: ^19.0.6
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.2
+        version: 19.2.3(@types/react@19.2.14)
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  .temp/next-todo:
+    dependencies:
+      '@danceroutine/tango-adapters-next':
+        specifier: workspace:*
+        version: link:../../packages/adapters/next
+      '@danceroutine/tango-config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@danceroutine/tango-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@danceroutine/tango-migrations':
+        specifier: workspace:*
+        version: link:../../packages/migrations
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../packages/orm
+      '@danceroutine/tango-resources':
+        specifier: workspace:*
+        version: link:../../packages/resources
+      '@danceroutine/tango-schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      next:
+        specifier: ^15.1.6
+        version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      '@types/react':
+        specifier: ^19.0.6
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.2
+        version: 19.2.3(@types/react@19.2.14)
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  .temp/pnpm-test:
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: link:/Users/pedro/coding/tango/packages/cli
+        version: link:../../packages/cli
+
   docs:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Summary
- Extract docs GitHub Pages deploy into a reusable workflow.
- Trigger docs deploy from the Release workflow after successful stable publish (and stable-recovery) so docs nav version stays current.
- Rename smoke-test check to a framework-agnostic label.

## Validation
- [1mpnpm docs:build[0m
- [1mpnpm format:check[0m