### PR TITLE
fix(scaffold): include generated relation typings

### DIFF
--- a/.changeset/fair-donuts-sing.md
+++ b/.changeset/fair-donuts-sing.md
@@ -1,0 +1,6 @@
+---
+'@danceroutine/tango-cli': patch
+'@danceroutine/tango-codegen': patch
+---
+
+Fix scaffolded apps so generated relation registry declarations participate in TypeScript relation-aware query typing by default.

--- a/packages/codegen/src/frameworks/scaffold/tests/scaffoldProject.test.ts
+++ b/packages/codegen/src/frameworks/scaffold/tests/scaffoldProject.test.ts
@@ -74,6 +74,7 @@ describe(scaffoldProject, () => {
             expect(serializerSource).toContain('TodoSerializer');
             expect(layoutSource).toContain('RootLayout');
             expect(tsconfig).toContain('"migrations/**/*.ts"');
+            expect(tsconfig).toContain('".tango/**/*.d.ts"');
         } finally {
             await rm(dir, { recursive: true, force: true });
         }
@@ -113,6 +114,7 @@ describe(scaffoldProject, () => {
             expect(appShell).toContain('<NuxtPage />');
             expect(pageSource).toContain('<script setup lang="ts">');
             expect(tsconfig).toContain('"migrations/**/*.ts"');
+            expect(tsconfig).toContain('".tango/**/*.d.ts"');
         } finally {
             await rm(dir, { recursive: true, force: true });
         }

--- a/packages/codegen/src/frameworks/strategies/express/templates/tsconfig.ts
+++ b/packages/codegen/src/frameworks/strategies/express/templates/tsconfig.ts
@@ -21,7 +21,7 @@ export class TsConfigTemplateBuilder extends TemplateBuilder {
                     resolveJsonModule: true,
                     types: ['node'],
                 },
-                include: ['src', 'migrations/**/*.ts', 'tango.config.ts'],
+                include: ['src', 'migrations/**/*.ts', 'tango.config.ts', '.tango/**/*.d.ts'],
                 exclude: ['node_modules', 'dist'],
             },
             null,

--- a/packages/codegen/src/frameworks/strategies/express/tests/ExpressScaffoldStrategy.test.ts
+++ b/packages/codegen/src/frameworks/strategies/express/tests/ExpressScaffoldStrategy.test.ts
@@ -48,6 +48,7 @@ describe(ExpressScaffoldStrategy, () => {
             expect(config).toContain("adapter: 'sqlite'");
             expect(config).toContain('./.data/express-sqlite.sqlite');
             expect((JSON.parse(tsconfig) as { include: string[] }).include).toContain('migrations/**/*.ts');
+            expect((JSON.parse(tsconfig) as { include: string[] }).include).toContain('.tango/**/*.d.ts');
             expect(indexSource).toContain("from './tango.js'");
             expect(openapiSource).toContain('describeViewSet');
             expect(openapiSource).toContain(

--- a/packages/codegen/src/frameworks/strategies/next/templates/tsconfig.ts
+++ b/packages/codegen/src/frameworks/strategies/next/templates/tsconfig.ts
@@ -25,7 +25,7 @@ export class TsConfigTemplateBuilder extends TemplateBuilder {
                         '@/*': ['src/*'],
                     },
                 },
-                include: ['next-env.d.ts', '**/*.ts', '**/*.tsx', 'migrations/**/*.ts'],
+                include: ['next-env.d.ts', '**/*.ts', '**/*.tsx', 'migrations/**/*.ts', '.tango/**/*.d.ts'],
                 exclude: ['node_modules'],
             },
             null,

--- a/packages/codegen/src/frameworks/strategies/next/tests/NextScaffoldStrategy.test.ts
+++ b/packages/codegen/src/frameworks/strategies/next/tests/NextScaffoldStrategy.test.ts
@@ -53,6 +53,7 @@ describe(NextScaffoldStrategy, () => {
 
             expect(packageJson).toContain('"codegen:relations"');
             expect(tsconfig).toContain('"migrations/**/*.ts"');
+            expect(tsconfig).toContain('".tango/**/*.d.ts"');
             expect(layout).toContain('RootLayout');
             expect(route).toContain('Response.json');
             expect(openapiRoute).toContain("from '@/lib/openapi'");

--- a/packages/codegen/src/frameworks/strategies/nuxt/templates/tsconfig.ts
+++ b/packages/codegen/src/frameworks/strategies/nuxt/templates/tsconfig.ts
@@ -13,7 +13,7 @@ export class TsConfigTemplateBuilder extends TemplateBuilder {
                 compilerOptions: {
                     strict: true,
                 },
-                include: ['.nuxt/**/*.d.ts', '**/*.ts', '**/*.vue', 'migrations/**/*.ts'],
+                include: ['.nuxt/**/*.d.ts', '**/*.ts', '**/*.vue', 'migrations/**/*.ts', '.tango/**/*.d.ts'],
             },
             null,
             4

--- a/packages/codegen/src/frameworks/strategies/nuxt/tests/NuxtScaffoldStrategy.test.ts
+++ b/packages/codegen/src/frameworks/strategies/nuxt/tests/NuxtScaffoldStrategy.test.ts
@@ -43,6 +43,7 @@ describe(NuxtScaffoldStrategy, () => {
             const templates = strategy.getTemplates();
             const packageJson = renderTemplate(templates, 'package.json', context);
             const nuxtConfig = renderTemplate(templates, 'nuxt.config.ts', context);
+            const tsconfig = renderTemplate(templates, 'tsconfig.json', context);
             const page = renderTemplate(templates, 'app/pages/index.server.vue', context);
             const route = renderTemplate(templates, 'server/tango/health.ts', context);
             const openapiRoute = renderTemplate(templates, 'server/tango/openapi.ts', context);
@@ -56,6 +57,7 @@ describe(NuxtScaffoldStrategy, () => {
             expect(packageJson).toContain('"codegen:relations"');
             expect(packageJson).toContain('"start": "NUXT_TELEMETRY_DISABLED=1 nuxt preview"');
             expect(nuxtConfig).toContain("route: '/api/todos/**:tango'");
+            expect(tsconfig).toContain('".tango/**/*.d.ts"');
             expect(page).toContain('<script setup lang="ts">');
             expect(route).toContain('defineEventHandler');
             expect(openapiRoute).toContain("from '~~/lib/openapi'");

--- a/packages/openapi/src/domain/describeResources.ts
+++ b/packages/openapi/src/domain/describeResources.ts
@@ -2,14 +2,7 @@ import type { APIViewMethod, AnyModelSerializer, AnyModelSerializerClass } from 
 import type { OpenAPIViewSetDescriptor, OpenAPIGenericAPIViewDescriptor, OpenAPIAPIViewDescriptor } from './types';
 
 export function describeViewSet(
-    descriptor: Omit<
-        OpenAPIViewSetDescriptor<
-            Record<string, unknown>,
-            // oxlint-disable-next-line typescript/no-explicit-any
-            AnyModelSerializerClass
-        >,
-        'kind'
-    >
+    descriptor: Omit<OpenAPIViewSetDescriptor<Record<string, unknown>, AnyModelSerializerClass>, 'kind'>
 ): OpenAPIViewSetDescriptor;
 export function describeViewSet<
     TModel extends Record<string, unknown>,
@@ -25,14 +18,7 @@ export function describeViewSet(descriptor: Omit<OpenAPIViewSetDescriptor, 'kind
 }
 
 export function describeGenericAPIView(
-    descriptor: Omit<
-        OpenAPIGenericAPIViewDescriptor<
-            Record<string, unknown>,
-            // oxlint-disable-next-line typescript/no-explicit-any
-            AnyModelSerializerClass
-        >,
-        'kind'
-    >
+    descriptor: Omit<OpenAPIGenericAPIViewDescriptor<Record<string, unknown>, AnyModelSerializerClass>, 'kind'>
 ): OpenAPIGenericAPIViewDescriptor;
 export function describeGenericAPIView<
     TModel extends Record<string, unknown>,


### PR DESCRIPTION
## Summary

Fresh scaffolded apps were not including `.tango/**/*.d.ts` in their TypeScript include surface, so generated relation registry declarations never participated in typechecking by default. That made relation-aware query methods such as `selectRelated('author')` and `prefetchRelated('tags')` collapse to `never` in scaffolded apps even though the generated registry was correct.

This change adds the generated relation declaration include to the Express, Next, and Nuxt scaffold templates and locks it in with scaffold regression tests. It also folds in a small `describeResources(...)` lint cleanup that was already in local scope.

Closes #55.
Related to #35.

## Validation

- `pnpm exec oxlint packages/codegen/src/frameworks/scaffold/tests/scaffoldProject.test.ts packages/codegen/src/frameworks/strategies/express/templates/tsconfig.ts packages/codegen/src/frameworks/strategies/express/tests/ExpressScaffoldStrategy.test.ts packages/codegen/src/frameworks/strategies/next/templates/tsconfig.ts packages/codegen/src/frameworks/strategies/next/tests/NextScaffoldStrategy.test.ts packages/codegen/src/frameworks/strategies/nuxt/templates/tsconfig.ts packages/codegen/src/frameworks/strategies/nuxt/tests/NuxtScaffoldStrategy.test.ts packages/openapi/src/domain/describeResources.ts`
- `pnpm exec eslint packages/codegen/src/frameworks/scaffold/tests/scaffoldProject.test.ts packages/codegen/src/frameworks/strategies/express/templates/tsconfig.ts packages/codegen/src/frameworks/strategies/express/tests/ExpressScaffoldStrategy.test.ts packages/codegen/src/frameworks/strategies/next/templates/tsconfig.ts packages/codegen/src/frameworks/strategies/next/tests/NextScaffoldStrategy.test.ts packages/codegen/src/frameworks/strategies/nuxt/templates/tsconfig.ts packages/codegen/src/frameworks/strategies/nuxt/tests/NuxtScaffoldStrategy.test.ts packages/openapi/src/domain/describeResources.ts`
- `pnpm --filter @danceroutine/tango-codegen typecheck:prod && pnpm --filter @danceroutine/tango-openapi typecheck:prod`
- `pnpm --filter @danceroutine/tango-codegen exec vitest run src/frameworks/strategies/next/tests/NextScaffoldStrategy.test.ts src/frameworks/strategies/express/tests/ExpressScaffoldStrategy.test.ts src/frameworks/strategies/nuxt/tests/NuxtScaffoldStrategy.test.ts src/frameworks/scaffold/tests/scaffoldProject.test.ts`