### PR TITLE
fix(ci): deploy docs from versioned release ref

### DIFF
--- a/.github/workflows/docs-pages.reusable.yml
+++ b/.github/workflows/docs-pages.reusable.yml
@@ -2,6 +2,12 @@ name: Docs Pages (reusable)
 
 on:
     workflow_call:
+        inputs:
+            checkout_ref:
+                description: Git ref to build the docs site from.
+                required: false
+                type: string
+                default: ''
 
 jobs:
     build:
@@ -10,6 +16,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+              with:
+                  ref: ${{ inputs.checkout_ref || github.sha }}
 
             - name: Setup Node.js
               uses: actions/setup-node@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,7 @@ jobs:
         outputs:
             stable_release_mode: ${{ steps.stable-release.outputs.mode }}
             publish_state_mode: ${{ steps.publish-state.outputs.mode }}
+            docs_checkout_ref: ${{ steps.docs-checkout-ref.outputs.ref }}
         services:
             postgres:
                 image: postgres:16
@@ -174,6 +175,11 @@ jobs:
               env:
                   NPM_CONFIG_PROVENANCE: true
 
+            - name: Capture docs checkout ref
+              if: (((github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable')) && steps.stable-release.outputs.mode == 'release') || (github.event_name == 'workflow_dispatch' && inputs.release_type == 'stable-recovery')) && steps.publish-state.outputs.mode == 'publish'
+              id: docs-checkout-ref
+              run: echo "ref=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
             - name: Get short SHA
               if: github.event_name == 'workflow_dispatch' && inputs.release_type == 'alpha'
               id: sha
@@ -208,3 +214,5 @@ jobs:
               && needs.release.outputs.publish_state_mode == 'publish'
             )
         uses: danceroutine/tango/.github/workflows/docs-pages.reusable.yml@main
+        with:
+            checkout_ref: ${{ needs.release.outputs.docs_checkout_ref }}


### PR DESCRIPTION
## Summary

- pass an explicit checkout ref into the reusable docs workflow
- capture the post-version release `HEAD` in the stable release workflow
- build docs from that exact ref so the deployed site reads the versioned package manifests instead of the triggering commit

## Why

The stable release workflow versions packages and pushes a new commit to `main` before deploying docs, but the reusable docs workflow was still checking out the original event SHA. Since VitePress reads the docs nav version from `packages/core/package.json`, the deployed site lagged one release behind npm.

## Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml'); YAML.load_file('.github/workflows/docs-pages.reusable.yml'); puts 'yaml-ok'"`
- `git diff --check`
- `pnpm exec prettier --check .github/workflows/release.yml .github/workflows/docs-pages.reusable.yml`