### PR TITLE
feat: improve generated changelog entries

### DIFF
--- a/.changeset/README.md
+++ b/.changeset/README.md
@@ -14,6 +14,8 @@ This will prompt you to select which packages have changed and what type of chan
 
 The summary you write is later used to generate Tango's root `CHANGELOG.md` for stable releases.
 
+Write that summary in the Markdown shape you want the changelog to preserve. The stable release script carries each changeset summary into the root changelog verbatim, so short bullets, short release-note paragraphs, and compact fenced examples can survive generation exactly as written.
+
 ## Releasing
 
 Releases are handled automatically via GitHub Actions:

--- a/.cursor/skills/tango-technical-writing/SKILL.md
+++ b/.cursor/skills/tango-technical-writing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tango-technical-writing
-description: Use this skill when writing or revising Tango documentation, package READMEs, or public-facing docstrings so the prose stays natural, pedagogical, audience-aware, and contract-accurate.
+description: Use this skill when writing or revising Tango documentation, changelogs, package READMEs, or public-facing docstrings so the prose stays natural, pedagogical, audience-aware, and contract-accurate.
 ---
 
 # Tango Technical Writing
@@ -10,6 +10,7 @@ description: Use this skill when writing or revising Tango documentation, packag
 Use this skill for:
 
 - `docs/**/*.md`
+- `CHANGELOG.md` and changelog-oriented release summaries
 - package `README.md`
 - public-facing JSDoc and docstrings
 
@@ -18,8 +19,11 @@ Do not use this skill for contributor-only code changes that do not touch techni
 ## Operating Rules
 
 1. State `Executing tango-technical-writing` before doing any other work.
-2. Treat `references/principles.md` and `references/anti-patterns.md` as the style and review source of truth when they are available.
-3. If those reference files are unavailable, continue using the embedded rules in this skill and note reduced certainty.
+2. Treat this skill’s companion reference docs as the style and review source of truth when they are available:
+   - `references/principles.md`
+   - `references/anti-patterns.md`
+   These paths are relative to the skill directory (they are not expected to live at the repository root).
+3. If those reference files cannot be located (for example, the skill was copied without its `references/` directory), continue using the embedded rules in this skill and note reduced certainty.
 4. Optimize first for reader clarity and contract accuracy, then for style polish.
 5. Verify behavior against current code or the current public contract before making claims about behavior, guarantees, names, or responsibilities.
 6. Perform every review pass against the current full draft text, not against memory or a summary of the draft.
@@ -108,6 +112,7 @@ Choose the primary document type:
 
 - end-user docs
 - contributor docs
+- changelog or release notes
 - package README
 - reference page
 - docstring
@@ -250,6 +255,91 @@ Optimize for:
 - release workflow
 - implementation constraints
 - repository details only when they reduce maintainer ambiguity
+
+#### Changelog and release notes
+
+Treat changelog writing as upgrade-oriented release communication.
+
+The target reader is:
+
+- a maintainer deciding whether to upgrade now
+- an application developer scanning for new capabilities, fixes, or contract changes
+- a contributor reconstructing the release arc after the fact
+
+Optimize for:
+
+- user-visible capability changes
+- observable behavior changes
+- public API and contract changes
+- upgrade-relevant release framing
+- scan speed
+
+Do not optimize for:
+
+- implementation archaeology
+- internal refactor narration
+- package-by-package bookkeeping presented as prose
+- marketing voice
+
+When writing an individual changelog note:
+
+- explain the change to a reader with zero context
+- lead with the new capability, behavior change, or fix
+- keep one note about one release-facing change
+- prefer outcome language over implementation language
+- use exact API names only when they help the reader recognize the feature
+- mention internal mechanics only when they explain observable behavior, compatibility, or upgrade risk
+
+When shaping a full release:
+
+- write a short release thesis when the release has a coherent feature arc
+- use the thesis to explain what ties the release together
+- keep the tone explanatory rather than promotional
+- order notes so they support the release thesis instead of reading like unrelated scraps
+
+Default release-thesis guidance:
+
+- patch releases usually do not need a thesis unless one clear upgrade concern dominates the release
+- minor releases should usually include a short 1 to 3 sentence thesis
+- larger feature releases may include a thesis plus grouped bullets by theme
+
+For Tango's current lockstep release model, omit package-by-package impact lists from changelog prose.
+
+If a future release workflow needs package-specific release notes:
+
+- keep package detail secondary to the release-facing explanation
+- do not let package metadata carry the meaning of the note
+
+Use illustrative fenced examples only when they materially improve changelog comprehension.
+
+Examples are appropriate when:
+
+- the release adds major functionality
+- the release changes a public API or contract in a way that is easiest to show in code
+- the upgrade benefit can be shown in a compact diff or side-by-side comparison
+
+Examples are usually not appropriate when:
+
+- the release is a patch with small bug fixes
+- the change is docs-only or internal-only
+- the benefit cannot be shown honestly in a short snippet
+
+When using illustrative examples:
+
+- treat them as evidence, not decoration
+- prefer one example per release, or one per major release theme
+- show the public API delta, not internal setup
+- keep the `Previously` and `Now` blocks on the same task or workflow so the contrast is immediate
+- keep snippets short enough to scan quickly
+- verify that every snippet is contract-accurate for the release being described
+- prefer `Previously` and `Now`, or `Without this release` and `With this release`, when a literal `Before` and `After` would misrepresent the older API
+- use short comments when they make the upgrade win legible at a glance
+- for transaction or consistency releases, place comments at the point where a thrown exception or eager side effect would leave the workflow partially applied
+- for typing releases, add comments that show the relevant inferred result shape or the property access that now succeeds or fails
+- do not add decorative comments that merely restate the code
+- if a `Previously` block does not make the missing capability, missing type information, or failure mode obvious, rewrite it until the contrast is explicit
+
+If changelog content is generated from terse source notes, keep individual source notes concise and place release storytelling, grouped framing, and fenced examples in a release-level summary surface rather than forcing them into raw bullet text.
 
 #### Package READMEs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,55 +4,197 @@ This file is generated from stable release changesets during Tango stable releas
 
 ## 1.5.0 - 2026-04-17
 
-- Add generated relation typing, deep relation hydration, and the supporting tooling and package contract updates. Affected packages: `@danceroutine/tango-core`, `@danceroutine/tango-schema`, `@danceroutine/tango-orm`, `@danceroutine/tango-resources`, `@danceroutine/tango-codegen`, `@danceroutine/tango-openapi`, `@danceroutine/tango-migrations`, `@danceroutine/tango-testing`, `@danceroutine/tango-adapters-express`.
+Tango's relation workflow now extends from first-hop hydration into deeper generated relation-aware contracts. Application code can traverse more of its related graph while keeping ORM results, generated surfaces, and runtime-facing contracts aligned.
+
+- Add generated relation typing and deep relation hydration for nested eager-loading paths.
+- Carry the new relation metadata through schema, codegen, OpenAPI, migrations, testing, and Express-facing integration so generated artifacts and runtime behavior agree on the same relation graph.
+
+Previously:
+
+```ts
+const recentPosts = await PostModel.objects
+    .query()
+    .filter({ published: true })
+    .selectRelated('author')
+    .fetch();
+
+const firstPost = recentPosts.results[0];
+
+firstPost.author?.email;
+// firstPost.author?.profile is not attached here.
+// firstPost.comments is not attached here.
+```
+
+Now:
+
+```ts
+const recentPosts = await PostModel.objects
+    .query()
+    .filter({ published: true })
+    .selectRelated('author__profile')
+    .prefetchRelated('comments__author')
+    .fetch();
+
+const firstPost = recentPosts.results[0];
+
+firstPost.author?.profile?.displayName;
+firstPost.comments[0]?.author?.email;
+// firstPost.author?.profile is attached and typed here.
+// firstPost.comments[0]?.author is attached and typed here.
+```
 
 ## 1.4.0 - 2026-04-09
 
-- Add a supported ORM transaction API centered on `transaction.atomic(async (tx) => ...)`, nested savepoints, and `tx.onCommit(...)`.
+Tango now provides a first-class ORM transaction boundary for multi-step write workflows. Transaction-aware hooks also receive a narrow post-commit contract so application code can schedule durable side effects without depending on ORM internals.
 
-Extend schema write-hook args with a narrow transaction callback contract so hooks can register post-commit work without depending on ORM internals.
+- Add `transaction.atomic(async (tx) => ...)`, nested savepoints, and `tx.onCommit(...)` for commit-aware application workflows.
+- Extend schema write-hook args with an optional transaction callback contract so hooks can register post-commit work without taking a broad ORM dependency.
+- Add the testing fixtures and client updates needed to exercise the runtime-backed transaction workflow end to end.
 
-Add testing fixtures and client contract updates needed to exercise the new runtime-backed transaction workflow. Affected packages: `@danceroutine/tango-schema`, `@danceroutine/tango-orm`, `@danceroutine/tango-testing`.
+Previously:
+
+```ts
+const user = await UserModel.objects.create({
+    email: 'author@example.com',
+});
+
+await ProfileModel.objects.create({
+    userId: user.id,
+});
+
+// If a later step throws here, both writes stay committed.
+sendWelcomeEmail(user.email);
+// This side effect also runs before the workflow is durably complete.
+```
+
+Now:
+
+```ts
+await transaction.atomic(async (tx) => {
+    const user = await UserModel.objects.create({
+        email: 'author@example.com',
+    });
+
+    await ProfileModel.objects.create({
+        userId: user.id,
+    });
+
+    // If a later step throws here, both writes roll back together.
+    tx.onCommit(() => {
+        sendWelcomeEmail(user.email);
+    });
+    // This side effect runs only after the outer commit succeeds.
+});
+```
 
 ## 1.3.0 - 2026-04-08
 
-- Add typed relation hydration for Tango querysets.
+Typed relation hydration is now available for Tango querysets. Query code can ask Tango to attach related records directly, while TypeScript keeps the hydrated result shape aligned with the relation metadata authored in the model layer.
 
-Querysets can now hydrate direct single-valued relations with `selectRelated(...)` and reverse collection relations with `prefetchRelated(...)`. Relation hydration is typed from field-authored relation metadata, with `t.modelRef<TModel>(...)` providing a typed string-reference path for projects that want runtime model-key decoupling without losing TypeScript result typing.
+- Add `selectRelated(...)` for single-valued relation traversal and `prefetchRelated(...)` for collection-rooted traversal.
+- Type relation hydration from model-authored relation metadata, including typed string references through `t.modelRef<TModel>(...)`.
+- Update relation-aware query planning and ORM result typing so selected model fields and hydrated relation properties compose correctly.
 
-This also moves relation-aware query planning through the SQL validation layer, adds compiler-owned prefetch SQL generation, and updates ORM result typing so selected model fields and hydrated relation properties compose correctly. Affected packages: `@danceroutine/tango-core`, `@danceroutine/tango-schema`, `@danceroutine/tango-orm`, `@danceroutine/tango-resources`, `@danceroutine/tango-codegen`, `@danceroutine/tango-migrations`, `@danceroutine/tango-testing`, `@danceroutine/tango-cli`.
+Previously:
+
+```ts
+const recentPosts = await PostModel.objects
+    .query()
+    .filter({ published: true })
+    .fetch();
+
+const firstPost = recentPosts.results[0];
+
+// firstPost.author is still the stored reference value here.
+// firstPost.author?.email is not available from the queryset result.
+```
+
+Now:
+
+```ts
+const recentPosts = await PostModel.objects
+    .query()
+    .filter({ published: true })
+    .selectRelated('author')
+    .fetch();
+
+const firstPost = recentPosts.results[0];
+
+// firstPost.author is now the hydrated user model or null.
+firstPost.author?.email;
+```
 
 ## 1.2.0 - 2026-04-08
 
-- Add decorator-owned relation resolution and field metadata APIs.
+The model metadata that relation-aware features build on is now stronger and more consistent. Schema, ORM, migrations, and code generation now share a clearer resolved relation graph and a more fluent scalar metadata authoring shape.
 
-Schema now supports object-form relation decorator configs, decorator-level relation naming, resolved relation graph finalization, and the fluent `t.field(...).build()` scalar metadata builder. ORM model metadata now consumes the resolved relation graph for relation metadata and aliases. Testing adds `withGlobalTestApi` for module-loading test helpers. Migrations now load model modules through a registry-aware loader, and codegen templates emit the new fluent scalar metadata form. Affected packages: `@danceroutine/tango-schema`, `@danceroutine/tango-orm`, `@danceroutine/tango-codegen`, `@danceroutine/tango-migrations`, `@danceroutine/tango-testing`.
+- Add object-form relation decorator configuration, decorator-level relation naming, and resolved relation graph finalization.
+- Add the fluent scalar metadata builder form `t.field(...).build()`.
+- Update ORM metadata, migrations, testing helpers, and codegen templates to consume the resolved relation graph consistently.
 
 ## 1.1.3 - 2026-04-07
 
-- Fixed type narrowing on select() to align with database projection Affected packages: `@danceroutine/tango-orm`, `@danceroutine/tango-testing`.
+- Fix `select()` result typing so projected fields narrow to the database projection rather than the full model shape.
+
+Previously:
+
+```ts
+const postCards = await PostModel.objects
+    .query()
+    .select(['id', 'title'] as const)
+    .fetch();
+
+const firstPost = postCards.results[0];
+
+firstPost.id;
+firstPost.title;
+// firstPost could still be treated like the full model shape here.
+// firstPost.slug;
+```
+
+Now:
+
+```ts
+const postCards = await PostModel.objects
+    .query()
+    .select(['id', 'title'] as const)
+    .fetch();
+
+const firstPost = postCards.results[0];
+
+firstPost.id;
+firstPost.title;
+// firstPost is narrowed to the selected projection here.
+// firstPost.slug; // type error
+```
 
 ## 1.1.2 - 2026-04-04
 
-- Update package documentation to reflect docsite url changes Affected packages: `@danceroutine/tango-schema`, `@danceroutine/tango-orm`, `@danceroutine/tango-resources`, `@danceroutine/tango-openapi`, `@danceroutine/tango-migrations`, `@danceroutine/tango-adapters-next`, `@danceroutine/tango-adapters-nuxt`, `@danceroutine/tango-adapters-express`.
+- Update package documentation to match the new documentation site URLs.
 
 ## 1.1.1 - 2026-04-02
 
-- Updated package readmes to point to the new contributor documentation Affected packages: `@danceroutine/tango-core`, `@danceroutine/tango-schema`, `@danceroutine/tango-config`, `@danceroutine/tango-openapi`, `@danceroutine/tango-migrations`, `@danceroutine/tango-testing`, `@danceroutine/tango-adapters-core`, `@danceroutine/tango-adapters-next`, `@danceroutine/tango-adapters-express`.
+- Update package READMEs to point maintainers to the new contributor documentation.
 
 ## 1.1.0 - 2026-04-01
 
-- Add first-class Nuxt support with a dedicated adapter package, Nuxt project scaffolding, an official Nuxt blog example, and Nuxt docs coverage. Affected packages: `@danceroutine/tango-core`, `@danceroutine/tango-codegen`, `@danceroutine/tango-cli`, `@danceroutine/tango-adapters-nuxt`.
+First-class Nuxt support is now available. Tango can live inside Nitro event handlers with an official adapter, generated project scaffolding, and a supported tutorial path that shows how the Tango layers fit into a Nuxt application.
+
+- Add the dedicated `@danceroutine/tango-adapters-nuxt` package.
+- Add Nuxt project scaffolding and an official Nuxt blog example.
+- Add Nuxt documentation coverage so the adapter, tutorial, and generated project shape describe the same integration model.
 
 ## 1.0.2 - 2026-03-31
 
-- Infer typed filter coercion from Tango model metadata so resource query params can be parsed into boolean, numeric, and timestamp values centrally. Affected packages: `@danceroutine/tango-resources`.
-- Derive resource OpenAPI lookup fields from Tango model metadata instead of manager internals during schema description. Affected packages: `@danceroutine/tango-resources`.
+- Infer typed filter coercion from model metadata so resource query params parse booleans, numbers, and timestamps centrally.
+- Derive resource OpenAPI lookup fields from model metadata during schema description.
 
 ## 1.0.1 - 2026-03-31
 
-- Hoist shared HTTP method and action scope value types into adapters core so framework adapters stop re-declaring them. Affected packages: `@danceroutine/tango-adapters-core`, `@danceroutine/tango-adapters-next`.
+- Hoist shared HTTP method and action-scope value types into adapters core so framework adapters stop re-declaring the same contract.
 
 ## 1.0.0 - 2026-03-30
 
-- Promote Tango's public packages to their first stable 1.0.0 release. Affected packages: `@danceroutine/tango-core`, `@danceroutine/tango-schema`, `@danceroutine/tango-config`, `@danceroutine/tango-orm`, `@danceroutine/tango-resources`, `@danceroutine/tango-codegen`, `@danceroutine/tango-openapi`, `@danceroutine/tango-migrations`, `@danceroutine/tango-testing`, `@danceroutine/tango-cli`, `@danceroutine/tango-adapters-core`, `@danceroutine/tango-adapters-next`, `@danceroutine/tango-adapters-express`.
+Tango's public packages now reach their first stable `1.0.0` release. This establishes the initial stable contract across the model, ORM, resource, tooling, migration, testing, and adapter layers that now make up the framework's supported package surface.
+
+- Publish Tango's first stable package line across the core framework, tooling, adapters, and supporting packages.

--- a/docs/contributors/releasing.md
+++ b/docs/contributors/releasing.md
@@ -67,6 +67,8 @@ The workflow performs these steps:
 
 The stable versioning command is `pnpm changeset:version`, which runs `scripts/release/version-with-root-changelog.ts`. That script executes `changeset version`, refreshes the lockfile, and prepends the new entry to the root `CHANGELOG.md`.
 
+Each pending changeset summary is copied into the new release entry as authored Markdown rather than being rewritten into a synthetic bullet format. That means maintainers should write the changeset summary in the changelog shape they want to preserve, whether that is a concise paragraph, a short bullet list, or a compact illustrative code block for a major feature.
+
 The release job pins Node 24 so trusted publishing can use the bundled npm 11 toolchain without a custom bootstrap layer in the workflow.
 
 If `pnpm changeset:version` produces no diff, the stable workflow becomes a no-op for publishing. That usually means there were no pending releasable changesets on `main`.

--- a/scripts/release/version-with-root-changelog.ts
+++ b/scripts/release/version-with-root-changelog.ts
@@ -147,9 +147,9 @@ export async function readReleaseVersion(rootDir: string, packageNames: string[]
 export function prependReleaseEntry(
     existingContent: string,
     releaseEntry: ReleaseEntry,
-    packageOrder: string[]
+    _packageOrder: string[]
 ): string {
-    const formattedEntry = formatReleaseEntry(releaseEntry, packageOrder);
+    const formattedEntry = formatReleaseEntry(releaseEntry);
     const normalizedExistingContent = normalizeLineEndings(existingContent).trim();
 
     if (
@@ -256,34 +256,18 @@ async function findPackageJsonPaths(directory: string): Promise<string[]> {
     return packageJsonPaths.sort();
 }
 
-function formatReleaseEntry(releaseEntry: ReleaseEntry, packageOrder: string[]): string {
+function formatReleaseEntry(releaseEntry: ReleaseEntry): string {
     const lines = [`## ${releaseEntry.version} - ${releaseEntry.date}`, ''];
 
-    for (const note of releaseEntry.notes) {
-        lines.push(`- ${formatBulletLine(note, packageOrder)}`);
-    }
+    releaseEntry.notes.forEach((note, index) => {
+        lines.push(note.summary.trim());
+
+        if (index < releaseEntry.notes.length - 1) {
+            lines.push('');
+        }
+    });
 
     return lines.join('\n');
-}
-
-function formatBulletLine(note: ChangesetReleaseNote, packageOrder: string[]): string {
-    const orderedPackages = orderPackages(note.packages, packageOrder);
-    return `${note.summary} Affected packages: ${orderedPackages.map((packageName) => `\`${packageName}\``).join(', ')}.`;
-}
-
-function orderPackages(packageNames: string[], packageOrder: string[]): string[] {
-    const packageIndex = new Map(packageOrder.map((packageName, index) => [packageName, index]));
-
-    return [...packageNames].sort((left, right) => {
-        const leftIndex = packageIndex.get(left) ?? Number.MAX_SAFE_INTEGER;
-        const rightIndex = packageIndex.get(right) ?? Number.MAX_SAFE_INTEGER;
-
-        if (leftIndex !== rightIndex) {
-            return leftIndex - rightIndex;
-        }
-
-        return left.localeCompare(right);
-    });
 }
 
 function normalizeLineEndings(value: string): string {

--- a/tests/release/version-with-root-changelog.test.ts
+++ b/tests/release/version-with-root-changelog.test.ts
@@ -131,7 +131,7 @@ No stable releases have been published yet.
         );
 
         expect(content).toContain('## 0.1.0 - 2026-03-14');
-        expect(content).toContain('Ship the first core primitive. Affected packages: `@danceroutine/tango-core`.');
+        expect(content).toContain('Ship the first core primitive.');
         expect(content).not.toContain('No stable releases have been published yet.');
     });
 
@@ -143,7 +143,7 @@ This file is generated from stable release changesets during Tango stable releas
 
 ## 0.1.0 - 2026-01-01
 
-- First stable release. Affected packages: \`@danceroutine/tango-core\`.
+First stable release.
 `,
             {
                 version: '0.2.0',
@@ -164,6 +164,44 @@ This file is generated from stable release changesets during Tango stable releas
         );
 
         expect(content.indexOf('## 0.2.0 - 2026-03-14')).toBeLessThan(content.indexOf('## 0.1.0 - 2026-01-01'));
+    });
+
+    it('preserves authored markdown summaries verbatim', () => {
+        const content = prependReleaseEntry(
+            `# Changelog
+
+This file is generated from stable release changesets during Tango stable releases. Do not edit manually.
+
+No stable releases have been published yet.
+`,
+            {
+                version: '0.2.0',
+                date: '2026-03-14',
+                notes: [
+                    {
+                        filename: 'gamma.md',
+                        packages: ['@danceroutine/tango-core'],
+                        summary: `Core querying now supports richer relation hydration.
+
+- Add nested eager-loading support.
+
+Previously:
+
+\`\`\`ts
+const posts = await PostModel.objects.query().fetch();
+\`\`\`
+`,
+                        bumpTypes: { '@danceroutine/tango-core': 'minor' },
+                    },
+                ],
+            },
+            ['@danceroutine/tango-core']
+        );
+
+        expect(content).toContain('Core querying now supports richer relation hydration.');
+        expect(content).toContain('- Add nested eager-loading support.');
+        expect(content).toContain('```ts');
+        expect(content).not.toContain('Affected packages:');
     });
 });
 
@@ -211,9 +249,8 @@ describe(runReleaseVersioning, () => {
         expect(schemaPackage.version).toBe('0.2.0');
         expect(lockfile).toContain('lockfileVersion: 9.0');
         expect(changelog).toContain('## 0.2.0 - 2026-03-14');
-        expect(changelog).toContain(
-            'Add first stable schema primitives. Affected packages: `@danceroutine/tango-core`, `@danceroutine/tango-schema`.'
-        );
+        expect(changelog).toContain('Add first stable schema primitives.');
+        expect(changelog).not.toContain('Affected packages:');
     });
 
     it('collects pending changesets from disk in filename order', async () => {


### PR DESCRIPTION
## Summary
- rewrite the changelog and technical-writing guidance around richer release storytelling and upgrade-focused examples
- update the root changelog generator to preserve authored changeset Markdown instead of synthesizing bullet lines and package lists
- refresh the release docs and release-script tests to match the new changelog contract

## Validation
- pnpm exec vitest run tests/release/version-with-root-changelog.test.ts
- pnpm exec tsc --noEmit -p tsconfig.scripts.json