### PR TITLE
fix(resources): count filtered querysets before pagination

### DIFF
--- a/.changeset/clean-cobras-move.md
+++ b/.changeset/clean-cobras-move.md
@@ -1,0 +1,5 @@
+---
+'@danceroutine/tango-resources': patch
+---
+
+Fix resource list pagination so offset-paginated `count` reflects the full filtered queryset instead of the current page slice.

--- a/packages/resources/src/view/GenericAPIView.ts
+++ b/packages/resources/src/view/GenericAPIView.ts
@@ -161,8 +161,8 @@ export abstract class GenericAPIView<
                 }
             }
 
-            qs = paginator.apply(qs);
-            const resultPromise = qs.fetch();
+            const paginatedQueryset = paginator.apply(qs);
+            const resultPromise = paginatedQueryset.fetch();
             const totalCountPromise = paginator.needsTotalCount()
                 ? qs.count()
                 : Promise.resolve<number | undefined>(undefined);

--- a/packages/resources/src/view/tests/GenericAPIView.test.ts
+++ b/packages/resources/src/view/tests/GenericAPIView.test.ts
@@ -202,6 +202,55 @@ describe(GenericAPIView, () => {
         });
     });
 
+    it('counts the filtered queryset before applying offset pagination', async () => {
+        const baseQuerySet = aQuerySet<UserRecord>();
+        const filteredQuerySet = aQuerySet<UserRecord>();
+        const paginatedQuerySet = aQuerySet<UserRecord>();
+
+        vi.mocked(baseQuerySet.filter).mockReturnValue(filteredQuerySet);
+        vi.mocked(filteredQuerySet.limit).mockReturnValue(filteredQuerySet);
+        vi.mocked(filteredQuerySet.offset).mockReturnValue(paginatedQuerySet);
+        vi.mocked(filteredQuerySet.count).mockResolvedValue(5);
+        vi.mocked(paginatedQuerySet.fetch).mockResolvedValue(
+            aQueryResult({
+                items: [
+                    { id: 3, email: 'c@example.com', name: 'C' },
+                    { id: 4, email: 'd@example.com', name: 'D' },
+                ],
+            })
+        );
+        vi.mocked(paginatedQuerySet.count).mockResolvedValue(2);
+
+        currentUserModel = {
+            objects: aManager<UserRecord>({
+                meta: { table: 'users', pk: 'id', columns: { id: 'int', email: 'text', name: 'text' } },
+                query: vi.fn(() => baseQuerySet),
+            }),
+        };
+
+        const view = new UserListCreateView({
+            serializer: UserSerializer,
+            searchFields: ['email'],
+        });
+
+        const response = await view.dispatch(
+            aResourcesRequestContext('GET', 'https://example.test/users?search=example&limit=2&offset=2')
+        );
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual({
+            count: 5,
+            next: '?limit=2&offset=4',
+            previous: '?limit=2&offset=0',
+            results: [
+                { id: 3, email: 'c@example.com', name: 'C' },
+                { id: 4, email: 'd@example.com', name: 'D' },
+            ],
+        });
+        expect(vi.mocked(filteredQuerySet.count)).toHaveBeenCalledOnce();
+        expect(vi.mocked(paginatedQuerySet.count)).not.toHaveBeenCalled();
+    });
+
     it('reads, updates, and deletes an existing record', async () => {
         const querySetDouble = aQuerySet<UserRecord>();
         vi.mocked(querySetDouble.fetchOne).mockResolvedValue({ id: 1, email: 'a@example.com', name: 'A' });

--- a/packages/resources/src/viewset/ModelViewSet.ts
+++ b/packages/resources/src/viewset/ModelViewSet.ts
@@ -212,8 +212,8 @@ export abstract class ModelViewSet<
                 }
             }
 
-            qs = paginator.apply(qs);
-            const resultPromise = qs.fetch();
+            const paginatedQueryset = paginator.apply(qs);
+            const resultPromise = paginatedQueryset.fetch();
             const totalCountPromise = paginator.needsTotalCount()
                 ? qs.count()
                 : Promise.resolve<number | undefined>(undefined);

--- a/packages/resources/src/viewset/tests/ModelViewSet.test.ts
+++ b/packages/resources/src/viewset/tests/ModelViewSet.test.ts
@@ -214,6 +214,42 @@ describe(ModelViewSet, () => {
         expect(vi.mocked(querySetDouble.orderBy)).toHaveBeenCalledWith('-name');
     });
 
+    it('counts the filtered queryset before applying offset pagination', async () => {
+        const filteredQuerySet = aQuerySet<UserRecord>();
+        const paginatedQuerySet = aQuerySet<UserRecord>();
+
+        vi.mocked(querySetDouble.filter).mockReturnValue(filteredQuerySet);
+        vi.mocked(filteredQuerySet.limit).mockReturnValue(filteredQuerySet);
+        vi.mocked(filteredQuerySet.offset).mockReturnValue(paginatedQuerySet);
+        vi.mocked(filteredQuerySet.count).mockResolvedValue(5);
+        vi.mocked(paginatedQuerySet.fetch).mockResolvedValue(
+            aQueryResult({
+                items: [
+                    { id: 3, email: 'c@example.com', name: 'C' },
+                    { id: 4, email: 'd@example.com', name: 'D' },
+                ],
+            })
+        );
+        vi.mocked(paginatedQuerySet.count).mockResolvedValue(2);
+
+        const response = await viewset.list(
+            aResourcesRequestContext('GET', 'https://example.test/users?search=example&limit=2&offset=2')
+        );
+
+        expect(response.status).toBe(200);
+        await expect(response.json()).resolves.toEqual({
+            count: 5,
+            next: '?limit=2&offset=4',
+            previous: '?limit=2&offset=0',
+            results: [
+                { id: 3, email: 'c@example.com', name: 'C' },
+                { id: 4, email: 'd@example.com', name: 'D' },
+            ],
+        });
+        expect(vi.mocked(filteredQuerySet.count)).toHaveBeenCalledOnce();
+        expect(vi.mocked(paginatedQuerySet.count)).not.toHaveBeenCalled();
+    });
+
     it('creates, retrieves, updates, and destroys a resource', async () => {
         vi.mocked(querySetDouble.fetchOne).mockResolvedValue({ id: 1, email: 'user@example.com', name: 'User' });
 


### PR DESCRIPTION
## Summary
- count offset-paginated resources from the filtered queryset before limit/offset are applied
- add regression coverage for `GenericAPIView` and `ModelViewSet` list flows
- include a patch changeset for `@danceroutine/tango-resources`

## Testing
- `pnpm --filter @danceroutine/tango-resources typecheck`
- `pnpm --filter @danceroutine/tango-resources exec vitest run src/view/tests/GenericAPIView.test.ts src/viewset/tests/ModelViewSet.test.ts`

Closes #58