### PR TITLE
docs: render generated changelog in docs site

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -67,7 +67,7 @@ export default defineConfig({
             { text: 'Contributors', link: '/contributors/' },
             {
                 text: `v${publicVersion}`,
-                items: [{ text: 'Changelog', link: 'https://github.com/danceroutine/tango/blob/master/CHANGELOG.md' }],
+                items: [{ text: 'Changelog', link: '/changelog' }],
             },
         ],
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,8 @@
-# Changelog
+---
+maintainerNote: This page is generated from stable release changesets during Tango stable releases. Do not edit manually.
+---
 
-This file is generated from stable release changesets during Tango stable releases. Do not edit manually.
+# Changelog
 
 ## 1.7.0 - 2026-04-20
 

--- a/docs/contributors/releasing.md
+++ b/docs/contributors/releasing.md
@@ -8,9 +8,9 @@ Complete the [Contributor setup](/contributors/setup) before you begin. Maintain
 
 Tango ships through two release channels.
 
-Stable releases publish the normal package versions that advance the fixed Tango release train. They are driven by changesets, update the root changelog, and must publish from `main`.
+Stable releases publish the normal package versions that advance the fixed Tango release train. They are driven by changesets, update the docs changelog page, and must publish from `main`.
 
-Alpha releases publish snapshot builds under the `alpha` dist-tag. They support testing and early feedback, and they leave the root changelog unchanged.
+Alpha releases publish snapshot builds under the `alpha` dist-tag. They support testing and early feedback, and they leave the docs changelog page unchanged.
 
 ## Release invariant
 
@@ -65,7 +65,7 @@ The workflow performs these steps:
 9. commits generated version changes to `main` with a bot-authored `[skip ci]` commit when a release is pending
 10. publishes the packages that are still missing from npm
 
-The stable versioning command is `pnpm changeset:version`, which runs `scripts/release/version-with-root-changelog.ts`. That script executes `changeset version`, refreshes the lockfile, and prepends the new entry to the root `CHANGELOG.md`.
+The stable versioning command is `pnpm changeset:version`, which runs `scripts/release/version-docs-changelog.ts`. That script executes `changeset version`, refreshes the lockfile, and prepends the new entry to `docs/changelog.md`.
 
 Each pending changeset summary is copied into the new release entry as authored Markdown rather than being rewritten into a synthetic bullet format. That means maintainers should write the changeset summary in the changelog shape they want to preserve, whether that is a concise paragraph, a short bullet list, or a compact illustrative code block for a major feature.
 
@@ -150,7 +150,7 @@ The alpha path performs these steps:
 5. builds the packages
 6. publishes them with the `alpha` dist-tag
 
-Alpha releases preserve the existing root changelog. The workflow publishes the snapshot build directly from the selected branch, and `main` remains unchanged.
+Alpha releases preserve the existing docs changelog page. The workflow publishes the snapshot build directly from the selected branch, and `main` remains unchanged.
 
 ## Verify the published result
 
@@ -180,7 +180,7 @@ When the release system changes, update these files and settings in the same pul
 - `.github/workflows/release.yml`
 - `.changeset/config.json`
 - `scripts/release/resolve-publish-state.ts`
-- `scripts/release/version-with-root-changelog.ts`
+- `scripts/release/version-docs-changelog.ts`
 - root `package.json` scripts for `changeset:version` and `changeset:publish`
 - repository Actions configuration for `RELEASE_APP_ID` and `RELEASE_APP_PRIVATE_KEY`
 - this page

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "docs:build": "pnpm --filter @danceroutine/tango-docs build",
         "docs:preview": "pnpm --filter @danceroutine/tango-docs preview",
         "changeset": "changeset",
-        "changeset:version": "pnpm exec tsx scripts/release/version-with-root-changelog.ts",
+        "changeset:version": "pnpm exec tsx scripts/release/version-docs-changelog.ts",
         "changeset:publish": "pnpm build && changeset publish",
         "typecheck:prod": "tsc --noEmit -p tsconfig.scripts.json && pnpm -r --filter '!./.temp/**' --if-present run typecheck:prod",
         "typecheck:tests": "pnpm -r --filter '!./.temp/**' --if-present run typecheck:test",

--- a/scripts/release/version-docs-changelog.ts
+++ b/scripts/release/version-docs-changelog.ts
@@ -1,6 +1,6 @@
 import { spawnSync } from 'node:child_process';
-import { readdir, readFile, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { mkdir, readdir, readFile, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
 
 type BumpType = 'major' | 'minor' | 'patch';
 
@@ -23,13 +23,15 @@ interface RunCommandOptions {
 
 type RunCommand = (command: string, args: string[], options: RunCommandOptions) => void | Promise<void>;
 
-const CHANGELOG_INTRO = `# Changelog
+const CHANGELOG_INTRO = `---
+maintainerNote: This page is generated from stable release changesets during Tango stable releases. Do not edit manually.
+---
 
-This file is generated from stable release changesets during Tango stable releases. Do not edit manually.`;
+# Changelog`;
 const NO_RELEASES_MESSAGE = 'No stable releases have been published yet.';
 const CHANGESET_DIRECTORY = '.changeset';
 const CHANGESET_CONFIG_PATH = join(CHANGESET_DIRECTORY, 'config.json');
-const CHANGELOG_PATH = 'CHANGELOG.md';
+const CHANGELOG_PATH = join('docs', 'changelog.md');
 const CHANGESET_README = 'README.md';
 
 export async function collectPendingChangesets(rootDir: string): Promise<ChangesetReleaseNote[]> {
@@ -211,6 +213,7 @@ export async function runReleaseVersioning(
         packageOrder
     );
 
+    await mkdir(dirname(changelogPath), { recursive: true });
     await writeFile(changelogPath, nextChangelog);
 }
 

--- a/tests/release/version-docs-changelog.test.ts
+++ b/tests/release/version-docs-changelog.test.ts
@@ -7,12 +7,13 @@ import {
     parseChangesetContent,
     prependReleaseEntry,
     runReleaseVersioning,
-} from '../../scripts/release/version-with-root-changelog';
+} from '../../scripts/release/version-docs-changelog';
 
 async function createFixtureRepository(): Promise<string> {
     const rootDir = await mkdtemp(join(tmpdir(), 'tango-release-'));
 
     await mkdir(join(rootDir, '.changeset'), { recursive: true });
+    await mkdir(join(rootDir, 'docs'), { recursive: true });
     await mkdir(join(rootDir, 'packages/core'), { recursive: true });
     await mkdir(join(rootDir, 'packages/schema'), { recursive: true });
     await writeFile(
@@ -42,10 +43,12 @@ These instructions explain how to write changesets for Tango packages.
 `
     );
     await writeFile(
-        join(rootDir, 'CHANGELOG.md'),
-        `# Changelog
+        join(rootDir, 'docs/changelog.md'),
+        `---
+maintainerNote: This page is generated from stable release changesets during Tango stable releases. Do not edit manually.
+---
 
-This file is generated from stable release changesets during Tango stable releases. Do not edit manually.
+# Changelog
 
 No stable releases have been published yet.
 `
@@ -109,9 +112,11 @@ Improve shared request normalization.`,
 describe(prependReleaseEntry, () => {
     it('replaces the bootstrap no-release state', () => {
         const content = prependReleaseEntry(
-            `# Changelog
+            `---
+maintainerNote: This page is generated from stable release changesets during Tango stable releases. Do not edit manually.
+---
 
-This file is generated from stable release changesets during Tango stable releases. Do not edit manually.
+# Changelog
 
 No stable releases have been published yet.
 `,
@@ -137,9 +142,11 @@ No stable releases have been published yet.
 
     it('prepends a new entry ahead of existing release entries', () => {
         const content = prependReleaseEntry(
-            `# Changelog
+            `---
+maintainerNote: This page is generated from stable release changesets during Tango stable releases. Do not edit manually.
+---
 
-This file is generated from stable release changesets during Tango stable releases. Do not edit manually.
+# Changelog
 
 ## 0.1.0 - 2026-01-01
 
@@ -168,9 +175,11 @@ First stable release.
 
     it('preserves authored markdown summaries verbatim', () => {
         const content = prependReleaseEntry(
-            `# Changelog
+            `---
+maintainerNote: This page is generated from stable release changesets during Tango stable releases. Do not edit manually.
+---
 
-This file is generated from stable release changesets during Tango stable releases. Do not edit manually.
+# Changelog
 
 No stable releases have been published yet.
 `,
@@ -213,7 +222,7 @@ describe(runReleaseVersioning, () => {
         temporaryDirectories.length = 0;
     });
 
-    it('updates versions, lockfile, and the root changelog in one pass', async () => {
+    it('updates versions, lockfile, and the docs changelog in one pass', async () => {
         const rootDir = await createFixtureRepository();
         temporaryDirectories.push(rootDir);
 
@@ -236,7 +245,7 @@ describe(runReleaseVersioning, () => {
             },
         });
 
-        const changelog = await readFile(join(rootDir, 'CHANGELOG.md'), 'utf8');
+        const changelog = await readFile(join(rootDir, 'docs/changelog.md'), 'utf8');
         const corePackage = JSON.parse(await readFile(join(rootDir, 'packages/core/package.json'), 'utf8')) as {
             version: string;
         };


### PR DESCRIPTION
## Summary
- move the generated stable changelog into `docs/changelog.md` so the site renders it directly
- point the release versioning script and test coverage at the docs changelog path
- update the docs nav and contributor release docs to match the new changelog location

## Validation
- `pnpm exec vitest run tests/release/version-docs-changelog.test.ts`
- `pnpm docs:build`