### PR TITLE
fix(ci): make reusable docs workflow callable

### DIFF
--- a/.github/workflows/docs-pages.reusable.yml
+++ b/.github/workflows/docs-pages.reusable.yml
@@ -3,10 +3,6 @@ name: Docs Pages (reusable)
 on:
     workflow_call:
 
-concurrency:
-    group: docs-pages
-    cancel-in-progress: true
-
 jobs:
     build:
         name: Build docs


### PR DESCRIPTION
## Summary
- Remove the workflow-level concurrency block from the reusable docs Pages workflow.

## Why
The `Docs` workflow runs on `main` were failing with a workflow file issue and creating zero jobs, indicating the called reusable workflow was being rejected at parse time. This makes the reusable workflow callable while keeping concurrency enforcement in the callers.

## Validation
- GitHub Actions on this PR