### PR TITLE
fix(scaffold): normalize migration naming scripts

### DIFF
--- a/.changeset/modern-shirts-taste.md
+++ b/.changeset/modern-shirts-taste.md
@@ -1,0 +1,6 @@
+---
+'@danceroutine/tango-cli': patch
+'@danceroutine/tango-codegen': patch
+---
+
+Make scaffolded `make:migrations` scripts forward a normal `--name` argument so migration naming works the same way across Express, Next, and Nuxt apps.

--- a/docs/tutorials/express-blog-api.md
+++ b/docs/tutorials/express-blog-api.md
@@ -195,7 +195,7 @@ The OpenAPI document is generated from the existing resource classes. Once the p
 From the repository root, generate a migration for the new column:
 
 ```bash
-pnpm --filter @danceroutine/tango-example-express-blog-api make:migrations --name add_post_summary
+pnpm --filter @danceroutine/tango-example-express-blog-api run make:migrations -- --name add_post_summary
 ```
 
 Open the new migration file in `examples/blog-api/migrations/` and confirm that it adds the new `summary` column to the posts table.

--- a/docs/tutorials/nextjs-blog.md
+++ b/docs/tutorials/nextjs-blog.md
@@ -224,7 +224,7 @@ The OpenAPI document is generated from the existing Tango resources. Once the sc
 From the repository root, generate a migration for the new column:
 
 ```bash
-pnpm --filter @danceroutine/tango-example-nextjs-blog make:migrations --name add_post_summary
+pnpm --filter @danceroutine/tango-example-nextjs-blog run make:migrations -- --name add_post_summary
 ```
 
 Open the new migration file in `examples/nextjs-blog/migrations/` and confirm that it adds the new `summary` column to the posts table.

--- a/docs/tutorials/nuxt-blog.md
+++ b/docs/tutorials/nuxt-blog.md
@@ -242,7 +242,7 @@ The OpenAPI document is generated from the existing Tango resources. Once the sc
 From the repository root, generate a migration for the new column:
 
 ```bash
-pnpm --filter @danceroutine/tango-example-nuxt-blog make:migrations --name add_post_summary
+pnpm --filter @danceroutine/tango-example-nuxt-blog run make:migrations -- --name add_post_summary
 ```
 
 Open the new migration file in `examples/nuxt-blog/migrations/` and confirm that it adds the new `summary` column to the posts table.

--- a/examples/blog-api/README.md
+++ b/examples/blog-api/README.md
@@ -15,7 +15,7 @@ pnpm --filter @danceroutine/tango-example-express-blog-api dev
 When you change model metadata, use:
 
 ```bash
-pnpm --filter @danceroutine/tango-example-express-blog-api make:migrations --name add_field
+pnpm --filter @danceroutine/tango-example-express-blog-api run make:migrations -- --name add_field
 ```
 
 That workflow generates the migration and refreshes the generated relation registry at the same time. If you only changed relation metadata and do not need a new migration file, run:

--- a/examples/blog-api/package.json
+++ b/examples/blog-api/package.json
@@ -11,7 +11,7 @@
         "start": "node dist/index.js",
         "typecheck": "tsc --noEmit",
         "setup:schema": "pnpm exec tango migrate --config ./tango.config.ts",
-        "make:migrations": "pnpm exec tango make:migrations --config ./tango.config.ts --models ./src/models/index.ts --name \"${npm_config_name:-manual_change}\"",
+        "make:migrations": "tango make:migrations --config ./tango.config.ts --models ./src/models/index.ts",
         "codegen:relations": "pnpm exec tango codegen relations --models ./src/models/index.ts",
         "prebootstrap": "pnpm run setup:schema",
         "bootstrap": "tsx scripts/bootstrap.ts"

--- a/examples/nextjs-blog/README.md
+++ b/examples/nextjs-blog/README.md
@@ -15,7 +15,7 @@ pnpm --filter @danceroutine/tango-example-nextjs-blog dev
 When you change model metadata, use:
 
 ```bash
-pnpm --filter @danceroutine/tango-example-nextjs-blog make:migrations --name add_field
+pnpm --filter @danceroutine/tango-example-nextjs-blog run make:migrations -- --name add_field
 ```
 
 That workflow generates the migration and refreshes the generated relation registry at the same time. If you only changed relation metadata and do not need a new migration file, run:

--- a/examples/nextjs-blog/package.json
+++ b/examples/nextjs-blog/package.json
@@ -11,7 +11,7 @@
         "start": "next start",
         "typecheck": "next typegen && tsc --noEmit",
         "setup:schema": "pnpm exec tango migrate --config ./tango.config.ts",
-        "make:migrations": "pnpm exec tango make:migrations --config ./tango.config.ts --models ./src/lib/models.ts --name \"${npm_config_name:-manual_change}\"",
+        "make:migrations": "tango make:migrations --config ./tango.config.ts --models ./src/lib/models.ts",
         "codegen:relations": "pnpm exec tango codegen relations --models ./src/lib/models.ts",
         "prebootstrap": "pnpm run setup:schema",
         "bootstrap": "tsx scripts/bootstrap.ts"

--- a/examples/nuxt-blog/README.md
+++ b/examples/nuxt-blog/README.md
@@ -14,7 +14,7 @@ pnpm --filter @danceroutine/tango-example-nuxt-blog dev
 When you change model metadata, use:
 
 ```bash
-pnpm --filter @danceroutine/tango-example-nuxt-blog make:migrations --name add_field
+pnpm --filter @danceroutine/tango-example-nuxt-blog run make:migrations -- --name add_field
 ```
 
 That workflow generates the migration and refreshes the generated relation registry at the same time. If you only changed relation metadata and do not need a new migration file, run:

--- a/examples/nuxt-blog/package.json
+++ b/examples/nuxt-blog/package.json
@@ -13,7 +13,7 @@
         "start": "NUXT_TELEMETRY_DISABLED=1 nuxt preview",
         "typecheck": "NUXT_TELEMETRY_DISABLED=1 nuxt typecheck",
         "setup:schema": "pnpm exec tango migrate --config ./tango.config.ts",
-        "make:migrations": "pnpm exec tango make:migrations --config ./tango.config.ts --models ./lib/models.ts --name \"${npm_config_name:-manual_change}\"",
+        "make:migrations": "tango make:migrations --config ./tango.config.ts --models ./lib/models.ts",
         "codegen:relations": "pnpm exec tango codegen relations --models ./lib/models.ts",
         "prebootstrap": "pnpm run prepare:tango && pnpm run setup:schema",
         "bootstrap": "tsx scripts/bootstrap.ts"

--- a/packages/codegen/src/frameworks/scaffold/tests/scaffoldProject.test.ts
+++ b/packages/codegen/src/frameworks/scaffold/tests/scaffoldProject.test.ts
@@ -1,11 +1,15 @@
-import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { chmod, mkdtemp, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
 import { describe, expect, it } from 'vitest';
 import { scaffoldProject } from '../scaffoldProject';
 import { ExpressScaffoldStrategy } from '../../strategies/express/ExpressScaffoldStrategy';
 import { NextScaffoldStrategy } from '../../strategies/next/NextScaffoldStrategy';
 import { NuxtScaffoldStrategy } from '../../strategies/nuxt/NuxtScaffoldStrategy';
+
+const execFileAsync = promisify(execFile);
 
 describe(scaffoldProject, () => {
     it('writes a full Express project into target directory', async () => {
@@ -29,9 +33,13 @@ describe(scaffoldProject, () => {
             const tangoSource = await readFile(join(dir, 'src/tango.ts'), 'utf8');
             const openapiSource = await readFile(join(dir, 'src/openapi.ts'), 'utf8');
             const serializerSource = await readFile(join(dir, 'src/serializers/TodoSerializer.ts'), 'utf8');
+            const readme = await readFile(join(dir, 'README.md'), 'utf8');
+            const scripts = JSON.parse(packageJson).scripts as Record<string, string>;
             expect(packageJson).toContain('"@danceroutine/tango-adapters-express"');
             expect(packageJson).toContain('"@danceroutine/tango-openapi"');
             expect(packageJson).toContain('"setup:schema"');
+            expect(scripts['make:migrations']).not.toContain('--name');
+            expect(readme).toContain('make:migrations -- --name initial');
             expect(appSource).toContain("from './tango.js'");
             expect(appSource).toContain('await registerTango(app)');
             expect(tangoSource).toContain("adapter.registerViewSet(app, '/api/todos'");
@@ -66,8 +74,12 @@ describe(scaffoldProject, () => {
             const serializerSource = await readFile(join(dir, 'src/serializers/TodoSerializer.ts'), 'utf8');
             const layoutSource = await readFile(join(dir, 'src/app/layout.tsx'), 'utf8');
             const tsconfig = await readFile(join(dir, 'tsconfig.json'), 'utf8');
+            const readme = await readFile(join(dir, 'README.md'), 'utf8');
+            const scripts = JSON.parse(packageJson).scripts as Record<string, string>;
             expect(packageJson).toContain('"next"');
             expect(packageJson).toContain('"@danceroutine/tango-openapi"');
+            expect(scripts['make:migrations']).not.toContain('--name');
+            expect(readme).toContain('make:migrations -- --name initial');
             expect(routeSource).toContain('Response.json');
             expect(openapiRoute).toContain("from '@/lib/openapi'");
             expect(openapiSource).toContain('describeViewSet');
@@ -104,8 +116,12 @@ describe(scaffoldProject, () => {
             const appShell = await readFile(join(dir, 'app/app.vue'), 'utf8');
             const pageSource = await readFile(join(dir, 'app/pages/index.server.vue'), 'utf8');
             const tsconfig = await readFile(join(dir, 'tsconfig.json'), 'utf8');
+            const readme = await readFile(join(dir, 'README.md'), 'utf8');
+            const scripts = JSON.parse(packageJson).scripts as Record<string, string>;
             expect(packageJson).toContain('"nuxt"');
             expect(packageJson).toContain('"@danceroutine/tango-openapi"');
+            expect(scripts['make:migrations']).not.toContain('--name');
+            expect(readme).toContain('make:migrations -- --name initial');
             expect(nuxtConfig).toContain('/api/todos/**:tango');
             expect(routeSource).toContain('NuxtAdapter');
             expect(openapiRoute).toContain("from '~~/lib/openapi'");
@@ -117,6 +133,71 @@ describe(scaffoldProject, () => {
             expect(tsconfig).toContain('".tango/**/*.d.ts"');
         } finally {
             await rm(dir, { recursive: true, force: true });
+        }
+    });
+
+    it('forwards named migration args cleanly through the scaffolded package script', async () => {
+        const scenarios = [
+            {
+                framework: 'express' as const,
+                strategy: new ExpressScaffoldStrategy(),
+                projectName: 'express-script-app',
+            },
+            {
+                framework: 'next' as const,
+                strategy: new NextScaffoldStrategy(),
+                projectName: 'next-script-app',
+            },
+            {
+                framework: 'nuxt' as const,
+                strategy: new NuxtScaffoldStrategy(),
+                projectName: 'nuxt-script-app',
+            },
+        ];
+
+        for (const scenario of scenarios) {
+            const dir = await mkdtemp(join(tmpdir(), `tango-codegen-${scenario.framework}-script-`));
+            try {
+                await scaffoldProject(
+                    {
+                        projectName: scenario.projectName,
+                        targetDir: dir,
+                        framework: scenario.framework,
+                        packageManager: 'pnpm',
+                        dialect: 'sqlite',
+                        includeSeed: false,
+                    },
+                    scenario.strategy
+                );
+
+                const tangoBinDir = join(dir, 'node_modules', '.bin');
+                await mkdir(tangoBinDir, { recursive: true });
+                const tangoStub = join(tangoBinDir, 'tango');
+                await writeFile(
+                    tangoStub,
+                    `#!/usr/bin/env node
+const { mkdirSync, writeFileSync } = require('node:fs');
+const { join } = require('node:path');
+const args = process.argv.slice(2);
+const nameIndex = args.indexOf('--name');
+if (nameIndex === -1 || !args[nameIndex + 1]) {
+  process.stderr.write('missing --name\\n');
+  process.exit(1);
+}
+mkdirSync(join(process.cwd(), 'migrations'), { recursive: true });
+writeFileSync(join(process.cwd(), 'migrations', \`20260424120000_\${args[nameIndex + 1]}.ts\`), args.join(' '), 'utf8');
+`,
+                    'utf8'
+                );
+                await chmod(tangoStub, 0o755);
+
+                await execFileAsync('pnpm', ['run', 'make:migrations', '--', '--name', 'initial'], { cwd: dir });
+
+                const filenames = await readdir(join(dir, 'migrations'));
+                expect(filenames).toContain('20260424120000_initial.ts');
+            } finally {
+                await rm(dir, { recursive: true, force: true });
+            }
         }
     });
 

--- a/packages/codegen/src/frameworks/strategies/express/templates/packageJson.ts
+++ b/packages/codegen/src/frameworks/strategies/express/templates/packageJson.ts
@@ -25,7 +25,7 @@ export class PackageJsonTemplateBuilder extends TemplateBuilder {
                     'setup:schema':
                         "node -e \"require('node:fs').mkdirSync('./.data',{recursive:true})\" && tango migrate --config ./tango.config.ts",
                     'make:migrations':
-                        'tango make:migrations --config ./tango.config.ts --models ./src/models/index.ts --name "${npm_config_name:-manual_change}"',
+                        'tango make:migrations --config ./tango.config.ts --models ./src/models/index.ts',
                     'codegen:relations': 'tango codegen relations --models ./src/models/index.ts',
                     prebootstrap:
                         "node -e \"require('node:fs').mkdirSync('./.data',{recursive:true})\" && tango migrate --config ./tango.config.ts",

--- a/packages/codegen/src/frameworks/strategies/express/templates/readme.ts
+++ b/packages/codegen/src/frameworks/strategies/express/templates/readme.ts
@@ -18,16 +18,18 @@ Express still owns the server and route registration; Tango owns model metadata,
 Generate your first migration from the scaffolded models, then start the app:
 
 \`\`\`bash
-${context.packageManager} run make:migrations --name initial
+${context.packageManager} run make:migrations -- --name initial
 ${context.packageManager} run dev
 \`\`\`
 
 \`make:migrations\` also refreshes the generated relation registry for the scaffolded model module. If you later change relation metadata without needing a new migration file, run \`${context.packageManager} run codegen:relations\`.
 
+When you run the package script, pass Tango flags after \`--\` so the script forwards them to the CLI unchanged.
+
 ## Scripts
 
 - \`${context.packageManager} run dev\`
-- \`${context.packageManager} run make:migrations --name add_field\`
+- \`${context.packageManager} run make:migrations -- --name add_field\`
 - \`${context.packageManager} run codegen:relations\`
 - \`${context.packageManager} run setup:schema\`
 - \`${context.packageManager} run bootstrap\`

--- a/packages/codegen/src/frameworks/strategies/express/tests/ExpressScaffoldStrategy.test.ts
+++ b/packages/codegen/src/frameworks/strategies/express/tests/ExpressScaffoldStrategy.test.ts
@@ -40,11 +40,14 @@ describe(ExpressScaffoldStrategy, () => {
             const viewsetSource = renderTemplate(templates, 'src/viewsets/TodoViewSet.ts', context);
             const readme = renderTemplate(templates, 'README.md', context);
             const migrationsKeep = renderTemplate(templates, 'migrations/.gitkeep', context);
+            const scripts = JSON.parse(packageJson).scripts as Record<string, string>;
 
             expect(packageJson).toContain('"better-sqlite3"');
             expect(packageJson).not.toContain('"pg"');
             expect(packageJson).toContain('"@danceroutine/tango-openapi"');
             expect(packageJson).toContain('"codegen:relations"');
+            expect(scripts['make:migrations']).not.toContain('--name');
+            expect(scripts['make:migrations']).not.toContain('npm_config_name');
             expect(config).toContain("adapter: 'sqlite'");
             expect(config).toContain('./.data/express-sqlite.sqlite');
             expect((JSON.parse(tsconfig) as { include: string[] }).include).toContain('migrations/**/*.ts');
@@ -58,7 +61,7 @@ describe(ExpressScaffoldStrategy, () => {
             expect(viewsetSource).toContain('serializer: TodoSerializer');
             expect(indexSource).toContain('await registerTango(app)');
             expect(readme).toContain('First-time setup');
-            expect(readme).toContain('make:migrations --name initial');
+            expect(readme).toContain('make:migrations -- --name initial');
             expect(readme).toContain('codegen:relations');
             expect(migrationsKeep).toBe('');
         });

--- a/packages/codegen/src/frameworks/strategies/next/templates/packageJson.ts
+++ b/packages/codegen/src/frameworks/strategies/next/templates/packageJson.ts
@@ -25,7 +25,7 @@ export class PackageJsonTemplateBuilder extends TemplateBuilder {
                     'setup:schema':
                         "node -e \"require('node:fs').mkdirSync('./.data',{recursive:true})\" && tango migrate --config ./tango.config.ts",
                     'make:migrations':
-                        'tango make:migrations --config ./tango.config.ts --models ./src/lib/models/index.ts --name "${npm_config_name:-manual_change}"',
+                        'tango make:migrations --config ./tango.config.ts --models ./src/lib/models/index.ts',
                     'codegen:relations': 'tango codegen relations --models ./src/lib/models/index.ts',
                     prebootstrap:
                         "node -e \"require('node:fs').mkdirSync('./.data',{recursive:true})\" && tango migrate --config ./tango.config.ts",

--- a/packages/codegen/src/frameworks/strategies/next/templates/readme.ts
+++ b/packages/codegen/src/frameworks/strategies/next/templates/readme.ts
@@ -18,16 +18,18 @@ Next.js still owns pages and route handlers; Tango owns model metadata, \`Model.
 Generate your first migration from the scaffolded models, then start the app:
 
 \`\`\`bash
-${context.packageManager} run make:migrations --name initial
+${context.packageManager} run make:migrations -- --name initial
 ${context.packageManager} run dev
 \`\`\`
 
 \`make:migrations\` also refreshes the generated relation registry for the scaffolded model module. If you later change relation metadata without needing a new migration file, run \`${context.packageManager} run codegen:relations\`.
 
+When you run the package script, pass Tango flags after \`--\` so the script forwards them to the CLI unchanged.
+
 ## Scripts
 
 - \`${context.packageManager} run dev\`
-- \`${context.packageManager} run make:migrations --name add_field\`
+- \`${context.packageManager} run make:migrations -- --name add_field\`
 - \`${context.packageManager} run codegen:relations\`
 - \`${context.packageManager} run setup:schema\`
 - \`${context.packageManager} run bootstrap\`

--- a/packages/codegen/src/frameworks/strategies/next/tests/NextScaffoldStrategy.test.ts
+++ b/packages/codegen/src/frameworks/strategies/next/tests/NextScaffoldStrategy.test.ts
@@ -50,8 +50,11 @@ describe(NextScaffoldStrategy, () => {
             const viewsetSource = renderTemplate(templates, 'src/viewsets/TodoViewSet.ts', context);
             const readme = renderTemplate(templates, 'README.md', context);
             const migrationsKeep = renderTemplate(templates, 'migrations/.gitkeep', context);
+            const scripts = JSON.parse(packageJson).scripts as Record<string, string>;
 
             expect(packageJson).toContain('"codegen:relations"');
+            expect(scripts['make:migrations']).not.toContain('--name');
+            expect(scripts['make:migrations']).not.toContain('npm_config_name');
             expect(tsconfig).toContain('"migrations/**/*.ts"');
             expect(tsconfig).toContain('".tango/**/*.d.ts"');
             expect(layout).toContain('RootLayout');
@@ -64,7 +67,7 @@ describe(NextScaffoldStrategy, () => {
             expect(serializerSource).toContain('export class TodoSerializer extends ModelSerializer');
             expect(viewsetSource).toContain('serializer: TodoSerializer');
             expect(readme).toContain('First-time setup');
-            expect(readme).toContain('make:migrations --name initial');
+            expect(readme).toContain('make:migrations -- --name initial');
             expect(readme).toContain('codegen:relations');
             expect(migrationsKeep).toBe('');
         });

--- a/packages/codegen/src/frameworks/strategies/nuxt/templates/packageJson.ts
+++ b/packages/codegen/src/frameworks/strategies/nuxt/templates/packageJson.ts
@@ -25,7 +25,7 @@ export class PackageJsonTemplateBuilder extends TemplateBuilder {
                     typecheck: 'NUXT_TELEMETRY_DISABLED=1 nuxt typecheck',
                     'setup:schema': 'pnpm exec tango migrate --config ./tango.config.ts',
                     'make:migrations':
-                        'pnpm exec tango make:migrations --config ./tango.config.ts --models ./lib/models/index.ts --name "${npm_config_name:-manual_change}"',
+                        'tango make:migrations --config ./tango.config.ts --models ./lib/models/index.ts',
                     'codegen:relations': 'pnpm exec tango codegen relations --models ./lib/models/index.ts',
                     prebootstrap: 'pnpm run setup:schema',
                     bootstrap: 'tsx scripts/bootstrap.ts',

--- a/packages/codegen/src/frameworks/strategies/nuxt/templates/readme.ts
+++ b/packages/codegen/src/frameworks/strategies/nuxt/templates/readme.ts
@@ -18,16 +18,18 @@ Nuxt still owns pages and SSR rendering; Tango owns model metadata, \`Model.obje
 Generate your first migration from the scaffolded models, then start the app:
 
 \`\`\`bash
-${context.packageManager} run make:migrations --name initial
+${context.packageManager} run make:migrations -- --name initial
 ${context.packageManager} run dev
 \`\`\`
 
 \`make:migrations\` also refreshes the generated relation registry for the scaffolded model module. If you later change relation metadata without needing a new migration file, run \`${context.packageManager} run codegen:relations\`.
 
+When you run the package script, pass Tango flags after \`--\` so the script forwards them to the CLI unchanged.
+
 ## Scripts
 
 - \`${context.packageManager} run dev\`
-- \`${context.packageManager} run make:migrations --name add_field\`
+- \`${context.packageManager} run make:migrations -- --name add_field\`
 - \`${context.packageManager} run codegen:relations\`
 - \`${context.packageManager} run setup:schema\`
 - \`${context.packageManager} run bootstrap\`

--- a/packages/codegen/src/frameworks/strategies/nuxt/tests/NuxtScaffoldStrategy.test.ts
+++ b/packages/codegen/src/frameworks/strategies/nuxt/tests/NuxtScaffoldStrategy.test.ts
@@ -52,9 +52,12 @@ describe(NuxtScaffoldStrategy, () => {
             const viewsetSource = renderTemplate(templates, 'viewsets/TodoViewSet.ts', context);
             const readme = renderTemplate(templates, 'README.md', context);
             const migrationsKeep = renderTemplate(templates, 'migrations/.gitkeep', context);
+            const scripts = JSON.parse(packageJson).scripts as Record<string, string>;
 
             expect(packageJson).toContain('"nuxt"');
             expect(packageJson).toContain('"codegen:relations"');
+            expect(scripts['make:migrations']).not.toContain('--name');
+            expect(scripts['make:migrations']).not.toContain('npm_config_name');
             expect(packageJson).toContain('"start": "NUXT_TELEMETRY_DISABLED=1 nuxt preview"');
             expect(nuxtConfig).toContain("route: '/api/todos/**:tango'");
             expect(tsconfig).toContain('".tango/**/*.d.ts"');
@@ -66,6 +69,7 @@ describe(NuxtScaffoldStrategy, () => {
             expect(serializerSource).toContain("from '~~/lib/models'");
             expect(viewsetSource).toContain("from '~~/serializers'");
             expect(readme).toContain('tango new --framework nuxt');
+            expect(readme).toContain('make:migrations -- --name initial');
             expect(readme).toContain('codegen:relations');
             expect(readme).toContain('server/tango/todos.ts');
             expect(migrationsKeep).toBe('');


### PR DESCRIPTION
## Summary

This makes scaffolded `make:migrations` usage boring and consistent again. The generated package scripts no longer hide a default `--name` via `npm_config_name`; instead they forward normal Tango CLI flags, and the scaffolded READMEs now teach one canonical invocation:

```bash
pnpm run make:migrations -- --name initial
```

The checked-in host examples and tutorial snippets were updated to match that same flow, and the scaffold test suite now includes an end-to-end guardrail that runs the generated package script with a stub `tango` binary and verifies it produces a named migration file with the expected `..._initial.ts` shape.

Closes #36.
Related to #35.
Related to #39.

## Validation

- `pnpm --filter @danceroutine/tango-codegen exec vitest run src/frameworks/strategies/express/tests/ExpressScaffoldStrategy.test.ts src/frameworks/strategies/next/tests/NextScaffoldStrategy.test.ts src/frameworks/strategies/nuxt/tests/NuxtScaffoldStrategy.test.ts src/frameworks/scaffold/tests/scaffoldProject.test.ts`
- `pnpm exec oxlint packages/codegen/src/frameworks/strategies/express/templates/packageJson.ts packages/codegen/src/frameworks/strategies/next/templates/packageJson.ts packages/codegen/src/frameworks/strategies/nuxt/templates/packageJson.ts packages/codegen/src/frameworks/strategies/express/templates/readme.ts packages/codegen/src/frameworks/strategies/next/templates/readme.ts packages/codegen/src/frameworks/strategies/nuxt/templates/readme.ts packages/codegen/src/frameworks/strategies/express/tests/ExpressScaffoldStrategy.test.ts packages/codegen/src/frameworks/strategies/next/tests/NextScaffoldStrategy.test.ts packages/codegen/src/frameworks/strategies/nuxt/tests/NuxtScaffoldStrategy.test.ts packages/codegen/src/frameworks/scaffold/tests/scaffoldProject.test.ts`
- `pnpm exec eslint packages/codegen/src/frameworks/strategies/express/templates/packageJson.ts packages/codegen/src/frameworks/strategies/next/templates/packageJson.ts packages/codegen/src/frameworks/strategies/nuxt/templates/packageJson.ts packages/codegen/src/frameworks/strategies/express/templates/readme.ts packages/codegen/src/frameworks/strategies/next/templates/readme.ts packages/codegen/src/frameworks/strategies/nuxt/templates/readme.ts packages/codegen/src/frameworks/strategies/express/tests/ExpressScaffoldStrategy.test.ts packages/codegen/src/frameworks/strategies/next/tests/NextScaffoldStrategy.test.ts packages/codegen/src/frameworks/strategies/nuxt/tests/NuxtScaffoldStrategy.test.ts packages/codegen/src/frameworks/scaffold/tests/scaffoldProject.test.ts`
- `pnpm --filter @danceroutine/tango-codegen typecheck:prod`
- `pnpm docs:build`