### PR TITLE
[codex] refine technical writing skill guidance

### DIFF
--- a/.cursor/skills/tango-technical-writing/SKILL.md
+++ b/.cursor/skills/tango-technical-writing/SKILL.md
@@ -393,7 +393,7 @@ If any major section violates the roadmap or answers a different question too ea
 
 ### Pass 2: Anti-Pattern Review
 
-Use the anti-pattern section headings from `references/anti-patterns.md` when available.
+Use the anti-pattern section headings from `./references/anti-patterns.md` (relative to this SKILL file) when available.
 
 During anti-pattern review, announce each pass in chat with this exact template before checking:
 


### PR DESCRIPTION
## What changed
Refines the Tango technical writing skill guidance so documentation and public-facing prose expectations are clearer and more consistent.

## Why
This isolates the skill update from the implicit many-to-many feature work so the writing guidance can be reviewed independently.

## Impact
This changes only the maintainer skill guidance in `.cursor/skills/tango-technical-writing/SKILL.md`.

## Validation
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
