### PR TITLE
feat(orm): add clear and create to m2m managers

### DIFF
--- a/.changeset/fair-parrots-battle.md
+++ b/.changeset/fair-parrots-battle.md
@@ -1,0 +1,7 @@
+---
+'@danceroutine/tango-orm': minor
+---
+
+Add `ManyToManyRelatedManager.clear()` and `create(...)`.
+
+`clear()` removes every join-row membership for one owner and invalidates the related-manager prefetch cache. `create(...)` now persists the related target through its normal model manager and inserts the join-row link inside the same atomic boundary, so target-manager hooks and defaults still run without leaking partial writes when the link step fails.

--- a/docs/reference/orm-query-api.md
+++ b/docs/reference/orm-query-api.md
@@ -169,12 +169,14 @@ Every persisted record returned by the manager carries a related-manager accesso
 ```ts
 const post = await PostModel.objects.getOrThrow(postId);
 
+const featuredTag = await post.tags.create({ name: 'featured' });
 await post.tags.add(tag, featuredTag);
 await post.tags.remove(tag, featuredTag);
 await post.tags.set(featuredTag);
+await post.tags.clear();
 ```
 
-`add(...targets)`, `remove(...targets)`, and `set(...targets)` accept target records, objects that carry the target primary key, or bare primary-key values. `add(...)` is idempotent for duplicate memberships, so repeated links do not raise a duplicate-row error. `set(...)` replaces the current membership with exactly the supplied targets: omitted targets are removed, new targets are added, and duplicate inputs are ignored before Tango diffs the relation set. When one call touches several targets, Tango resolves the target primary keys once and runs the membership write inside one `transaction.atomic(...)` boundary.
+`add(...targets)`, `remove(...targets)`, and `set(...targets)` accept target records, objects that carry the target primary key, or bare primary-key values. `add(...)` is idempotent for duplicate memberships, so repeated links do not raise a duplicate-row error. `set(...)` replaces the current membership with exactly the supplied targets: omitted targets are removed, new targets are added, and duplicate inputs are ignored before Tango diffs the relation set. `clear()` removes every membership row for the current owner without first loading the related targets. `create(input)` delegates to the related model's normal `create(...)` path, then inserts the join-row link inside the same `transaction.atomic(...)` boundary so target-manager hooks and defaults still run without leaking a partially applied relation write.
 
 Use `post.tags.all()` when application code wants to read the linked targets. The returned queryset reads through the join table and follows the standard `QuerySet` contract, so it accepts `filter(...)`, `exclude(...)`, `orderBy(...)`, `select(...)`, `fetch(...)`, `fetchOne(...)`, `count()`, and `exists()`.
 
@@ -185,9 +187,7 @@ const featuredTags = await post.tags.all().filter({ featured: true }).fetch();
 
 `post.tags` remains a related manager even after eager loading. `prefetchRelated('tags')` warms that manager's cache; it does not replace the relation with a plain array on the model instance. This mirrors the Django-style contract that Tango follows for many-to-many accessors.
 
-When `prefetchRelated('tags')` ran in the same fetch, `post.tags.all()` returns the prefetched targets without issuing a follow-up query. The prefetch result is cached on the related manager and a successful `add(...)`, `remove(...)`, or `set(...)` invalidates that cache so the next read returns fresh data. If application code or a serializer needs an array-shaped value, materialize it explicitly from the manager with `await post.tags.all().fetch()`.
-
-Reverse many-to-many access, the `clear()` helper, and `create(...)` on the related manager are tracked on the roadmap for a follow-up release.
+When `prefetchRelated('tags')` ran in the same fetch, `post.tags.all()` returns the prefetched targets without issuing a follow-up query. The prefetch result is cached on the related manager and a successful `add(...)`, `remove(...)`, `set(...)`, `clear()`, or `create(...)` invalidates that cache so the next read returns fresh data. If application code or a serializer needs an array-shaped value, materialize it explicitly from the manager with `await post.tags.all().fetch()`.
 
 ## Transactions
 

--- a/docs/reference/schema-api.md
+++ b/docs/reference/schema-api.md
@@ -324,7 +324,7 @@ The config object supports `field`, `name`, `through`, `throughSourceFieldName`,
 
 The forward many-to-many edge stays `migratable: false` on the owner model because there is still no owner-row column for the collection; DDL for the join rows is owned by the synthesized or explicit through model that appears in migration metadata.
 
-Persisted records returned by the manager carry a related-manager accessor named after the published relation. For the example above, `post.tags.add(tag, featuredTag)`, `post.tags.remove(tag)`, `post.tags.set(featuredTag)`, `post.tags.clear()`, `post.tags.create({ name: 'featured' })`, and `post.tags.all()` insert, delete, replace, clear, create-and-link, and read membership rows through the resolved through model. `add(...)`, `remove(...)`, and `set(...)` accept one or more targets, and duplicate `add(...)` calls are ignored. `create(...)` follows the related model's normal manager create path before attaching the new target row to the join table inside one atomic write. The accessor stays a manager even after `prefetchRelated('tags')`; eager loading only warms its cache. The accessor is documented in the [ORM query API reference](/reference/orm-query-api).
+Persisted records returned by the manager carry a related-manager accessor named after the published relation. For the example above, Tango exposes `post.tags` rather than a raw array field. That accessor and its read and write methods are documented in the [ORM query API reference](/reference/orm-query-api).
 
 The object form is the preferred public relation-decorator contract. The older positional schema overloads remain available for compatibility.
 

--- a/docs/reference/schema-api.md
+++ b/docs/reference/schema-api.md
@@ -324,9 +324,7 @@ The config object supports `field`, `name`, `through`, `throughSourceFieldName`,
 
 The forward many-to-many edge stays `migratable: false` on the owner model because there is still no owner-row column for the collection; DDL for the join rows is owned by the synthesized or explicit through model that appears in migration metadata.
 
-Persisted records returned by the manager carry a related-manager accessor named after the published relation. For the example above, `post.tags.add(tag, featuredTag)`, `post.tags.remove(tag)`, `post.tags.set(featuredTag)`, and `post.tags.all()` insert, delete, replace, and read membership rows through the resolved through model. `add(...)`, `remove(...)`, and `set(...)` accept one or more targets, and duplicate `add(...)` calls are ignored. The accessor stays a manager even after `prefetchRelated('tags')`; eager loading only warms its cache. The accessor is documented in the [ORM query API reference](/reference/orm-query-api).
-
-Reverse many-to-many naming, the bulk `set(...)` helper, the `clear()` helper, and `create(...)` on the related manager remain roadmap work.
+Persisted records returned by the manager carry a related-manager accessor named after the published relation. For the example above, `post.tags.add(tag, featuredTag)`, `post.tags.remove(tag)`, `post.tags.set(featuredTag)`, `post.tags.clear()`, `post.tags.create({ name: 'featured' })`, and `post.tags.all()` insert, delete, replace, clear, create-and-link, and read membership rows through the resolved through model. `add(...)`, `remove(...)`, and `set(...)` accept one or more targets, and duplicate `add(...)` calls are ignored. `create(...)` follows the related model's normal manager create path before attaching the new target row to the join table inside one atomic write. The accessor stays a manager even after `prefetchRelated('tags')`; eager loading only warms its cache. The accessor is documented in the [ORM query API reference](/reference/orm-query-api).
 
 The object form is the preferred public relation-decorator contract. The older positional schema overloads remain available for compatibility.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,7 +14,7 @@ The next relation work focuses on related-row projection: fetching related field
 
 ### Many-to-many Django-parity follow-ups
 
-Many-to-many hydration and join-row writes now share the resolved through-table metadata path, and persisted records expose a related manager that supports `add(...)`, `remove(...)`, and `all()` against the active runtime client. Follow-up work includes reverse-side naming for many-to-many, inverse edges in the resolved graph, the bulk `set(...)` helper, the `clear()` helper, `create(...)` on the related manager, and richer symmetry helpers beyond the current join-row link helpers.
+Many-to-many hydration and join-row writes now share the resolved through-table metadata path, and persisted records expose a related manager that supports `add(...)`, `remove(...)`, `set(...)`, `clear()`, `create(...)`, and `all()` against the active runtime client. Follow-up work includes reverse-side naming for many-to-many, inverse edges in the resolved graph, and richer symmetry helpers beyond the current join-row link helpers.
 
 ### Transaction ergonomics beyond `atomic(...)`
 

--- a/docs/topics/orm-and-querysets.md
+++ b/docs/topics/orm-and-querysets.md
@@ -235,7 +235,18 @@ firstUser?.posts[0]?.comments[0]?.body;
 
 In that form, a user with no posts still receives `posts: []`, while a post with no comments receives `comments: []`.
 
-Persisted records returned by the manager carry a related-manager accessor for each many-to-many relation declared on the source model. The accessor is named after the published forward relation name, so a field such as `tagIds: t.manyToMany(..., { name: 'tags' })` exposes `post.tags.add(...)`, `post.tags.remove(...)`, `post.tags.set(...)`, `post.tags.clear()`, `post.tags.create(...)`, and `post.tags.all()`. `add(...)`, `remove(...)`, and `set(...)` all accept one or more targets, and duplicate links are ignored so repeated `add(...)` calls stay idempotent. `set(...)` replaces the membership with exactly the supplied targets, `clear()` removes every linked target for that owner, and `create(...)` follows the target model's normal `create(...)` path before attaching the new row to the relation in the same atomic write boundary. The accessor is attached non-enumerably so persistence-style helpers such as `JSON.stringify(post)` continue to focus on the persisted columns.
+Persisted records returned by the manager carry a related-manager accessor for each many-to-many relation declared on the source model. The accessor is named after the published forward relation name, so a field such as `tagIds: t.manyToMany(..., { name: 'tags' })` exposes `post.tags`. The accessor is attached non-enumerably so persistence-style helpers such as `JSON.stringify(post)` continue to focus on the persisted columns.
+
+#### Many-to-many related managers
+
+The many-to-many related manager owns both membership writes and membership reads.
+
+- `add(...targets)` links one or more existing targets. Duplicate links are ignored, so repeated `add(...)` calls stay idempotent.
+- `remove(...targets)` unlinks one or more existing targets from the current owner.
+- `set(...targets)` replaces the membership with exactly the supplied targets.
+- `clear()` removes every linked target for the current owner.
+- `create(input)` follows the target model's normal `create(...)` path, then links the new target row inside the same atomic write boundary.
+- `all()` returns a queryset scoped to the related targets for the current owner.
 
 ```ts
 const post = await PostModel.objects.getOrThrow(postId);

--- a/docs/topics/orm-and-querysets.md
+++ b/docs/topics/orm-and-querysets.md
@@ -235,19 +235,21 @@ firstUser?.posts[0]?.comments[0]?.body;
 
 In that form, a user with no posts still receives `posts: []`, while a post with no comments receives `comments: []`.
 
-Persisted records returned by the manager carry a related-manager accessor for each many-to-many relation declared on the source model. The accessor is named after the published forward relation name, so a field such as `tagIds: t.manyToMany(..., { name: 'tags' })` exposes `post.tags.add(...)`, `post.tags.remove(...)`, `post.tags.set(...)`, and `post.tags.all()`. `add(...)`, `remove(...)`, and `set(...)` all accept one or more targets, and duplicate links are ignored so repeated `add(...)` calls stay idempotent. `set(...)` replaces the membership with exactly the supplied targets. The accessor is attached non-enumerably so persistence-style helpers such as `JSON.stringify(post)` continue to focus on the persisted columns.
+Persisted records returned by the manager carry a related-manager accessor for each many-to-many relation declared on the source model. The accessor is named after the published forward relation name, so a field such as `tagIds: t.manyToMany(..., { name: 'tags' })` exposes `post.tags.add(...)`, `post.tags.remove(...)`, `post.tags.set(...)`, `post.tags.clear()`, `post.tags.create(...)`, and `post.tags.all()`. `add(...)`, `remove(...)`, and `set(...)` all accept one or more targets, and duplicate links are ignored so repeated `add(...)` calls stay idempotent. `set(...)` replaces the membership with exactly the supplied targets, `clear()` removes every linked target for that owner, and `create(...)` follows the target model's normal `create(...)` path before attaching the new row to the relation in the same atomic write boundary. The accessor is attached non-enumerably so persistence-style helpers such as `JSON.stringify(post)` continue to focus on the persisted columns.
 
 ```ts
 const post = await PostModel.objects.getOrThrow(postId);
 
+const featuredTag = await post.tags.create({ name: 'featured' });
 await post.tags.add(tag, featuredTag);
 await post.tags.set(featuredTag);
 const linked = await post.tags.all().fetch();
+await post.tags.clear();
 ```
 
 `post.tags` stays a related manager on the model instance. `prefetchRelated('tags')` only warms that manager's cache, so application code still reads through `post.tags.all()` rather than expecting `post.tags` itself to become an array.
 
-When `prefetchRelated('tags')` ran in the same fetch, `post.tags.all()` reads from the prefetched cache. A successful `add(...)`, `remove(...)`, or `set(...)` invalidates that cache so the next read returns fresh data. If an API response or page helper needs an array-shaped value, materialize it explicitly with `await post.tags.all().fetch()`.
+When `prefetchRelated('tags')` ran in the same fetch, `post.tags.all()` reads from the prefetched cache. A successful `add(...)`, `remove(...)`, `set(...)`, `clear()`, or `create(...)` invalidates that cache so the next read returns fresh data. If an API response or page helper needs an array-shaped value, materialize it explicitly with `await post.tags.all().fetch()`.
 
 Forward many-to-many prefetch path typing comes from the generated relation registry. Without generated relation typing, the older explicit target-model generic still only describes reverse `hasMany` paths even though the runtime can execute the many-to-many prefetch.
 

--- a/packages/orm/src/manager/ModelManager.ts
+++ b/packages/orm/src/manager/ModelManager.ts
@@ -408,6 +408,15 @@ export class ModelManager<TModelRow extends Record<string, unknown>, TSourceMode
             adapter: this.adapter,
             sqlSafetyAdapter,
             targetExecutorProvider: () => this.resolveTargetExecutor<TTarget>(relation.targetModelKey),
+            createTarget: async (input) => {
+                const targetManager = this.resolveTargetManager<TTarget>(relation.targetModelKey);
+                if (!targetManager) {
+                    throw new Error(
+                        `Cannot resolve a target manager for relation '${relationName}' on '${this.model.metadata.name}'.`
+                    );
+                }
+                return targetManager.create(input);
+            },
             runAtomic: (work) => TransactionEngine.forRuntime(this.runtime).atomic(() => work()),
         });
     }
@@ -527,11 +536,21 @@ export class ModelManager<TModelRow extends Record<string, unknown>, TSourceMode
     private resolveTargetExecutor<TTarget extends Record<string, unknown>>(
         targetModelKey: string
     ): QueryExecutor<TTarget> | null {
-        const targetManager = this.resolveManagerForModelKey(targetModelKey);
+        const targetManager = this.resolveTargetManager<TTarget>(targetModelKey);
         if (!targetManager) {
             return null;
         }
         return (targetManager as unknown as { queryExecutor: QueryExecutor<TTarget> }).queryExecutor;
+    }
+
+    private resolveTargetManager<TTarget extends Record<string, unknown>>(
+        targetModelKey: string
+    ): ModelManager<TTarget> | null {
+        const targetManager = this.resolveManagerForModelKey(targetModelKey);
+        if (!targetManager) {
+            return null;
+        }
+        return targetManager as unknown as ModelManager<TTarget>;
     }
 
     private requireManyToManyEdge(relationName: string): NonNullable<TableMeta['relations']>[string] {

--- a/packages/orm/src/manager/relations/ManyToManyRelatedManager.ts
+++ b/packages/orm/src/manager/relations/ManyToManyRelatedManager.ts
@@ -51,6 +51,8 @@ export interface ManyToManyRelatedManagerCreateInputs<TTarget extends Record<str
     sqlSafetyAdapter: OrmSqlSafetyAdapter;
     /** Lazy resolver returning the target model's {@link QueryExecutor}. */
     targetExecutorProvider: () => QueryExecutor<TTarget> | null;
+    /** Model-manager-backed create path for new target records. */
+    createTarget: (input: Partial<TTarget>) => Promise<TTarget>;
     /** Internal transaction runner used for multi-target membership writes. */
     runAtomic: <T>(work: () => Promise<T>) => Promise<T>;
 }
@@ -62,6 +64,7 @@ interface ManyToManyRelatedManagerInternalInputs<TTarget extends Record<string, 
     targetPrimaryKeyField: string;
     throughTableManager: ThroughTableManager;
     targetExecutorProvider: () => QueryExecutor<TTarget> | null;
+    createTarget: (input: Partial<TTarget>) => Promise<TTarget>;
     runAtomic: <T>(work: () => Promise<T>) => Promise<T>;
 }
 
@@ -76,12 +79,14 @@ interface ManyToManyRelatedManagerInternalInputs<TTarget extends Record<string, 
  *
  * Prefetched memberships seed an internal cache that the queryset returned
  * from `all()` short-circuits to without re-querying. Mutations through
- * `add`, `remove`, and `set` invalidate the cache so subsequent reads
- * observe the updated membership. `set(...)` applies Django-shaped
- * replacement semantics:
+ * `add`, `remove`, `set`, `clear`, and `create` invalidate the cache so
+ * subsequent reads observe the updated membership. `set(...)` applies
+ * Django-shaped replacement semantics:
  * it diffs the current relation membership against the supplied targets,
  * removes any missing links, and inserts any new links inside one atomic
- * write boundary.
+ * write boundary. `clear()` removes every join row for the owner, and
+ * `create(...)` persists a new target row plus its join-row link inside one
+ * atomic boundary.
  *
  * @template TTarget - The persisted target record shape returned by `all()`.
  */
@@ -118,7 +123,7 @@ export class ManyToManyRelatedManager<TTarget extends Record<string, unknown>> {
      * The factory derives the join-table descriptor from the relation edge and
      * through-model fields, wires a {@link ThroughTableManager} against the
      * supplied runtime-bound client, and returns a manager whose `add`,
-     * `remove`, and `all` methods enroll in any active
+     * `remove`, `clear`, `create`, and `all` methods enroll in any active
      * `transaction.atomic(...)` boundary.
      */
     static create<TTarget extends Record<string, unknown>>(
@@ -139,6 +144,7 @@ export class ManyToManyRelatedManager<TTarget extends Record<string, unknown>> {
             targetPrimaryKeyField: inputs.relation.targetPrimaryKey,
             throughTableManager,
             targetExecutorProvider: inputs.targetExecutorProvider,
+            createTarget: inputs.createTarget,
             runAtomic: inputs.runAtomic,
         });
     }
@@ -183,6 +189,32 @@ export class ManyToManyRelatedManager<TTarget extends Record<string, unknown>> {
     }
 
     /**
+     * Delete every join-table row linked to the owning record and invalidate
+     * any prefetched membership cache after the delete succeeds.
+     */
+    async clear(): Promise<void> {
+        await this.inputs.throughTableManager.deleteAllLinksForOwner(this.inputs.ownerPrimaryKey);
+        this.invalidateCache();
+    }
+
+    /**
+     * Create a new target record through the related model's manager and link
+     * it to the owning record inside one `transaction.atomic(...)` boundary.
+     * This preserves target-manager hooks and defaults while preventing a
+     * created target row from leaking if the join-row insert fails.
+     */
+    async create(input: Partial<TTarget>): Promise<TTarget> {
+        const created = await this.inputs.runAtomic(async () => {
+            const target = await this.inputs.createTarget(input);
+            const targetPrimaryKey = this.resolveTargetPrimaryKey(target);
+            await this.insertTargetPrimaryKeys([targetPrimaryKey]);
+            return target;
+        });
+        this.invalidateCache();
+        return created;
+    }
+
+    /**
      * Replace the current relation membership with exactly the supplied
      * targets. Duplicate inputs are collapsed before diffing against the
      * current through-table rows, so repeated values do not trigger extra
@@ -224,8 +256,8 @@ export class ManyToManyRelatedManager<TTarget extends Record<string, unknown>> {
      * Return a {@link QuerySet} for the related target rows of this many-to-many
      * relation. When the relation was already loaded by `prefetchRelated(...)`,
      * the first `fetch()` resolves with the cached materialization without
-     * re-querying. Mutating the membership through `add`/`remove`/`set`
-     * invalidates that cache.
+     * re-querying. Mutating the membership through `add`/`remove`/`set`/
+     * `clear`/`create` invalidates that cache.
      */
     all(): QuerySet<TTarget> {
         const executor = this.inputs.targetExecutorProvider();
@@ -252,7 +284,7 @@ export class ManyToManyRelatedManager<TTarget extends Record<string, unknown>> {
 
     /**
      * Drop any cached prefetch results. Mutating helpers call this so reads
-     * after an `add`/`remove`/`set` go back to the database.
+     * after an `add`/`remove`/`set`/`clear`/`create` go back to the database.
      */
     invalidateCache(): void {
         this.prefetchCache = null;

--- a/packages/orm/src/manager/relations/internal/ThroughTableManager.ts
+++ b/packages/orm/src/manager/relations/internal/ThroughTableManager.ts
@@ -194,4 +194,25 @@ export class ThroughTableManager {
         );
         await this.client.query(compiled.sql, compiled.params);
     }
+
+    /**
+     * Delete every join-table row linked to one owner record. Used by
+     * `ManyToManyRelatedManager.clear()` so the related manager can clear a
+     * relation without first loading the current target ids.
+     */
+    async deleteAllLinksForOwner(ownerPrimaryKey: unknown): Promise<void> {
+        const validated = this.sqlSafetyAdapter.validate({
+            kind: SqlPlanKind.SELECT,
+            meta: {
+                table: this.descriptor.table,
+                pk: this.descriptor.primaryKey,
+                columns: this.descriptor.columns,
+            },
+            filterKeys: [this.descriptor.sourceColumn],
+        });
+        const sourceColumn = validated.filterKeys[this.descriptor.sourceColumn]!.field;
+        const placeholder = this.adapter.placeholders.at(1);
+        const sql = `DELETE FROM ${validated.meta.table} WHERE ${sourceColumn} = ${placeholder}`;
+        await this.client.query(sql, [ownerPrimaryKey]);
+    }
 }

--- a/packages/orm/src/manager/relations/internal/tests/ThroughTableManager.test.ts
+++ b/packages/orm/src/manager/relations/internal/tests/ThroughTableManager.test.ts
@@ -183,6 +183,25 @@ describe(ThroughTableManager, () => {
         ]);
     });
 
+    it('compiles parameterized DELETE statements when clearing all links for one owner', async () => {
+        const { client, calls } = buildHarness();
+        const manager = new ThroughTableManager(
+            client,
+            new MutationCompiler(postgresAdapter),
+            ThroughTableManager.buildLinkDescriptor(persistedRelation, throughFields),
+            postgresAdapter
+        );
+
+        await manager.deleteAllLinksForOwner(9);
+
+        expect(calls).toEqual([
+            {
+                sql: 'DELETE FROM m2m_post_tags WHERE postId = $1',
+                params: [9],
+            },
+        ]);
+    });
+
     it('selects target ids linked to the supplied owner via the join table', async () => {
         const { client, calls } = buildHarness(async () => ({
             rows: [{ target_id: 10 }, { target_id: 11 }, { target_id: null }],
@@ -220,6 +239,25 @@ describe(ThroughTableManager, () => {
             {
                 sql: 'SELECT tagId AS target_id FROM m2m_post_tags WHERE postId = ?',
                 params: [3],
+            },
+        ]);
+    });
+
+    it('uses positional placeholders for owner-wide deletes when the dialect is sqlite', async () => {
+        const { client, calls } = buildHarness();
+        const manager = new ThroughTableManager(
+            client,
+            new MutationCompiler(sqliteAdapter),
+            ThroughTableManager.buildLinkDescriptor(persistedRelation, throughFields),
+            sqliteAdapter
+        );
+
+        await manager.deleteAllLinksForOwner(4);
+
+        expect(calls).toEqual([
+            {
+                sql: 'DELETE FROM m2m_post_tags WHERE postId = ?',
+                params: [4],
             },
         ]);
     });

--- a/packages/orm/src/manager/relations/tests/ManyToManyRelatedManager.test.ts
+++ b/packages/orm/src/manager/relations/tests/ManyToManyRelatedManager.test.ts
@@ -78,9 +78,11 @@ describe(ManyToManyRelatedManager, () => {
                     insertLinks: async () => {},
                     deleteLink: async () => {},
                     deleteLinks: async () => {},
+                    deleteAllLinksForOwner: async () => {},
                     selectTargetIdsForOwner: async () => [],
                 } as unknown as ConstructorParameters<typeof ManyToManyRelatedManager>[0]['throughTableManager'],
                 targetExecutorProvider: () => null,
+                createTarget: async () => ({ id: 1 } as { id: number }),
                 runAtomic: async (work) => work(),
             });
             await expect(manager.add(true as unknown as { id: number })).rejects.toThrow(
@@ -138,6 +140,90 @@ describe(ManyToManyRelatedManager, () => {
             manager.primePrefetchCache([{ id: 7 }]);
             await manager.remove(7);
             expect(manager.snapshotCache()).toBeNull();
+        });
+    });
+
+    describe(ManyToManyRelatedManager.prototype.clear, () => {
+        it('deletes every link for the owning record', async () => {
+            const { manager, deleteAllLinksForOwner, runAtomic } = aManyToManyRelatedManager<{ id: number }>();
+
+            await manager.clear();
+
+            expect(deleteAllLinksForOwner).toHaveBeenCalledWith(7);
+            expect(runAtomic).not.toHaveBeenCalled();
+        });
+
+        it('invalidates the prefetch cache after a successful clear', async () => {
+            const { manager } = aManyToManyRelatedManager<{ id: number }>();
+            manager.primePrefetchCache([{ id: 7 }]);
+
+            await manager.clear();
+
+            expect(manager.snapshotCache()).toBeNull();
+        });
+    });
+
+    describe(ManyToManyRelatedManager.prototype.create, () => {
+        it('creates the target record and links it inside one atomic boundary', async () => {
+            const events: string[] = [];
+            const { manager, createTarget, insertLink, runAtomic } = aManyToManyRelatedManager<{
+                id: number;
+                name: string;
+            }>({
+                createTarget: async (input) => {
+                    events.push(`create:${String(input.name)}`);
+                    return { id: 23, name: String(input.name) };
+                },
+                insertLink: async (_ownerPrimaryKey, targetPrimaryKey) => {
+                    events.push(`link:${String(targetPrimaryKey)}`);
+                },
+            });
+
+            const created = await manager.create({ name: 'Featured' });
+
+            expect(runAtomic).toHaveBeenCalledTimes(1);
+            expect(createTarget).toHaveBeenCalledWith({ name: 'Featured' });
+            expect(insertLink).toHaveBeenCalledWith(7, 23, { onDuplicate: 'ignore' });
+            expect(created).toEqual({ id: 23, name: 'Featured' });
+            expect(events).toEqual(['create:Featured', 'link:23']);
+        });
+
+        it('invalidates the prefetch cache after a successful create', async () => {
+            const { manager } = aManyToManyRelatedManager<{ id: number }>({
+                createTarget: async () => ({ id: 29 }),
+            });
+            manager.primePrefetchCache([{ id: 7 }]);
+
+            await manager.create({});
+
+            expect(manager.snapshotCache()).toBeNull();
+        });
+
+        it('preserves the cache when target creation fails', async () => {
+            const { manager, insertLink } = aManyToManyRelatedManager<{ id: number }>({
+                createTarget: async () => {
+                    throw new Error('create failed');
+                },
+            });
+            manager.primePrefetchCache([{ id: 7 }]);
+
+            await expect(manager.create({})).rejects.toThrow('create failed');
+
+            expect(insertLink).not.toHaveBeenCalled();
+            expect(manager.snapshotCache()).toEqual([{ id: 7 }]);
+        });
+
+        it('throws when the created target record does not expose the configured primary key', async () => {
+            const { manager, insertLink } = aManyToManyRelatedManager<{ id: number }>({
+                targetPrimaryKeyField: 'id',
+                createTarget: async () => ({ slug: 'missing-id' } as unknown as { id: number }),
+            });
+
+            await expect(manager.create({})).rejects.toThrow(
+                /Cannot resolve target primary key 'id' for relation 'tags' on 'Post'/
+            );
+
+            expect(insertLink).not.toHaveBeenCalled();
         });
     });
 

--- a/packages/orm/src/manager/tests/attachManyToManyRelatedManagers.test.ts
+++ b/packages/orm/src/manager/tests/attachManyToManyRelatedManagers.test.ts
@@ -64,6 +64,8 @@ describe('ModelManager many-to-many related-manager attachment', () => {
         type PostRecord = MaterializedModelRecord<typeof PostModel.schema>;
 
         expectTypeOf<PostRecord['tags']>().toMatchTypeOf<ManyToManyRelatedManager<{ id: number }>>();
+        expectTypeOf<Parameters<PostRecord['tags']['create']>>().toEqualTypeOf<[Partial<{ id: number }>]>();
+        expectTypeOf<Awaited<ReturnType<PostRecord['tags']['create']>>>().toEqualTypeOf<{ id: number }>();
     });
 
     it('skips relations that already carry a hydration-assigned value on the record', () => {

--- a/packages/orm/src/manager/tests/registerModelObjects.test.ts
+++ b/packages/orm/src/manager/tests/registerModelObjects.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { z } from 'zod';
 import { setupTestTangoRuntime } from '@danceroutine/tango-testing';
@@ -358,6 +361,50 @@ describe(registerModelObjects, () => {
         }
     });
 
+    it('throws from create() when the target model has no registered objects manager', async () => {
+        const TagModel = Model({
+            namespace: 'test',
+            name: 'Tag',
+            schema: z.object({
+                id: t.primaryKey(z.number().int()),
+            }),
+        });
+        const PostModel = Model({
+            namespace: 'test',
+            name: 'Post',
+            schema: z.object({
+                id: t.primaryKey(z.number().int()),
+                tags: t.manyToMany(TagModel),
+            }),
+        });
+        const tagsManager = PostModel.objects.createManyToManyRelatedManager<{ id: number }>('tags', 1);
+        const registry = ModelRegistry.getOwner(PostModel);
+        const fakeModel = { metadata: { key: TagModel.metadata.key }, schema: { parse: () => ({}) } };
+        const getByKeySpy = vi
+            .spyOn(registry, 'getByKey')
+            .mockReturnValue(fakeModel as unknown as ReturnType<typeof registry.getByKey>);
+        const runtime = getTangoRuntime();
+        const client = {
+            query: vi.fn(async (_sql: string, _params?: readonly unknown[]) => ({ rows: [] as never[] })),
+            begin: vi.fn(async () => {}),
+            commit: vi.fn(async () => {}),
+            rollback: vi.fn(async () => {}),
+            createSavepoint: vi.fn(async () => {}),
+            releaseSavepoint: vi.fn(async () => {}),
+            rollbackToSavepoint: vi.fn(async () => {}),
+            close: vi.fn(async () => {}),
+        };
+        const release = vi.fn(async () => {});
+        const leaseSpy = vi.spyOn(runtime, 'leaseTransactionClient').mockResolvedValue({ client, release });
+
+        try {
+            await expect(tagsManager.create({ id: 7 })).rejects.toThrow(/Cannot resolve a target manager/);
+        } finally {
+            leaseSpy.mockRestore();
+            getByKeySpy.mockRestore();
+        }
+    });
+
     it('adds and removes many-to-many links for implicit join tables through the related manager', async () => {
         const TagModel = Model({
             namespace: 'test',
@@ -411,6 +458,110 @@ describe(registerModelObjects, () => {
             expect(batchedSql).toContain('1,3,5');
         } finally {
             leaseSpy.mockRestore();
+        }
+    });
+
+    it('creates, links, and clears many-to-many rows through the runtime-backed related manager', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'tango-m2m-create-clear-'));
+
+        try {
+            await setupTestTangoRuntime({ sqliteFilename: join(tempDir, 'runtime.sqlite') });
+
+            const TagModel = Model({
+                namespace: 'test',
+                name: 'Tag',
+                schema: z.object({
+                    id: t.primaryKey(z.number().int()),
+                    name: z.string(),
+                }),
+            });
+            const PostModel = Model({
+                namespace: 'test',
+                name: 'Post',
+                schema: z.object({
+                    id: t.primaryKey(z.number().int()),
+                    title: z.string(),
+                    tags: t.manyToMany(TagModel),
+                }),
+            });
+
+            const relation = PostModel.objects.meta.relations?.tags;
+            expect(relation?.kind).toBe('manyToMany');
+            expect(relation?.throughTable).toBeDefined();
+            expect(relation?.throughSourceKey).toBeDefined();
+            expect(relation?.throughTargetKey).toBeDefined();
+
+            const client = await getTangoRuntime().getClient();
+            await client.query('CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT)');
+            await client.query('CREATE TABLE tags (id INTEGER PRIMARY KEY, name TEXT)');
+            await client.query(
+                `CREATE TABLE ${relation!.throughTable} (
+                    id INTEGER PRIMARY KEY,
+                    ${relation!.throughSourceKey} INTEGER NOT NULL,
+                    ${relation!.throughTargetKey} INTEGER NOT NULL,
+                    UNIQUE (${relation!.throughSourceKey}, ${relation!.throughTargetKey})
+                )`
+            );
+
+            const post = await PostModel.objects.create({ id: 1, title: 'Hello' });
+            expect(ManyToManyRelatedManager.isManyToManyRelatedManager(post.tags)).toBe(true);
+
+            post.tags.primePrefetchCache([{ id: 99, name: 'stale' }]);
+            const created = await post.tags.create({ id: 2, name: 'tango' });
+
+            expect(created).toEqual({ id: 2, name: 'tango' });
+            expect(post.tags.snapshotCache()).toBeNull();
+
+            const linked = await post.tags.all().orderBy('id').fetch();
+            expect(linked.results).toEqual([{ id: 2, name: 'tango' }]);
+
+            post.tags.primePrefetchCache([{ id: 2, name: 'tango' }]);
+            await post.tags.clear();
+
+            expect(post.tags.snapshotCache()).toBeNull();
+            const remaining = await post.tags.all().fetch();
+            expect(remaining.results).toEqual([]);
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('rolls back the created target when the follow-up join insert fails', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'tango-m2m-create-rollback-'));
+
+        try {
+            await setupTestTangoRuntime({ sqliteFilename: join(tempDir, 'runtime.sqlite') });
+
+            const TagModel = Model({
+                namespace: 'test',
+                name: 'Tag',
+                schema: z.object({
+                    id: t.primaryKey(z.number().int()),
+                    name: z.string(),
+                }),
+            });
+            const PostModel = Model({
+                namespace: 'test',
+                name: 'Post',
+                schema: z.object({
+                    id: t.primaryKey(z.number().int()),
+                    title: z.string(),
+                    tags: t.manyToMany(TagModel),
+                }),
+            });
+
+            const client = await getTangoRuntime().getClient();
+            await client.query('CREATE TABLE posts (id INTEGER PRIMARY KEY, title TEXT)');
+            await client.query('CREATE TABLE tags (id INTEGER PRIMARY KEY, name TEXT)');
+
+            const post = await PostModel.objects.create({ id: 1, title: 'Rollback' });
+
+            await expect(post.tags.create({ id: 5, name: 'transient' })).rejects.toThrow();
+
+            const tags = await TagModel.objects.all().fetch();
+            expect(tags.results).toEqual([]);
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
         }
     });
 });

--- a/packages/testing/src/mocks/aManyToManyRelatedManager.ts
+++ b/packages/testing/src/mocks/aManyToManyRelatedManager.ts
@@ -25,7 +25,9 @@ export interface ManyToManyRelatedManagerFixtureOverrides<TTarget extends Record
     insertLinks?: (ownerPrimaryKey: unknown, targetPrimaryKeys: readonly unknown[]) => Promise<void>;
     deleteLink?: (ownerPrimaryKey: unknown, targetPrimaryKey: unknown) => Promise<void>;
     deleteLinks?: (ownerPrimaryKey: unknown, targetPrimaryKeys: readonly unknown[]) => Promise<void>;
+    deleteAllLinksForOwner?: (ownerPrimaryKey: unknown) => Promise<void>;
     selectTargetIdsForOwner?: (ownerPrimaryKey: unknown) => Promise<readonly (string | number)[]>;
+    createTarget?: (input: Partial<TTarget>) => Promise<TTarget>;
     runAtomic?: <T>(work: () => Promise<T>) => Promise<T>;
 }
 
@@ -40,7 +42,9 @@ export interface ManyToManyRelatedManagerFixture<TTarget extends Record<string, 
     insertLinks: ReturnType<typeof vi.fn>;
     deleteLink: ReturnType<typeof vi.fn>;
     deleteLinks: ReturnType<typeof vi.fn>;
+    deleteAllLinksForOwner: ReturnType<typeof vi.fn>;
     selectTargetIdsForOwner: ReturnType<typeof vi.fn>;
+    createTarget: ReturnType<typeof vi.fn>;
     runAtomic: ReturnType<typeof vi.fn>;
 }
 
@@ -57,8 +61,15 @@ export function aManyToManyRelatedManager<TTarget extends Record<string, unknown
     const insertLinks = vi.fn(overrides.insertLinks ?? (async () => {}));
     const deleteLink = vi.fn(overrides.deleteLink ?? (async () => {}));
     const deleteLinks = vi.fn(overrides.deleteLinks ?? (async () => {}));
+    const deleteAllLinksForOwner = vi.fn(overrides.deleteAllLinksForOwner ?? (async () => {}));
     const selectTargetIdsForOwner = vi.fn(
         overrides.selectTargetIdsForOwner ?? (async (): Promise<readonly (string | number)[]> => [])
+    );
+    const createTarget = vi.fn(
+        overrides.createTarget ??
+            (async (input: Partial<TTarget>) => {
+                return input as TTarget;
+            })
     );
     const runAtomicImpl: ManagerConstructorInputs['runAtomic'] =
         overrides.runAtomic ?? (async <T>(work: () => Promise<T>) => work());
@@ -69,6 +80,7 @@ export function aManyToManyRelatedManager<TTarget extends Record<string, unknown
         insertLinks,
         deleteLink,
         deleteLinks,
+        deleteAllLinksForOwner,
         selectTargetIdsForOwner,
     } as unknown as ManagerConstructorInputs['throughTableManager'];
 
@@ -80,6 +92,7 @@ export function aManyToManyRelatedManager<TTarget extends Record<string, unknown
         throughTableManager,
         targetExecutorProvider: () =>
             overrides.targetExecutor === undefined ? ({} as QueryExecutor<TTarget>) : overrides.targetExecutor,
+        createTarget,
         runAtomic: runAtomicSpy as ManagerConstructorInputs['runAtomic'],
     });
 
@@ -89,7 +102,9 @@ export function aManyToManyRelatedManager<TTarget extends Record<string, unknown
         insertLinks,
         deleteLink,
         deleteLinks,
+        deleteAllLinksForOwner,
         selectTargetIdsForOwner,
+        createTarget,
         runAtomic: runAtomicSpy,
     };
 }

--- a/packages/testing/src/mocks/tests/aManyToManyRelatedManager.test.ts
+++ b/packages/testing/src/mocks/tests/aManyToManyRelatedManager.test.ts
@@ -74,6 +74,19 @@ describe(aManyToManyRelatedManager, () => {
         expect(runAtomic).toHaveBeenCalledTimes(2);
     });
 
+    it('uses the default clear and createTarget spies when no overrides are supplied', async () => {
+        const { manager, deleteAllLinksForOwner, createTarget } = aManyToManyRelatedManager<{
+            id: number;
+            name?: string;
+        }>();
+
+        await manager.clear();
+        const created = await createTarget({ name: 'tagged' });
+
+        expect(deleteAllLinksForOwner).toHaveBeenCalledWith(7);
+        expect(created).toEqual({ name: 'tagged' });
+    });
+
     it('routes all().fetch through the default selectTargetIdsForOwner spy when no override is supplied', async () => {
         const targetExecutor = aQueryExecutor<{ id: number }>({
             meta: { table: 'tags', pk: 'id', columns: { id: 'int' } },

--- a/packages/testing/src/mocks/tests/aManyToManyRelatedManager.test.ts
+++ b/packages/testing/src/mocks/tests/aManyToManyRelatedManager.test.ts
@@ -81,10 +81,11 @@ describe(aManyToManyRelatedManager, () => {
         }>();
 
         await manager.clear();
-        const created = await createTarget({ name: 'tagged' });
+        const created = await manager.create({ id: 99, name: 'tagged' });
 
         expect(deleteAllLinksForOwner).toHaveBeenCalledWith(7);
-        expect(created).toEqual({ name: 'tagged' });
+        expect(createTarget).toHaveBeenCalledWith({ id: 99, name: 'tagged' });
+        expect(created).toEqual({ id: 99, name: 'tagged' });
     });
 
     it('routes all().fetch through the default selectTargetIdsForOwner spy when no override is supplied', async () => {


### PR DESCRIPTION
## Summary
- add `clear()` and `create(...)` to `ManyToManyRelatedManager`
- support owner-wide join-row deletes and create-and-link flows through the runtime-backed manager path
- document the expanded many-to-many manager surface and ship a minor changeset

## Testing
- `pnpm build:test:integration`
- `pnpm --filter @danceroutine/tango-orm typecheck`
- `pnpm --filter @danceroutine/tango-testing typecheck`
- `pnpm --filter @danceroutine/tango-orm exec vitest run src/manager/relations/internal/tests/ThroughTableManager.test.ts src/manager/relations/tests/ManyToManyRelatedManager.test.ts src/manager/tests/attachManyToManyRelatedManagers.test.ts src/manager/tests/registerModelObjects.test.ts`

Closes #42