### PR TITLE
fix(ci): reference reusable docs workflow by ref

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,4 +22,4 @@ concurrency:
 jobs:
     pages:
         name: Docs Pages
-        uses: ./.github/workflows/docs-pages.reusable.yml
+        uses: danceroutine/tango/.github/workflows/docs-pages.reusable.yml@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -207,4 +207,4 @@ jobs:
               && inputs.release_type == 'stable-recovery'
               && needs.release.outputs.publish_state_mode == 'publish'
             )
-        uses: ./.github/workflows/docs-pages.reusable.yml
+        uses: danceroutine/tango/.github/workflows/docs-pages.reusable.yml@main


### PR DESCRIPTION
## Summary
- Fix Docs/Release workflow calls to reference the reusable docs Pages workflow via an explicit ref so GitHub Actions can load it.

## Why
The post-merge Docs workflow run failed with a workflow file issue; referencing the reusable workflow via a ref resolves it.

## Validation
- GitHub Actions (CI/Docs) on this PR