### PR TITLE
feat(relations): add many-to-many set helper

### DIFF
--- a/.changeset/good-socks-yawn.md
+++ b/.changeset/good-socks-yawn.md
@@ -1,0 +1,6 @@
+---
+'@danceroutine/tango-orm': minor
+'@danceroutine/tango-resources': patch
+---
+
+Add `ManyToManyRelatedManager.set(...)` so Tango can replace many-to-many memberships in one Django-shaped relation-manager call.

--- a/docs/reference/orm-query-api.md
+++ b/docs/reference/orm-query-api.md
@@ -171,9 +171,10 @@ const post = await PostModel.objects.getOrThrow(postId);
 
 await post.tags.add(tag, featuredTag);
 await post.tags.remove(tag, featuredTag);
+await post.tags.set(featuredTag);
 ```
 
-`add(...targets)` and `remove(...targets)` accept target records, objects that carry the target primary key, or bare primary-key values. `add(...)` is idempotent for duplicate memberships, so repeated links do not raise a duplicate-row error. When one call touches several targets, Tango resolves the target primary keys once and runs the membership write inside one `transaction.atomic(...)` boundary.
+`add(...targets)`, `remove(...targets)`, and `set(...targets)` accept target records, objects that carry the target primary key, or bare primary-key values. `add(...)` is idempotent for duplicate memberships, so repeated links do not raise a duplicate-row error. `set(...)` replaces the current membership with exactly the supplied targets: omitted targets are removed, new targets are added, and duplicate inputs are ignored before Tango diffs the relation set. When one call touches several targets, Tango resolves the target primary keys once and runs the membership write inside one `transaction.atomic(...)` boundary.
 
 Use `post.tags.all()` when application code wants to read the linked targets. The returned queryset reads through the join table and follows the standard `QuerySet` contract, so it accepts `filter(...)`, `exclude(...)`, `orderBy(...)`, `select(...)`, `fetch(...)`, `fetchOne(...)`, `count()`, and `exists()`.
 
@@ -184,9 +185,9 @@ const featuredTags = await post.tags.all().filter({ featured: true }).fetch();
 
 `post.tags` remains a related manager even after eager loading. `prefetchRelated('tags')` warms that manager's cache; it does not replace the relation with a plain array on the model instance. This mirrors the Django-style contract that Tango follows for many-to-many accessors.
 
-When `prefetchRelated('tags')` ran in the same fetch, `post.tags.all()` returns the prefetched targets without issuing a follow-up query. The prefetch result is cached on the related manager and a successful `add(...)` or `remove(...)` invalidates that cache so the next read returns fresh data. If application code or a serializer needs an array-shaped value, materialize it explicitly from the manager with `await post.tags.all().fetch()`.
+When `prefetchRelated('tags')` ran in the same fetch, `post.tags.all()` returns the prefetched targets without issuing a follow-up query. The prefetch result is cached on the related manager and a successful `add(...)`, `remove(...)`, or `set(...)` invalidates that cache so the next read returns fresh data. If application code or a serializer needs an array-shaped value, materialize it explicitly from the manager with `await post.tags.all().fetch()`.
 
-Reverse many-to-many access, the bulk `set(...)` helper, the `clear()` helper, and `create(...)` on the related manager are tracked on the roadmap for a follow-up release.
+Reverse many-to-many access, the `clear()` helper, and `create(...)` on the related manager are tracked on the roadmap for a follow-up release.
 
 ## Transactions
 

--- a/docs/reference/schema-api.md
+++ b/docs/reference/schema-api.md
@@ -324,7 +324,7 @@ The config object supports `field`, `name`, `through`, `throughSourceFieldName`,
 
 The forward many-to-many edge stays `migratable: false` on the owner model because there is still no owner-row column for the collection; DDL for the join rows is owned by the synthesized or explicit through model that appears in migration metadata.
 
-Persisted records returned by the manager carry a related-manager accessor named after the published relation. For the example above, `post.tags.add(tag, featuredTag)`, `post.tags.remove(tag)`, and `post.tags.all()` insert, delete, and read membership rows through the resolved through model. `add(...)` and `remove(...)` accept one or more targets, and duplicate `add(...)` calls are ignored. The accessor stays a manager even after `prefetchRelated('tags')`; eager loading only warms its cache. The accessor is documented in the [ORM query API reference](/reference/orm-query-api).
+Persisted records returned by the manager carry a related-manager accessor named after the published relation. For the example above, `post.tags.add(tag, featuredTag)`, `post.tags.remove(tag)`, `post.tags.set(featuredTag)`, and `post.tags.all()` insert, delete, replace, and read membership rows through the resolved through model. `add(...)`, `remove(...)`, and `set(...)` accept one or more targets, and duplicate `add(...)` calls are ignored. The accessor stays a manager even after `prefetchRelated('tags')`; eager loading only warms its cache. The accessor is documented in the [ORM query API reference](/reference/orm-query-api).
 
 Reverse many-to-many naming, the bulk `set(...)` helper, the `clear()` helper, and `create(...)` on the related manager remain roadmap work.
 

--- a/docs/topics/orm-and-querysets.md
+++ b/docs/topics/orm-and-querysets.md
@@ -235,18 +235,19 @@ firstUser?.posts[0]?.comments[0]?.body;
 
 In that form, a user with no posts still receives `posts: []`, while a post with no comments receives `comments: []`.
 
-Persisted records returned by the manager carry a related-manager accessor for each many-to-many relation declared on the source model. The accessor is named after the published forward relation name, so a field such as `tagIds: t.manyToMany(..., { name: 'tags' })` exposes `post.tags.add(...)`, `post.tags.remove(...)`, and `post.tags.all()`. `add(...)` and `remove(...)` both accept one or more targets, and duplicate links are ignored so repeated `add(...)` calls stay idempotent. The accessor is attached non-enumerably so persistence-style helpers such as `JSON.stringify(post)` continue to focus on the persisted columns.
+Persisted records returned by the manager carry a related-manager accessor for each many-to-many relation declared on the source model. The accessor is named after the published forward relation name, so a field such as `tagIds: t.manyToMany(..., { name: 'tags' })` exposes `post.tags.add(...)`, `post.tags.remove(...)`, `post.tags.set(...)`, and `post.tags.all()`. `add(...)`, `remove(...)`, and `set(...)` all accept one or more targets, and duplicate links are ignored so repeated `add(...)` calls stay idempotent. `set(...)` replaces the membership with exactly the supplied targets. The accessor is attached non-enumerably so persistence-style helpers such as `JSON.stringify(post)` continue to focus on the persisted columns.
 
 ```ts
 const post = await PostModel.objects.getOrThrow(postId);
 
 await post.tags.add(tag, featuredTag);
+await post.tags.set(featuredTag);
 const linked = await post.tags.all().fetch();
 ```
 
 `post.tags` stays a related manager on the model instance. `prefetchRelated('tags')` only warms that manager's cache, so application code still reads through `post.tags.all()` rather than expecting `post.tags` itself to become an array.
 
-When `prefetchRelated('tags')` ran in the same fetch, `post.tags.all()` reads from the prefetched cache. A successful `add(...)` or `remove(...)` invalidates that cache so the next read returns fresh data. If an API response or page helper needs an array-shaped value, materialize it explicitly with `await post.tags.all().fetch()`.
+When `prefetchRelated('tags')` ran in the same fetch, `post.tags.all()` reads from the prefetched cache. A successful `add(...)`, `remove(...)`, or `set(...)` invalidates that cache so the next read returns fresh data. If an API response or page helper needs an array-shaped value, materialize it explicitly with `await post.tags.all().fetch()`.
 
 Forward many-to-many prefetch path typing comes from the generated relation registry. Without generated relation typing, the older explicit target-model generic still only describes reverse `hasMany` paths even though the runtime can execute the many-to-many prefetch.
 

--- a/packages/orm/src/manager/relations/ManyToManyRelatedManager.ts
+++ b/packages/orm/src/manager/relations/ManyToManyRelatedManager.ts
@@ -9,8 +9,9 @@ import { ManyToManyRelatedQuerySet } from './ManyToManyRelatedQuerySet';
 import { ThroughTableManager } from './internal/ThroughTableManager';
 
 /**
- * Accepted target reference shapes for {@link ManyToManyRelatedManager.add} and
- * {@link ManyToManyRelatedManager.remove}.
+ * Accepted target reference shapes for {@link ManyToManyRelatedManager.add},
+ * {@link ManyToManyRelatedManager.remove}, and
+ * {@link ManyToManyRelatedManager.set}.
  *
  * Application code may pass a target record, a primary-key carrier object, or
  * a bare primary-key value.
@@ -75,8 +76,12 @@ interface ManyToManyRelatedManagerInternalInputs<TTarget extends Record<string, 
  *
  * Prefetched memberships seed an internal cache that the queryset returned
  * from `all()` short-circuits to without re-querying. Mutations through
- * `add` and `remove` invalidate the cache so subsequent reads observe the
- * updated membership.
+ * `add`, `remove`, and `set` invalidate the cache so subsequent reads
+ * observe the updated membership. `set(...)` applies Django-shaped
+ * replacement semantics:
+ * it diffs the current relation membership against the supplied targets,
+ * removes any missing links, and inserts any new links inside one atomic
+ * write boundary.
  *
  * @template TTarget - The persisted target record shape returned by `all()`.
  */
@@ -151,15 +156,9 @@ export class ManyToManyRelatedManager<TTarget extends Record<string, unknown>> {
         }
 
         if (targetPrimaryKeys.length === 1) {
-            await this.inputs.throughTableManager.insertLink(this.inputs.ownerPrimaryKey, targetPrimaryKeys[0], {
-                onDuplicate: InternalDuplicateInsertPolicy.IGNORE,
-            });
+            await this.insertTargetPrimaryKeys(targetPrimaryKeys);
         } else {
-            await this.inputs.runAtomic(() =>
-                this.inputs.throughTableManager.insertLinks(this.inputs.ownerPrimaryKey, targetPrimaryKeys, {
-                    onDuplicate: InternalDuplicateInsertPolicy.IGNORE,
-                })
-            );
+            await this.inputs.runAtomic(() => this.insertTargetPrimaryKeys(targetPrimaryKeys));
         }
         this.invalidateCache();
     }
@@ -176,12 +175,48 @@ export class ManyToManyRelatedManager<TTarget extends Record<string, unknown>> {
         }
 
         if (targetPrimaryKeys.length === 1) {
-            await this.inputs.throughTableManager.deleteLink(this.inputs.ownerPrimaryKey, targetPrimaryKeys[0]);
+            await this.deleteTargetPrimaryKeys(targetPrimaryKeys);
         } else {
-            await this.inputs.runAtomic(() =>
-                this.inputs.throughTableManager.deleteLinks(this.inputs.ownerPrimaryKey, targetPrimaryKeys)
-            );
+            await this.inputs.runAtomic(() => this.deleteTargetPrimaryKeys(targetPrimaryKeys));
         }
+        this.invalidateCache();
+    }
+
+    /**
+     * Replace the current relation membership with exactly the supplied
+     * targets. Duplicate inputs are collapsed before diffing against the
+     * current through-table rows, so repeated values do not trigger extra
+     * writes. Calling `set()` with no targets clears the relation.
+     *
+     * When replacement requires writes, Tango performs the delete/insert
+     * sequence inside one `transaction.atomic(...)` boundary.
+     */
+    async set(...targets: ManyToManyTargetRef<TTarget>[]): Promise<void> {
+        const nextTargetPrimaryKeys = this.resolveTargetPrimaryKeys(targets);
+        const currentTargetPrimaryKeys = await this.inputs.throughTableManager.selectTargetIdsForOwner(
+            this.inputs.ownerPrimaryKey
+        );
+        const currentCanonical = new Set(
+            currentTargetPrimaryKeys.map((primaryKey) => this.canonicalizePrimaryKey(primaryKey))
+        );
+        const nextCanonical = new Set(
+            nextTargetPrimaryKeys.map((primaryKey) => this.canonicalizePrimaryKey(primaryKey))
+        );
+        const targetPrimaryKeysToRemove = currentTargetPrimaryKeys.filter(
+            (primaryKey) => !nextCanonical.has(this.canonicalizePrimaryKey(primaryKey))
+        );
+        const targetPrimaryKeysToAdd = nextTargetPrimaryKeys.filter(
+            (primaryKey) => !currentCanonical.has(this.canonicalizePrimaryKey(primaryKey))
+        );
+
+        if (targetPrimaryKeysToRemove.length === 0 && targetPrimaryKeysToAdd.length === 0) {
+            return;
+        }
+
+        await this.inputs.runAtomic(async () => {
+            await this.deleteTargetPrimaryKeys(targetPrimaryKeysToRemove);
+            await this.insertTargetPrimaryKeys(targetPrimaryKeysToAdd);
+        });
         this.invalidateCache();
     }
 
@@ -189,8 +224,8 @@ export class ManyToManyRelatedManager<TTarget extends Record<string, unknown>> {
      * Return a {@link QuerySet} for the related target rows of this many-to-many
      * relation. When the relation was already loaded by `prefetchRelated(...)`,
      * the first `fetch()` resolves with the cached materialization without
-     * re-querying. Mutating the membership through `add`/`remove` invalidates
-     * that cache.
+     * re-querying. Mutating the membership through `add`/`remove`/`set`
+     * invalidates that cache.
      */
     all(): QuerySet<TTarget> {
         const executor = this.inputs.targetExecutorProvider();
@@ -217,7 +252,7 @@ export class ManyToManyRelatedManager<TTarget extends Record<string, unknown>> {
 
     /**
      * Drop any cached prefetch results. Mutating helpers call this so reads
-     * after an `add`/`remove` go back to the database.
+     * after an `add`/`remove`/`set` go back to the database.
      */
     invalidateCache(): void {
         this.prefetchCache = null;
@@ -230,6 +265,32 @@ export class ManyToManyRelatedManager<TTarget extends Record<string, unknown>> {
      */
     snapshotCache(): readonly TTarget[] | null {
         return this.prefetchCache ? [...this.prefetchCache] : null;
+    }
+
+    private async insertTargetPrimaryKeys(targetPrimaryKeys: readonly unknown[]): Promise<void> {
+        if (targetPrimaryKeys.length === 0) {
+            return;
+        }
+        if (targetPrimaryKeys.length === 1) {
+            await this.inputs.throughTableManager.insertLink(this.inputs.ownerPrimaryKey, targetPrimaryKeys[0], {
+                onDuplicate: InternalDuplicateInsertPolicy.IGNORE,
+            });
+            return;
+        }
+        await this.inputs.throughTableManager.insertLinks(this.inputs.ownerPrimaryKey, targetPrimaryKeys, {
+            onDuplicate: InternalDuplicateInsertPolicy.IGNORE,
+        });
+    }
+
+    private async deleteTargetPrimaryKeys(targetPrimaryKeys: readonly unknown[]): Promise<void> {
+        if (targetPrimaryKeys.length === 0) {
+            return;
+        }
+        if (targetPrimaryKeys.length === 1) {
+            await this.inputs.throughTableManager.deleteLink(this.inputs.ownerPrimaryKey, targetPrimaryKeys[0]);
+            return;
+        }
+        await this.inputs.throughTableManager.deleteLinks(this.inputs.ownerPrimaryKey, targetPrimaryKeys);
     }
 
     private resolveTargetPrimaryKeys(targets: readonly ManyToManyTargetRef<TTarget>[]): unknown[] {

--- a/packages/orm/src/manager/relations/tests/ManyToManyRelatedManager.test.ts
+++ b/packages/orm/src/manager/relations/tests/ManyToManyRelatedManager.test.ts
@@ -141,6 +141,95 @@ describe(ManyToManyRelatedManager, () => {
         });
     });
 
+    describe(ManyToManyRelatedManager.prototype.set, () => {
+        it('replaces a non-empty relation set by removing missing links and adding new ones', async () => {
+            const { manager, insertLink, insertLinks, deleteLink, deleteLinks, selectTargetIdsForOwner, runAtomic } =
+                aManyToManyRelatedManager<{ id: number }>({
+                    selectTargetIdsForOwner: async () => [11, 12],
+                });
+            manager.primePrefetchCache([{ id: 11 }, { id: 12 }]);
+
+            await manager.set({ id: 12 }, { id: 13 });
+
+            expect(selectTargetIdsForOwner).toHaveBeenCalledWith(7);
+            expect(runAtomic).toHaveBeenCalledTimes(1);
+            expect(deleteLink).toHaveBeenCalledWith(7, 11);
+            expect(deleteLinks).not.toHaveBeenCalled();
+            expect(insertLink).toHaveBeenCalledWith(7, 13, { onDuplicate: 'ignore' });
+            expect(insertLinks).not.toHaveBeenCalled();
+            expect(manager.snapshotCache()).toBeNull();
+        });
+
+        it('replaces the current relation set with an empty set when no targets are supplied', async () => {
+            const { manager, deleteLink, deleteLinks, insertLink, insertLinks, runAtomic } = aManyToManyRelatedManager<{
+                id: number;
+            }>({
+                selectTargetIdsForOwner: async () => [11, 12],
+            });
+
+            await manager.set();
+
+            expect(runAtomic).toHaveBeenCalledTimes(1);
+            expect(deleteLink).not.toHaveBeenCalled();
+            expect(deleteLinks).toHaveBeenCalledWith(7, [11, 12]);
+            expect(insertLink).not.toHaveBeenCalled();
+            expect(insertLinks).not.toHaveBeenCalled();
+        });
+
+        it('deduplicates duplicate targets before diffing the replacement set', async () => {
+            const { manager, insertLink, insertLinks, deleteLink, deleteLinks } = aManyToManyRelatedManager<{
+                id: number;
+            }>({
+                selectTargetIdsForOwner: async () => [11],
+            });
+
+            await manager.set(11, { id: 12 }, 11, { id: 12 });
+
+            expect(deleteLink).not.toHaveBeenCalled();
+            expect(deleteLinks).not.toHaveBeenCalled();
+            expect(insertLink).toHaveBeenCalledWith(7, 12, { onDuplicate: 'ignore' });
+            expect(insertLinks).not.toHaveBeenCalled();
+        });
+
+        it('returns without mutating or invalidating the cache when the target set is unchanged', async () => {
+            const { manager, insertLink, insertLinks, deleteLink, deleteLinks, runAtomic } = aManyToManyRelatedManager<{
+                id: number;
+            }>({
+                selectTargetIdsForOwner: async () => [11, 12],
+            });
+            manager.primePrefetchCache([{ id: 11 }, { id: 12 }]);
+
+            await manager.set(12, 11, 12);
+
+            expect(deleteLink).not.toHaveBeenCalled();
+            expect(deleteLinks).not.toHaveBeenCalled();
+            expect(insertLink).not.toHaveBeenCalled();
+            expect(insertLinks).not.toHaveBeenCalled();
+            expect(runAtomic).not.toHaveBeenCalled();
+            expect(manager.snapshotCache()).toEqual([{ id: 11 }, { id: 12 }]);
+        });
+
+        it('is idempotent across repeated calls with the same replacement set', async () => {
+            let currentTargetPrimaryKeys: readonly number[] = [11];
+            const { manager, insertLink, deleteLink, runAtomic } = aManyToManyRelatedManager<{ id: number }>({
+                selectTargetIdsForOwner: async () => currentTargetPrimaryKeys,
+                insertLink: async (_ownerPrimaryKey, targetPrimaryKey) => {
+                    currentTargetPrimaryKeys = [...currentTargetPrimaryKeys, Number(targetPrimaryKey)];
+                },
+                deleteLink: async (_ownerPrimaryKey, targetPrimaryKey) => {
+                    currentTargetPrimaryKeys = currentTargetPrimaryKeys.filter((id) => id !== Number(targetPrimaryKey));
+                },
+            });
+
+            await manager.set(11, 12);
+            await manager.set(12, 11);
+
+            expect(insertLink).toHaveBeenCalledTimes(1);
+            expect(deleteLink).not.toHaveBeenCalled();
+            expect(runAtomic).toHaveBeenCalledTimes(1);
+        });
+    });
+
     describe(ManyToManyRelatedManager.prototype.all, () => {
         it('throws a descriptive error when the target executor cannot be resolved', () => {
             const { manager } = aManyToManyRelatedManager<{ id: number }>({ targetExecutor: null });

--- a/packages/resources/src/serializer/ModelSerializer.ts
+++ b/packages/resources/src/serializer/ModelSerializer.ts
@@ -261,13 +261,7 @@ export abstract class ModelSerializer<
         }
 
         const nextTargets = await this.resolveWriteTargets(fieldName, field.write, value);
-        const currentTargets = (await manager.all().fetch()).results;
-        if (currentTargets.length > 0) {
-            await manager.remove(...currentTargets);
-        }
-        if (nextTargets.length > 0) {
-            await manager.add(...nextTargets);
-        }
+        await manager.set(...nextTargets);
     }
 
     private async resolveWriteTargets(

--- a/packages/resources/src/serializer/tests/ModelSerializer.test.ts
+++ b/packages/resources/src/serializer/tests/ModelSerializer.test.ts
@@ -159,15 +159,18 @@ function aTaggableManagerFixture(
             }
         },
         insertLinks: async (_ownerPrimaryKey, targetPrimaryKeys) => {
-            currentTargets = targetPrimaryKeys
-                .map((targetPrimaryKey) => resolveTarget(targetPrimaryKey))
-                .filter((candidate): candidate is TagRecord => !!candidate);
+            currentTargets = [
+                ...currentTargets,
+                ...targetPrimaryKeys
+                    .map((targetPrimaryKey) => resolveTarget(targetPrimaryKey))
+                    .filter((candidate): candidate is TagRecord => !!candidate),
+            ];
         },
         deleteLink: async (_ownerPrimaryKey, targetPrimaryKey) => {
             currentTargets = currentTargets.filter((tag) => tag.id !== Number(targetPrimaryKey));
         },
         deleteLinks: async (_ownerPrimaryKey, targetPrimaryKeys) => {
-            const toRemove = new Set(targetPrimaryKeys.map((value) => Number(value)));
+            const toRemove = new Set(targetPrimaryKeys.map(Number));
             currentTargets = currentTargets.filter((tag) => !toRemove.has(tag.id));
         },
     });
@@ -445,6 +448,135 @@ describe(ModelSerializer, () => {
         expect(createdTargetRows).toEqual([{ id: 3, slug: 'orm', name: 'ORM' }]);
     });
 
+    it('applies many-to-many replacements through the manager set diff instead of clearing shared rows first', async () => {
+        const existingTags: TagRecord[] = [
+            { id: 2, slug: 'staff', name: 'Staff' },
+            { id: 3, slug: 'orm', name: 'ORM' },
+        ];
+        const availableBySlug = new Map(existingTags.map((tag) => [tag.slug, tag]));
+        const availableById = new Map(existingTags.map((tag) => [tag.id, tag]));
+        const relationFixture = aTaggableManagerFixture([existingTags[0]!], (targetPrimaryKey) =>
+            availableById.get(Number(targetPrimaryKey))
+        );
+
+        const tagQuerySet = {
+            filter: vi.fn((where: Record<string, unknown>) => {
+                const slugs = (where['slug__in'] as string[]) ?? [];
+                return {
+                    fetch: vi.fn(async () =>
+                        aQueryResult({
+                            items: slugs
+                                .map((slug) => availableBySlug.get(slug))
+                                .filter((candidate): candidate is TagRecord => !!candidate),
+                        })
+                    ),
+                } as Pick<QuerySet<TagRecord>, 'fetch'>;
+            }),
+        };
+
+        const tagModel: ResourceModelLike<TagRecord, TagRecord> = {
+            objects: aManager<TagRecord>({
+                meta: { table: 'tags', pk: 'id', columns: { id: 'int', slug: 'text', name: 'text' } },
+                query: vi.fn(() => tagQuerySet as unknown as QuerySet<TagRecord>),
+                create: vi.fn(async () => {
+                    throw new Error('not used');
+                }),
+                update: vi.fn(async () => {
+                    throw new Error('not used');
+                }),
+                delete: vi.fn(async () => {}),
+                bulkCreate: vi.fn(async () => []),
+            }),
+        };
+
+        const relationModel: ResourceModelLike<UserRecord, TaggedUserRecord> = {
+            objects: aManager<TaggedUserRecord>({
+                meta: {
+                    table: 'users',
+                    pk: 'id',
+                    columns: { id: 'int', email: 'text', slug: 'text' },
+                    relations: {
+                        tags: {
+                            edgeId: 'users:tags',
+                            sourceModelKey: 'test/User',
+                            targetModelKey: 'test/Tag',
+                            kind: 'manyToMany',
+                            cardinality: 'many',
+                            capabilities: { queryable: true, hydratable: true, joinable: false, prefetchable: true },
+                            table: 'tags',
+                            sourceKey: 'id',
+                            targetKey: 'id',
+                            throughTable: 'm2m_tags',
+                            throughSourceKey: 'userId',
+                            throughTargetKey: 'tagId',
+                            targetPrimaryKey: 'id',
+                            targetColumns: { id: 'int', slug: 'text', name: 'text' },
+                            alias: 'tag_tags',
+                        },
+                    },
+                },
+                create: vi.fn(
+                    async (input) => ({ id: 41, ...input, tags: relationFixture.manager }) as TaggedUserRecord
+                ),
+                update: vi.fn(
+                    async (id, patch) =>
+                        ({
+                            id: Number(id),
+                            email: 'existing@example.com',
+                            ...patch,
+                            tags: relationFixture.manager,
+                        }) as TaggedUserRecord
+                ),
+            }),
+        };
+
+        const relationCreateSchema = z.object({
+            email: z.string().email(),
+            tags: z.array(z.string()).default([]),
+        });
+        const relationUpdateSchema = relationCreateSchema.partial();
+        const relationOutputSchema = outputSchema.extend({
+            tags: z.array(tagSummarySchema),
+        });
+
+        class SlugRelatedUserSerializer extends ModelSerializer<
+            UserRecord,
+            typeof relationCreateSchema,
+            typeof relationUpdateSchema,
+            typeof relationOutputSchema,
+            TaggedUserRecord
+        > {
+            static readonly model = relationModel;
+            static readonly createSchema = relationCreateSchema;
+            static readonly updateSchema = relationUpdateSchema;
+            static readonly outputSchema = relationOutputSchema;
+            static readonly relationFields = {
+                tags: relation.manyToMany({
+                    read: relation.nested(tagSummarySchema),
+                    write: relation.slugList<TagRecord>({
+                        model: tagModel,
+                        lookupField: 'slug',
+                    }),
+                }),
+            };
+        }
+
+        const serializer = new SlugRelatedUserSerializer();
+
+        await expect(serializer.update(41, { tags: ['staff', 'orm'] })).resolves.toEqual({
+            id: 41,
+            email: 'existing@example.com',
+            tags: [
+                { id: 2, slug: 'staff', name: 'Staff' },
+                { id: 3, slug: 'orm', name: 'ORM' },
+            ],
+        });
+        expect(relationFixture.deleteLink).not.toHaveBeenCalled();
+        expect(relationFixture.deleteLinks).not.toHaveBeenCalled();
+        expect(relationFixture.insertLink).toHaveBeenCalledWith(7, 3, { onDuplicate: 'ignore' });
+        expect(relationFixture.insertLinks).not.toHaveBeenCalled();
+    });
+
     it('resolves serializer-owned async output fields before parsing the outward schema', async () => {
         const serializer = new TaggedUserSerializer();
         const fixture = aTaggableManagerFixture([{ id: 1, slug: 'staff', name: 'Staff' }], (targetPrimaryKey) =>
@@ -489,9 +621,9 @@ describe(ModelSerializer, () => {
         await expect(serializer.syncManyToManyRelation(record, 'tags', [])).resolves.toBeUndefined();
         await expect(serializer.applyRelationWrites(record, { missing: ['ignored'] })).resolves.toBeUndefined();
 
-        await expect(
-            serializer.resolveWriteTargets('tags', relation.pkList(), 'not-an-array')
-        ).rejects.toThrow(/primary-key values/i);
+        await expect(serializer.resolveWriteTargets('tags', relation.pkList(), 'not-an-array')).rejects.toThrow(
+            /primary-key values/i
+        );
         await expect(
             serializer.resolveWriteTargets(
                 'tags',
@@ -513,9 +645,9 @@ describe(ModelSerializer, () => {
             )
         ).resolves.toEqual([]);
 
-        expect(() => serializer.getManyToManyManager({ id: 1, email: 'bad@example.com', tags: [] } as never, 'tags')).toThrow(
-            /many-to-many related manager/i
-        );
+        expect(() =>
+            serializer.getManyToManyManager({ id: 1, email: 'bad@example.com', tags: [] } as never, 'tags')
+        ).toThrow(/many-to-many related manager/i);
         expect(() => serializer.getManyToManyRelationMeta('missing')).toThrow(/persisted many-to-many edge/i);
     });
 
@@ -526,7 +658,9 @@ describe(ModelSerializer, () => {
         const clearingFixture = aTaggableManagerFixture([availableTags[0]!], (targetPrimaryKey) =>
             availableById.get(Number(targetPrimaryKey))
         );
-        const createFixture = aTaggableManagerFixture([], (targetPrimaryKey) => availableById.get(Number(targetPrimaryKey)));
+        const createFixture = aTaggableManagerFixture([], (targetPrimaryKey) =>
+            availableById.get(Number(targetPrimaryKey))
+        );
 
         const tagQuerySet = {
             filter: vi.fn((where: Record<string, unknown>) => {
@@ -594,7 +728,12 @@ describe(ModelSerializer, () => {
                 create: vi.fn(async (input) => ({ id: 31, ...input, tags: createFixture.manager }) as TaggedUserRecord),
                 update: vi.fn(
                     async (id, patch) =>
-                        ({ id: Number(id), email: 'existing@example.com', ...patch, tags: clearingFixture.manager }) as TaggedUserRecord
+                        ({
+                            id: Number(id),
+                            email: 'existing@example.com',
+                            ...patch,
+                            tags: clearingFixture.manager,
+                        }) as TaggedUserRecord
                 ),
             }),
         };


### PR DESCRIPTION
## Summary

This adds `ManyToManyRelatedManager.set(...)` with Django-shaped replacement semantics. The related manager now diffs the current membership against the supplied targets, removes missing links, inserts new links, and invalidates any prefetched cache after a successful replacement.

The resource-layer many-to-many serializer path now uses `set(...)` instead of manually clearing and re-adding memberships, which avoids unnecessary delete/reinsert churn when a replacement only changes part of the relation set. The public ORM docs were updated to describe `set(...)` alongside `add(...)`, `remove(...)`, and `all()`.

Closes #37.
Related to #57.

## Validation

- `pnpm exec oxlint packages/orm/src/manager/relations/ManyToManyRelatedManager.ts packages/orm/src/manager/relations/tests/ManyToManyRelatedManager.test.ts packages/resources/src/serializer/ModelSerializer.ts packages/resources/src/serializer/tests/ModelSerializer.test.ts docs/reference/orm-query-api.md docs/topics/orm-and-querysets.md docs/reference/schema-api.md`
- `pnpm exec eslint packages/orm/src/manager/relations/ManyToManyRelatedManager.ts packages/orm/src/manager/relations/tests/ManyToManyRelatedManager.test.ts packages/resources/src/serializer/ModelSerializer.ts packages/resources/src/serializer/tests/ModelSerializer.test.ts`
- `pnpm --filter @danceroutine/tango-config build && pnpm --filter @danceroutine/tango-core build && pnpm --filter @danceroutine/tango-schema build && pnpm --filter @danceroutine/tango-codegen build && pnpm --filter @danceroutine/tango-migrations build && pnpm --filter @danceroutine/tango-testing build`
- `pnpm exec vitest run packages/orm/src/manager/relations/tests/ManyToManyRelatedManager.test.ts packages/resources/src/serializer/tests/ModelSerializer.test.ts`
- `pnpm --filter @danceroutine/tango-orm typecheck:prod && pnpm --filter @danceroutine/tango-resources typecheck:prod && pnpm docs:build`