### PR TITLE
fix(codegen): tighten host-specific scaffolds

### DIFF
--- a/.changeset/shiny-crabs-care.md
+++ b/.changeset/shiny-crabs-care.md
@@ -1,0 +1,5 @@
+---
+'@danceroutine/tango-codegen': patch
+---
+
+Clarify scaffold ownership in `tango new`, keep each host scaffold framework-specific, and add a fresh-app smoke that validates generated projects through local install, typecheck, and Tango setup commands.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "test:integration:sqlite": "TANGO_TEST_DIALECT=sqlite pnpm test:integration",
         "test:integration:postgres": "TANGO_TEST_DIALECT=postgres TANGO_DB_ADAPTER=postgres TANGO_DATABASE_URL=postgres://postgres:postgres@localhost:5432/tango_test pnpm test:integration",
         "test:integration:all": "bash ./scripts/test-integration-all.sh",
-        "test:smoke": "TANGO_RUN_SMOKE=true pnpm build && TANGO_RUN_SMOKE=true pnpm exec vitest run tests/smoke/examples.smoke.test.ts",
+        "test:smoke": "TANGO_RUN_SMOKE=true pnpm build && TANGO_RUN_SMOKE=true pnpm exec vitest run tests/smoke/examples.smoke.test.ts tests/smoke/scaffolded-new.smoke.test.ts",
         "typecheck": "pnpm run typecheck:prod && pnpm run typecheck:tests && pnpm run typecheck:examples",
         "build:test:packages": "pnpm -r --filter '@danceroutine/*' --filter '!@danceroutine/tango-docs' --filter '!@danceroutine/tango-example-*' --if-present run build",
         "build:test:integration": "pnpm --filter @danceroutine/tango-config build && pnpm --filter @danceroutine/tango-core build && pnpm --filter @danceroutine/tango-schema build && pnpm --filter @danceroutine/tango-resources build && pnpm --filter @danceroutine/tango-testing build && pnpm --filter @danceroutine/tango-codegen build && pnpm --filter @danceroutine/tango-migrations build && pnpm --filter @danceroutine/tango-orm build",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "test:integration:sqlite": "TANGO_TEST_DIALECT=sqlite pnpm test:integration",
         "test:integration:postgres": "TANGO_TEST_DIALECT=postgres TANGO_DB_ADAPTER=postgres TANGO_DATABASE_URL=postgres://postgres:postgres@localhost:5432/tango_test pnpm test:integration",
         "test:integration:all": "bash ./scripts/test-integration-all.sh",
-        "test:smoke": "TANGO_RUN_SMOKE=true pnpm build && TANGO_RUN_SMOKE=true pnpm exec vitest run tests/smoke/examples.smoke.test.ts tests/smoke/scaffolded-new.smoke.test.ts",
+        "test:smoke": "TANGO_RUN_SMOKE=true pnpm run build:test:packages && pnpm --filter @danceroutine/tango-example-express-blog-api build && pnpm --filter @danceroutine/tango-example-nextjs-blog build && pnpm --filter @danceroutine/tango-example-nuxt-blog build && pnpm --filter @danceroutine/tango-cli build && TANGO_RUN_SMOKE=true pnpm exec vitest run tests/smoke/examples.smoke.test.ts && TANGO_RUN_SMOKE=true pnpm exec vitest run tests/smoke/scaffolded-new.smoke.test.ts",
         "typecheck": "pnpm run typecheck:prod && pnpm run typecheck:tests && pnpm run typecheck:examples",
         "build:test:packages": "pnpm -r --filter '@danceroutine/*' --filter '!@danceroutine/tango-docs' --filter '!@danceroutine/tango-example-*' --if-present run build",
         "build:test:integration": "pnpm --filter @danceroutine/tango-config build && pnpm --filter @danceroutine/tango-core build && pnpm --filter @danceroutine/tango-schema build && pnpm --filter @danceroutine/tango-resources build && pnpm --filter @danceroutine/tango-testing build && pnpm --filter @danceroutine/tango-codegen build && pnpm --filter @danceroutine/tango-migrations build && pnpm --filter @danceroutine/tango-orm build",

--- a/packages/codegen/src/commands/tests/registerCodegenCommands.test.ts
+++ b/packages/codegen/src/commands/tests/registerCodegenCommands.test.ts
@@ -25,6 +25,8 @@ describe(registerCodegenCommands, () => {
             const packageJson = await readFile(join(targetDir, 'package.json'), 'utf8');
             const tsconfig = await readFile(join(targetDir, 'tsconfig.json'), 'utf8');
             const source = await readFile(join(targetDir, 'src/index.ts'), 'utf8');
+            await expect(stat(join(targetDir, 'src/app/layout.tsx'))).rejects.toThrow();
+            await expect(stat(join(targetDir, 'nuxt.config.ts'))).rejects.toThrow();
             expect(packageJson).toContain('"name": "demo"');
             expect(packageJson).toContain('"@danceroutine/tango-migrations"');
             expect(packageJson).toContain('"@danceroutine/tango-openapi"');
@@ -46,6 +48,8 @@ describe(registerCodegenCommands, () => {
             await parser.parseAsync();
 
             const readme = await readFile(join(targetDir, 'README.md'), 'utf8');
+            await expect(stat(join(targetDir, 'src/tango.ts'))).rejects.toThrow();
+            await expect(stat(join(targetDir, 'nuxt.config.ts'))).rejects.toThrow();
             expect(readme).toContain('scaffolded by `tango new --framework next`');
         } finally {
             await rm(dir, { recursive: true, force: true });
@@ -119,10 +123,14 @@ describe(registerCodegenCommands, () => {
             const packageJson = await readFile(join(targetDir, 'package.json'), 'utf8');
             const nuxtConfig = await readFile(join(targetDir, 'nuxt.config.ts'), 'utf8');
             const routeSource = await readFile(join(targetDir, 'server/tango/todos.ts'), 'utf8');
+            const readme = await readFile(join(targetDir, 'README.md'), 'utf8');
+            await expect(stat(join(targetDir, 'src/index.ts'))).rejects.toThrow();
+            await expect(stat(join(targetDir, 'src/app/layout.tsx'))).rejects.toThrow();
             expect(packageJson).toContain('"nuxt"');
             expect(packageJson).toContain('"@danceroutine/tango-adapters-nuxt"');
             expect(nuxtConfig).toContain('/api/todos/**:tango');
             expect(routeSource).toContain('NuxtAdapter');
+            expect(readme).toContain('Nuxt owns the public page route at `/`');
         } finally {
             await rm(dir, { recursive: true, force: true });
         }

--- a/packages/codegen/src/frameworks/contracts/template/TemplateBuilder.ts
+++ b/packages/codegen/src/frameworks/contracts/template/TemplateBuilder.ts
@@ -1,4 +1,5 @@
 import packageJson from '../../../../package.json';
+import { PACKAGE_MANAGER, type PackageManager } from '../FrameworkScaffoldStrategy';
 import type { FrameworkScaffoldContext } from './ScaffoldTemplate';
 
 const { version } = packageJson as { version: string };
@@ -29,7 +30,7 @@ export abstract class TemplateBuilder implements BoundTemplate {
      * One-liner to install Tango + dialect deps and Tango CLI (for init success message).
      */
     static getTangoInstallOneLiner(
-        packageManager: string,
+        packageManager: PackageManager,
         dialect: 'sqlite' | 'postgres',
         framework: 'express' | 'next' | 'nuxt'
     ): string {
@@ -44,6 +45,28 @@ export abstract class TemplateBuilder implements BoundTemplate {
         const addCmd = packageManager === 'npm' ? 'npm install' : `${packageManager} add`;
         const addDevCmd = packageManager === 'npm' ? 'npm install -D' : `${packageManager} add -D`;
         return `${addCmd} ${depList} && ${addDevCmd} ${devList}`;
+    }
+
+    static getRunScriptCommand(
+        packageManager: PackageManager,
+        scriptName: string,
+        scriptArgs: readonly string[] = []
+    ): string {
+        const serializedArgs = scriptArgs.join(' ');
+
+        switch (packageManager) {
+            case PACKAGE_MANAGER.NPM:
+                return serializedArgs.length > 0
+                    ? `npm run ${scriptName} -- ${serializedArgs}`
+                    : `npm run ${scriptName}`;
+            case PACKAGE_MANAGER.YARN:
+                return serializedArgs.length > 0 ? `yarn run ${scriptName} ${serializedArgs}` : `yarn run ${scriptName}`;
+            case PACKAGE_MANAGER.BUN:
+                return serializedArgs.length > 0 ? `bun run ${scriptName} ${serializedArgs}` : `bun run ${scriptName}`;
+            case PACKAGE_MANAGER.PNPM:
+            default:
+                return serializedArgs.length > 0 ? `pnpm run ${scriptName} ${serializedArgs}` : `pnpm run ${scriptName}`;
+        }
     }
 
     /**
@@ -64,7 +87,7 @@ export abstract class TemplateBuilder implements BoundTemplate {
     }
 
     private static getTangoDependencyEntriesFor(
-        dialect: 'sqlite' | 'postgres',
+        _dialect: 'sqlite' | 'postgres',
         framework: 'express' | 'next' | 'nuxt'
     ): Record<string, string> {
         const v = TemplateBuilder.getTangoVersion();
@@ -83,13 +106,18 @@ export abstract class TemplateBuilder implements BoundTemplate {
                 : framework === 'next'
                   ? { '@danceroutine/tango-adapters-next': v }
                   : { '@danceroutine/tango-adapters-nuxt': v };
-        const dialectDeps: Record<string, string> =
-            dialect === 'sqlite' ? { 'better-sqlite3': '^11.10.0' } : { pg: '^8.16.3' };
+        const dialectDeps: Record<string, string> = {
+            'better-sqlite3': '^11.10.0',
+            pg: '^8.16.3',
+        };
         return { ...core, ...adapter, ...dialectDeps };
     }
 
     private static getTangoDevDependencyEntriesFor(): Record<string, string> {
-        return { '@danceroutine/tango-cli': TemplateBuilder.getTangoVersion() };
+        return {
+            '@danceroutine/tango-cli': TemplateBuilder.getTangoVersion(),
+            '@types/better-sqlite3': '^7.6.12',
+        };
     }
 
     /** Bind context and return this for chaining. Use before passing to add* methods. */

--- a/packages/codegen/src/frameworks/contracts/template/tests/TemplateBuilder.test.ts
+++ b/packages/codegen/src/frameworks/contracts/template/tests/TemplateBuilder.test.ts
@@ -32,7 +32,9 @@ describe(TemplateBuilder, () => {
         expect(oneLiner).toContain('npm install ');
         expect(oneLiner).toContain('npm install -D ');
         expect(oneLiner).toContain('@danceroutine/tango-adapters-express@');
+        expect(oneLiner).toContain('better-sqlite3@^11.10.0');
         expect(oneLiner).toContain('pg@^8.16.3');
+        expect(oneLiner).toContain('@types/better-sqlite3@^7.6.12');
     });
 
     it('formats Nuxt install instructions with the Nuxt adapter package', () => {
@@ -40,5 +42,19 @@ describe(TemplateBuilder, () => {
 
         expect(oneLiner).toContain('@danceroutine/tango-adapters-nuxt@');
         expect(oneLiner).toContain('better-sqlite3@^11.10.0');
+        expect(oneLiner).toContain('pg@^8.16.3');
+        expect(oneLiner).toContain('@types/better-sqlite3@^7.6.12');
+    });
+
+    it('formats npm script forwarding with an explicit separator', () => {
+        expect(TemplateBuilder.getRunScriptCommand('npm', 'make:migrations', ['--name', 'initial'])).toBe(
+            'npm run make:migrations -- --name initial'
+        );
+    });
+
+    it('formats pnpm script forwarding without a literal separator arg', () => {
+        expect(TemplateBuilder.getRunScriptCommand('pnpm', 'make:migrations', ['--name', 'initial'])).toBe(
+            'pnpm run make:migrations --name initial'
+        );
     });
 });

--- a/packages/codegen/src/frameworks/contracts/template/tests/TemplateBuilder.test.ts
+++ b/packages/codegen/src/frameworks/contracts/template/tests/TemplateBuilder.test.ts
@@ -57,4 +57,20 @@ describe(TemplateBuilder, () => {
             'pnpm run make:migrations --name initial'
         );
     });
+
+    it('formats yarn and bun script forwarding without npm-specific separators', () => {
+        expect(TemplateBuilder.getRunScriptCommand('yarn', 'make:migrations', ['--name', 'initial'])).toBe(
+            'yarn run make:migrations --name initial'
+        );
+        expect(TemplateBuilder.getRunScriptCommand('bun', 'make:migrations', ['--name', 'initial'])).toBe(
+            'bun run make:migrations --name initial'
+        );
+    });
+
+    it('formats script invocations with no forwarded args', () => {
+        expect(TemplateBuilder.getRunScriptCommand('pnpm', 'dev')).toBe('pnpm run dev');
+        expect(TemplateBuilder.getRunScriptCommand('npm', 'dev')).toBe('npm run dev');
+        expect(TemplateBuilder.getRunScriptCommand('yarn', 'dev')).toBe('yarn run dev');
+        expect(TemplateBuilder.getRunScriptCommand('bun', 'dev')).toBe('bun run dev');
+    });
 });

--- a/packages/codegen/src/frameworks/scaffold/tests/scaffoldProject.test.ts
+++ b/packages/codegen/src/frameworks/scaffold/tests/scaffoldProject.test.ts
@@ -39,7 +39,7 @@ describe(scaffoldProject, () => {
             expect(packageJson).toContain('"@danceroutine/tango-openapi"');
             expect(packageJson).toContain('"setup:schema"');
             expect(scripts['make:migrations']).not.toContain('--name');
-            expect(readme).toContain('make:migrations -- --name initial');
+            expect(readme).toContain('pnpm run make:migrations --name initial');
             expect(appSource).toContain("from './tango.js'");
             expect(appSource).toContain('await registerTango(app)');
             expect(tangoSource).toContain("adapter.registerViewSet(app, '/api/todos'");
@@ -79,7 +79,7 @@ describe(scaffoldProject, () => {
             expect(packageJson).toContain('"next"');
             expect(packageJson).toContain('"@danceroutine/tango-openapi"');
             expect(scripts['make:migrations']).not.toContain('--name');
-            expect(readme).toContain('make:migrations -- --name initial');
+            expect(readme).toContain('pnpm run make:migrations --name initial');
             expect(routeSource).toContain('Response.json');
             expect(openapiRoute).toContain("from '@/lib/openapi'");
             expect(openapiSource).toContain('describeViewSet');
@@ -121,7 +121,7 @@ describe(scaffoldProject, () => {
             expect(packageJson).toContain('"nuxt"');
             expect(packageJson).toContain('"@danceroutine/tango-openapi"');
             expect(scripts['make:migrations']).not.toContain('--name');
-            expect(readme).toContain('make:migrations -- --name initial');
+            expect(readme).toContain('pnpm run make:migrations --name initial');
             expect(nuxtConfig).toContain('/api/todos/**:tango');
             expect(routeSource).toContain('NuxtAdapter');
             expect(openapiRoute).toContain("from '~~/lib/openapi'");
@@ -191,7 +191,7 @@ writeFileSync(join(process.cwd(), 'migrations', \`20260424120000_\${args[nameInd
                 );
                 await chmod(tangoStub, 0o755);
 
-                await execFileAsync('pnpm', ['run', 'make:migrations', '--', '--name', 'initial'], { cwd: dir });
+                await execFileAsync('pnpm', ['run', 'make:migrations', '--name', 'initial'], { cwd: dir });
 
                 const filenames = await readdir(join(dir, 'migrations'));
                 expect(filenames).toContain('20260424120000_initial.ts');

--- a/packages/codegen/src/frameworks/strategies/express/templates/bootstrap.ts
+++ b/packages/codegen/src/frameworks/strategies/express/templates/bootstrap.ts
@@ -7,7 +7,11 @@ export class BootstrapTemplateBuilder extends TemplateBuilder {
     }
 
     protected override resolveTemplate(_context: FrameworkScaffoldContext): string {
-        return `import { TodoModel, type Todo } from './models/index.js';
+        return `import { initializeTangoRuntime } from '@danceroutine/tango-orm/runtime';
+import tangoConfig from '../tango.config.js';
+import { TodoModel, type Todo } from './models/index.js';
+
+initializeTangoRuntime(() => tangoConfig);
 
 export async function seedExampleData(count = 100): Promise<void> {
     const existing = await TodoModel.objects.query().count();

--- a/packages/codegen/src/frameworks/strategies/express/templates/models.ts
+++ b/packages/codegen/src/frameworks/strategies/express/templates/models.ts
@@ -8,8 +8,10 @@ export class TodoModelTemplateBuilder extends TemplateBuilder {
 
     protected override resolveTemplate(_context: FrameworkScaffoldContext): string {
         return `import { z } from 'zod';
-import '@danceroutine/tango-orm/runtime';
+import { registerModelObjects } from '@danceroutine/tango-orm/runtime';
 import { Model, t } from '@danceroutine/tango-schema';
+
+registerModelObjects();
 
 export const TodoReadSchema = z.object({
     id: z.number(),

--- a/packages/codegen/src/frameworks/strategies/express/templates/readme.ts
+++ b/packages/codegen/src/frameworks/strategies/express/templates/readme.ts
@@ -7,6 +7,20 @@ export class ReadmeTemplateBuilder extends TemplateBuilder {
     }
 
     protected override resolveTemplate(context: FrameworkScaffoldContext): string {
+        const makeMigrations = TemplateBuilder.getRunScriptCommand(context.packageManager, 'make:migrations', [
+            '--name',
+            'initial',
+        ]);
+        const makeNamedMigration = TemplateBuilder.getRunScriptCommand(context.packageManager, 'make:migrations', [
+            '--name',
+            'add_field',
+        ]);
+        const dev = TemplateBuilder.getRunScriptCommand(context.packageManager, 'dev');
+        const codegenRelations = TemplateBuilder.getRunScriptCommand(context.packageManager, 'codegen:relations');
+        const setupSchema = TemplateBuilder.getRunScriptCommand(context.packageManager, 'setup:schema');
+        const bootstrap = TemplateBuilder.getRunScriptCommand(context.packageManager, 'bootstrap');
+        const typecheck = TemplateBuilder.getRunScriptCommand(context.packageManager, 'typecheck');
+
         return `# ${context.projectName}
 
 This project was scaffolded by \`tango new --framework express\`.
@@ -18,22 +32,20 @@ Express still owns the server and route registration; Tango owns model metadata,
 Generate your first migration from the scaffolded models, then start the app:
 
 \`\`\`bash
-${context.packageManager} run make:migrations -- --name initial
-${context.packageManager} run dev
+${makeMigrations}
+${dev}
 \`\`\`
 
-\`make:migrations\` also refreshes the generated relation registry for the scaffolded model module. If you later change relation metadata without needing a new migration file, run \`${context.packageManager} run codegen:relations\`.
-
-When you run the package script, pass Tango flags after \`--\` so the script forwards them to the CLI unchanged.
+\`make:migrations\` also refreshes the generated relation registry for the scaffolded model module. If you later change relation metadata without needing a new migration file, run \`${codegenRelations}\`.
 
 ## Scripts
 
-- \`${context.packageManager} run dev\`
-- \`${context.packageManager} run make:migrations -- --name add_field\`
-- \`${context.packageManager} run codegen:relations\`
-- \`${context.packageManager} run setup:schema\`
-- \`${context.packageManager} run bootstrap\`
-- \`${context.packageManager} run typecheck\`
+- \`${dev}\`
+- \`${makeNamedMigration}\`
+- \`${codegenRelations}\`
+- \`${setupSchema}\`
+- \`${bootstrap}\`
+- \`${typecheck}\`
 
 ## Useful endpoints
 
@@ -41,17 +53,24 @@ When you run the package script, pass Tango flags after \`--\` so the script for
 - \`GET /api/openapi.json\`
 - \`GET|POST|PATCH|DELETE /api/todos...\`
 
-## Project layout
+## Durable app code
 
 - \`tango.config.ts\` Tango configuration
-- \`src/tango.ts\` Express registration helper for Tango routes
+- \`src/index.ts\` Express app entrypoint; you own server boot, ports, and middleware here
+- \`src/tango.ts\` Express registration helper for Tango routes and OpenAPI wiring
 - \`src/models/\` schemas and Tango model metadata; importing the model module enables \`Model.objects\`
 - \`src/serializers/\` serializer-backed API contracts for Tango resources
 - \`src/viewsets/\` CRUD resources backed by \`Model.objects\`
 - \`src/openapi.ts\` OpenAPI document generation
-- \`src/bootstrap.ts\` seed utility for a larger demo dataset
-- \`migrations/\` checked-in Tango migrations
-- \`.tango/\` generated relation typing artifacts
+
+## Generated artifacts
+
+- \`.tango/\` generated relation typing artifacts; regenerate through \`make:migrations\` or \`codegen:relations\`
+- \`migrations/\` checked-in Tango migrations; review them like source, but let Tango generate the files
+
+## Utility surface
+
+- \`src/bootstrap.ts\` sample seed utility; keep it if it helps your app, or replace it once your own seed flow exists
 `;
     }
 }

--- a/packages/codegen/src/frameworks/strategies/express/tests/ExpressScaffoldStrategy.test.ts
+++ b/packages/codegen/src/frameworks/strategies/express/tests/ExpressScaffoldStrategy.test.ts
@@ -43,7 +43,8 @@ describe(ExpressScaffoldStrategy, () => {
             const scripts = JSON.parse(packageJson).scripts as Record<string, string>;
 
             expect(packageJson).toContain('"better-sqlite3"');
-            expect(packageJson).not.toContain('"pg"');
+            expect(packageJson).toContain('"pg"');
+            expect(packageJson).toContain('"@types/better-sqlite3"');
             expect(packageJson).toContain('"@danceroutine/tango-openapi"');
             expect(packageJson).toContain('"codegen:relations"');
             expect(scripts['make:migrations']).not.toContain('--name');
@@ -61,7 +62,10 @@ describe(ExpressScaffoldStrategy, () => {
             expect(viewsetSource).toContain('serializer: TodoSerializer');
             expect(indexSource).toContain('await registerTango(app)');
             expect(readme).toContain('First-time setup');
-            expect(readme).toContain('make:migrations -- --name initial');
+            expect(readme).toContain('pnpm run make:migrations --name initial');
+            expect(readme).toContain('## Durable app code');
+            expect(readme).toContain('## Generated artifacts');
+            expect(readme).toContain('## Utility surface');
             expect(readme).toContain('codegen:relations');
             expect(migrationsKeep).toBe('');
         });
@@ -82,7 +86,8 @@ describe(ExpressScaffoldStrategy, () => {
             const config = renderTemplate(templates, 'tango.config.ts', context);
 
             expect(packageJson).toContain('"pg"');
-            expect(packageJson).not.toContain('"better-sqlite3"');
+            expect(packageJson).toContain('"better-sqlite3"');
+            expect(packageJson).toContain('"@types/better-sqlite3"');
             expect(config).toContain("adapter: 'postgres'");
             expect(config).toContain('TANGO_DATABASE_URL');
         });
@@ -117,6 +122,17 @@ describe(ExpressScaffoldStrategy, () => {
             expect(tangoSource).toContain('export async function registerTango(app: Application)');
             expect(tangoSource).toContain("adapter.registerViewSet(app, '/api/todos'");
             expect(tangoSource).toContain('/api/openapi.json');
+        });
+
+        it('does not emit Next or Nuxt-specific files', () => {
+            const strategy = new ExpressScaffoldStrategy();
+            const templatePaths = new Set(strategy.getTemplates().map((template) => template.path));
+
+            expect(templatePaths.has('src/app/layout.tsx')).toBe(false);
+            expect(templatePaths.has('src/app/page.tsx')).toBe(false);
+            expect(templatePaths.has('next.config.mjs')).toBe(false);
+            expect(templatePaths.has('nuxt.config.ts')).toBe(false);
+            expect(templatePaths.has('server/tango/todos.ts')).toBe(false);
         });
     });
 });

--- a/packages/codegen/src/frameworks/strategies/next/templates/bootstrap.ts
+++ b/packages/codegen/src/frameworks/strategies/next/templates/bootstrap.ts
@@ -7,7 +7,11 @@ export class BootstrapTemplateBuilder extends TemplateBuilder {
     }
 
     protected override resolveTemplate(_context: FrameworkScaffoldContext): string {
-        return `import { TodoModel, type Todo } from '../src/lib/models';
+        return `import { initializeTangoRuntime } from '@danceroutine/tango-orm/runtime';
+import tangoConfig from '../tango.config.js';
+import { TodoModel, type Todo } from '../src/lib/models';
+
+initializeTangoRuntime(() => tangoConfig);
 
 async function seedExampleData(count = 100): Promise<void> {
     const existing = await TodoModel.objects.query().count();

--- a/packages/codegen/src/frameworks/strategies/next/templates/models.ts
+++ b/packages/codegen/src/frameworks/strategies/next/templates/models.ts
@@ -11,8 +11,10 @@ export class TodoModelTemplateBuilder extends TemplateBuilder {
 
     protected override resolveTemplate(_context: FrameworkScaffoldContext): string {
         return `import { z } from 'zod';
-import '@danceroutine/tango-orm/runtime';
+import { registerModelObjects } from '@danceroutine/tango-orm/runtime';
 import { Model, t } from '@danceroutine/tango-schema';
+
+registerModelObjects();
 
 export const TodoReadSchema = z.object({
     id: z.number(),

--- a/packages/codegen/src/frameworks/strategies/next/templates/readme.ts
+++ b/packages/codegen/src/frameworks/strategies/next/templates/readme.ts
@@ -7,6 +7,20 @@ export class ReadmeTemplateBuilder extends TemplateBuilder {
     }
 
     protected override resolveTemplate(context: FrameworkScaffoldContext): string {
+        const makeMigrations = TemplateBuilder.getRunScriptCommand(context.packageManager, 'make:migrations', [
+            '--name',
+            'initial',
+        ]);
+        const makeNamedMigration = TemplateBuilder.getRunScriptCommand(context.packageManager, 'make:migrations', [
+            '--name',
+            'add_field',
+        ]);
+        const dev = TemplateBuilder.getRunScriptCommand(context.packageManager, 'dev');
+        const codegenRelations = TemplateBuilder.getRunScriptCommand(context.packageManager, 'codegen:relations');
+        const setupSchema = TemplateBuilder.getRunScriptCommand(context.packageManager, 'setup:schema');
+        const bootstrap = TemplateBuilder.getRunScriptCommand(context.packageManager, 'bootstrap');
+        const typecheck = TemplateBuilder.getRunScriptCommand(context.packageManager, 'typecheck');
+
         return `# ${context.projectName}
 
 This project was scaffolded by \`tango new --framework next\`.
@@ -18,41 +32,46 @@ Next.js still owns pages and route handlers; Tango owns model metadata, \`Model.
 Generate your first migration from the scaffolded models, then start the app:
 
 \`\`\`bash
-${context.packageManager} run make:migrations -- --name initial
-${context.packageManager} run dev
+${makeMigrations}
+${dev}
 \`\`\`
 
-\`make:migrations\` also refreshes the generated relation registry for the scaffolded model module. If you later change relation metadata without needing a new migration file, run \`${context.packageManager} run codegen:relations\`.
-
-When you run the package script, pass Tango flags after \`--\` so the script forwards them to the CLI unchanged.
+\`make:migrations\` also refreshes the generated relation registry for the scaffolded model module. If you later change relation metadata without needing a new migration file, run \`${codegenRelations}\`.
 
 ## Scripts
 
-- \`${context.packageManager} run dev\`
-- \`${context.packageManager} run make:migrations -- --name add_field\`
-- \`${context.packageManager} run codegen:relations\`
-- \`${context.packageManager} run setup:schema\`
-- \`${context.packageManager} run bootstrap\`
-- \`${context.packageManager} run typecheck\`
+- \`${dev}\`
+- \`${makeNamedMigration}\`
+- \`${codegenRelations}\`
+- \`${setupSchema}\`
+- \`${bootstrap}\`
+- \`${typecheck}\`
 
 ## Useful endpoints
 
+- \`GET /\` browser entry route rendered by \`src/app/page.tsx\`
 - \`GET /api/health\`
 - \`GET /api/openapi\`
 - \`GET|POST|PATCH|DELETE /api/todos...\`
 
-## Project layout
+## Durable app code
 
 - \`tango.config.ts\` Tango configuration
 - \`src/lib/models/\` schemas and Tango model metadata; importing the model module enables \`Model.objects\`
 - \`src/serializers/\` serializer-backed API contracts for Tango resources
 - \`src/viewsets/\` CRUD resources backed by \`Model.objects\`
-- \`src/app/page.tsx\` server-rendered page reading through \`TodoModel.objects\`
+- \`src/app/page.tsx\` browser entry route at \`/\`; replace the Todo page once your own app shell is ready
 - \`src/app/api/todos/[[...tango]]/route.ts\` Next adapter wiring for the viewset
 - \`src/lib/openapi.ts\` OpenAPI document generation
-- \`scripts/bootstrap.ts\` seed utility for a larger demo dataset
-- \`migrations/\` checked-in Tango migrations
-- \`.tango/\` generated relation typing artifacts
+
+## Generated artifacts
+
+- \`.tango/\` generated relation typing artifacts; regenerate through \`make:migrations\` or \`codegen:relations\`
+- \`migrations/\` checked-in Tango migrations; review them like source, but let Tango generate the files
+
+## Utility surface
+
+- \`scripts/bootstrap.ts\` sample seed utility; keep it if it helps your app, or replace it once your own seed flow exists
 `;
     }
 }

--- a/packages/codegen/src/frameworks/strategies/next/templates/tests/TodoModelTemplateBuilder.test.ts
+++ b/packages/codegen/src/frameworks/strategies/next/templates/tests/TodoModelTemplateBuilder.test.ts
@@ -17,7 +17,8 @@ describe(TodoModelTemplateBuilder, () => {
             const template = TodoModelTemplateBuilder.context(context);
 
             expect(template.getPath()).toBe('src/lib/models/TodoModel.ts');
-            expect(template.build()).toContain("import '@danceroutine/tango-orm/runtime';");
+            expect(template.build()).toContain("import { registerModelObjects } from '@danceroutine/tango-orm/runtime';");
+            expect(template.build()).toContain('registerModelObjects();');
         });
     });
 });

--- a/packages/codegen/src/frameworks/strategies/next/templates/tsconfig.ts
+++ b/packages/codegen/src/frameworks/strategies/next/templates/tsconfig.ts
@@ -20,6 +20,7 @@ export class TsConfigTemplateBuilder extends TemplateBuilder {
                     isolatedModules: true,
                     jsx: 'preserve',
                     esModuleInterop: true,
+                    skipLibCheck: true,
                     baseUrl: '.',
                     paths: {
                         '@/*': ['src/*'],

--- a/packages/codegen/src/frameworks/strategies/next/tests/NextScaffoldStrategy.test.ts
+++ b/packages/codegen/src/frameworks/strategies/next/tests/NextScaffoldStrategy.test.ts
@@ -52,6 +52,9 @@ describe(NextScaffoldStrategy, () => {
             const migrationsKeep = renderTemplate(templates, 'migrations/.gitkeep', context);
             const scripts = JSON.parse(packageJson).scripts as Record<string, string>;
 
+            expect(packageJson).toContain('"better-sqlite3"');
+            expect(packageJson).toContain('"pg"');
+            expect(packageJson).toContain('"@types/better-sqlite3"');
             expect(packageJson).toContain('"codegen:relations"');
             expect(scripts['make:migrations']).not.toContain('--name');
             expect(scripts['make:migrations']).not.toContain('npm_config_name');
@@ -67,7 +70,11 @@ describe(NextScaffoldStrategy, () => {
             expect(serializerSource).toContain('export class TodoSerializer extends ModelSerializer');
             expect(viewsetSource).toContain('serializer: TodoSerializer');
             expect(readme).toContain('First-time setup');
-            expect(readme).toContain('make:migrations -- --name initial');
+            expect(readme).toContain('pnpm run make:migrations --name initial');
+            expect(readme).toContain('GET /');
+            expect(readme).toContain('## Durable app code');
+            expect(readme).toContain('## Generated artifacts');
+            expect(readme).toContain('## Utility surface');
             expect(readme).toContain('codegen:relations');
             expect(migrationsKeep).toBe('');
         });
@@ -88,8 +95,19 @@ describe(NextScaffoldStrategy, () => {
             const config = renderTemplate(templates, 'tango.config.ts', context);
 
             expect(packageJson).toContain('"pg"');
-            expect(packageJson).not.toContain('"better-sqlite3"');
+            expect(packageJson).toContain('"better-sqlite3"');
+            expect(packageJson).toContain('"@types/better-sqlite3"');
             expect(config).toContain("adapter: 'postgres'");
+        });
+
+        it('does not emit Express or Nuxt-specific files', () => {
+            const strategy = new NextScaffoldStrategy();
+            const templatePaths = new Set(strategy.getTemplates().map((template) => template.path));
+
+            expect(templatePaths.has('src/tango.ts')).toBe(false);
+            expect(templatePaths.has('src/index.ts')).toBe(false);
+            expect(templatePaths.has('nuxt.config.ts')).toBe(false);
+            expect(templatePaths.has('server/tango/todos.ts')).toBe(false);
         });
     });
 });

--- a/packages/codegen/src/frameworks/strategies/nuxt/templates/bootstrap.ts
+++ b/packages/codegen/src/frameworks/strategies/nuxt/templates/bootstrap.ts
@@ -7,7 +7,11 @@ export class BootstrapTemplateBuilder extends TemplateBuilder {
     }
 
     protected override resolveTemplate(_context: FrameworkScaffoldContext): string {
-        return `import { TodoModel, type Todo } from '../lib/models';
+        return `import { initializeTangoRuntime } from '@danceroutine/tango-orm/runtime';
+import tangoConfig from '../tango.config.js';
+import { TodoModel, type Todo } from '../lib/models';
+
+initializeTangoRuntime(() => tangoConfig);
 
 async function seedExampleData(count = 100): Promise<void> {
     const existing = await TodoModel.objects.query().count();

--- a/packages/codegen/src/frameworks/strategies/nuxt/templates/page.ts
+++ b/packages/codegen/src/frameworks/strategies/nuxt/templates/page.ts
@@ -8,7 +8,7 @@ export class PageTemplateBuilder extends TemplateBuilder {
 
     protected override resolveTemplate(_context: FrameworkScaffoldContext): string {
         return `<script setup lang="ts">
-import { TodoModel, TodoReadSchema } from '~/lib/models';
+import { TodoModel, TodoReadSchema } from '~~/lib/models';
 
 const todos = await TodoModel.objects.query().orderBy('-createdAt').limit(10).fetch(TodoReadSchema);
 </script>

--- a/packages/codegen/src/frameworks/strategies/nuxt/templates/readme.ts
+++ b/packages/codegen/src/frameworks/strategies/nuxt/templates/readme.ts
@@ -7,6 +7,20 @@ export class ReadmeTemplateBuilder extends TemplateBuilder {
     }
 
     protected override resolveTemplate(context: FrameworkScaffoldContext): string {
+        const makeMigrations = TemplateBuilder.getRunScriptCommand(context.packageManager, 'make:migrations', [
+            '--name',
+            'initial',
+        ]);
+        const makeNamedMigration = TemplateBuilder.getRunScriptCommand(context.packageManager, 'make:migrations', [
+            '--name',
+            'add_field',
+        ]);
+        const dev = TemplateBuilder.getRunScriptCommand(context.packageManager, 'dev');
+        const codegenRelations = TemplateBuilder.getRunScriptCommand(context.packageManager, 'codegen:relations');
+        const setupSchema = TemplateBuilder.getRunScriptCommand(context.packageManager, 'setup:schema');
+        const bootstrap = TemplateBuilder.getRunScriptCommand(context.packageManager, 'bootstrap');
+        const typecheck = TemplateBuilder.getRunScriptCommand(context.packageManager, 'typecheck');
+
         return `# ${context.projectName}
 
 This project was scaffolded by \`tango new --framework nuxt\`.
@@ -18,42 +32,50 @@ Nuxt still owns pages and SSR rendering; Tango owns model metadata, \`Model.obje
 Generate your first migration from the scaffolded models, then start the app:
 
 \`\`\`bash
-${context.packageManager} run make:migrations -- --name initial
-${context.packageManager} run dev
+${makeMigrations}
+${dev}
 \`\`\`
 
-\`make:migrations\` also refreshes the generated relation registry for the scaffolded model module. If you later change relation metadata without needing a new migration file, run \`${context.packageManager} run codegen:relations\`.
-
-When you run the package script, pass Tango flags after \`--\` so the script forwards them to the CLI unchanged.
+\`make:migrations\` also refreshes the generated relation registry for the scaffolded model module. If you later change relation metadata without needing a new migration file, run \`${codegenRelations}\`.
 
 ## Scripts
 
-- \`${context.packageManager} run dev\`
-- \`${context.packageManager} run make:migrations -- --name add_field\`
-- \`${context.packageManager} run codegen:relations\`
-- \`${context.packageManager} run setup:schema\`
-- \`${context.packageManager} run bootstrap\`
-- \`${context.packageManager} run typecheck\`
+- \`${dev}\`
+- \`${makeNamedMigration}\`
+- \`${codegenRelations}\`
+- \`${setupSchema}\`
+- \`${bootstrap}\`
+- \`${typecheck}\`
 
 ## Useful endpoints
 
+- \`GET /\` browser entry route rendered by \`app/pages/index.server.vue\`
 - \`GET /api/health\`
 - \`GET /api/openapi\`
 - \`GET|POST|PATCH|DELETE /api/todos...\`
 
-## Project layout
+Nuxt owns the public page route at \`/\`. Tango-owned endpoints stay under \`/api/*\`.
+
+## Durable app code
 
 - \`nuxt.config.ts\` Nuxt config and explicit Tango server handler registration
 - \`tango.config.ts\` Tango configuration
 - \`lib/models/\` schemas and Tango model metadata; explicit ORM registration keeps \`Model.objects\` available in SSR pages and handlers
 - \`serializers/\` serializer-backed API contracts for Tango resources
 - \`viewsets/\` CRUD resources backed by \`Model.objects\`
-- \`app/pages/index.server.vue\` server-rendered page reading through \`TodoModel.objects\`
+- \`app/pages/index.server.vue\` browser entry route at \`/\`; replace the Todo page once your own app shell is ready
 - \`server/tango/todos.ts\` Nuxt adapter wiring for the viewset
+- \`server/tango/openapi.ts\` Tango-owned API surface for your OpenAPI document
 - \`lib/openapi.ts\` OpenAPI document generation
-- \`scripts/bootstrap.ts\` seed utility for a larger demo dataset
-- \`migrations/\` checked-in Tango migrations
-- \`.tango/\` generated relation typing artifacts
+
+## Generated artifacts
+
+- \`.tango/\` generated relation typing artifacts; regenerate through \`make:migrations\` or \`codegen:relations\`
+- \`migrations/\` checked-in Tango migrations; review them like source, but let Tango generate the files
+
+## Utility surface
+
+- \`scripts/bootstrap.ts\` sample seed utility; keep it if it helps your app, or replace it once your own seed flow exists
 `;
     }
 }

--- a/packages/codegen/src/frameworks/strategies/nuxt/templates/tsconfig.ts
+++ b/packages/codegen/src/frameworks/strategies/nuxt/templates/tsconfig.ts
@@ -12,6 +12,7 @@ export class TsConfigTemplateBuilder extends TemplateBuilder {
                 extends: './.nuxt/tsconfig.json',
                 compilerOptions: {
                     strict: true,
+                    skipLibCheck: true,
                 },
                 include: ['.nuxt/**/*.d.ts', '**/*.ts', '**/*.vue', 'migrations/**/*.ts', '.tango/**/*.d.ts'],
             },

--- a/packages/codegen/src/frameworks/strategies/nuxt/tests/NuxtScaffoldStrategy.test.ts
+++ b/packages/codegen/src/frameworks/strategies/nuxt/tests/NuxtScaffoldStrategy.test.ts
@@ -55,6 +55,9 @@ describe(NuxtScaffoldStrategy, () => {
             const scripts = JSON.parse(packageJson).scripts as Record<string, string>;
 
             expect(packageJson).toContain('"nuxt"');
+            expect(packageJson).toContain('"better-sqlite3"');
+            expect(packageJson).toContain('"pg"');
+            expect(packageJson).toContain('"@types/better-sqlite3"');
             expect(packageJson).toContain('"codegen:relations"');
             expect(scripts['make:migrations']).not.toContain('--name');
             expect(scripts['make:migrations']).not.toContain('npm_config_name');
@@ -62,6 +65,7 @@ describe(NuxtScaffoldStrategy, () => {
             expect(nuxtConfig).toContain("route: '/api/todos/**:tango'");
             expect(tsconfig).toContain('".tango/**/*.d.ts"');
             expect(page).toContain('<script setup lang="ts">');
+            expect(page).toContain("from '~~/lib/models'");
             expect(route).toContain('defineEventHandler');
             expect(openapiRoute).toContain("from '~~/lib/openapi'");
             expect(openapiSource).toContain('describeViewSet');
@@ -69,7 +73,12 @@ describe(NuxtScaffoldStrategy, () => {
             expect(serializerSource).toContain("from '~~/lib/models'");
             expect(viewsetSource).toContain("from '~~/serializers'");
             expect(readme).toContain('tango new --framework nuxt');
-            expect(readme).toContain('make:migrations -- --name initial');
+            expect(readme).toContain('pnpm run make:migrations --name initial');
+            expect(readme).toContain('GET /');
+            expect(readme).toContain('Nuxt owns the public page route at `/`');
+            expect(readme).toContain('## Durable app code');
+            expect(readme).toContain('## Generated artifacts');
+            expect(readme).toContain('## Utility surface');
             expect(readme).toContain('codegen:relations');
             expect(readme).toContain('server/tango/todos.ts');
             expect(migrationsKeep).toBe('');
@@ -91,7 +100,8 @@ describe(NuxtScaffoldStrategy, () => {
             const config = renderTemplate(templates, 'tango.config.ts', context);
 
             expect(packageJson).toContain('"pg"');
-            expect(packageJson).not.toContain('"better-sqlite3"');
+            expect(packageJson).toContain('"better-sqlite3"');
+            expect(packageJson).toContain('"@types/better-sqlite3"');
             expect(config).toContain("adapter: 'postgres'");
         });
 
@@ -109,6 +119,16 @@ describe(NuxtScaffoldStrategy, () => {
 
             expect(modelSource).toContain('export const TodoModel = Model(');
             expect(modelSource).toContain('export const TodoReadSchema = z.object({');
+        });
+
+        it('does not emit Express or Next-specific files', () => {
+            const strategy = new NuxtScaffoldStrategy();
+            const templatePaths = new Set(strategy.getTemplates().map((template) => template.path));
+
+            expect(templatePaths.has('src/tango.ts')).toBe(false);
+            expect(templatePaths.has('src/index.ts')).toBe(false);
+            expect(templatePaths.has('src/app/layout.tsx')).toBe(false);
+            expect(templatePaths.has('next.config.mjs')).toBe(false);
         });
     });
 });

--- a/tests/smoke/examples.smoke.test.ts
+++ b/tests/smoke/examples.smoke.test.ts
@@ -6,36 +6,6 @@ import { AppProcessHarness } from '@danceroutine/tango-testing/integration';
 
 const smokeDescribe = process.env.TANGO_RUN_SMOKE === 'true' ? describe.sequential : describe.skip;
 
-function ensureSmokeBuildPrerequisites(): void {
-    const commands: ReadonlyArray<ReadonlyArray<string>> = [
-        ['--filter', '@danceroutine/tango-cli', 'build'],
-        ['--filter', '@danceroutine/tango-adapters-express', 'build'],
-        ['--filter', '@danceroutine/tango-adapters-next', 'build'],
-        ['--filter', '@danceroutine/tango-adapters-nuxt', 'build'],
-    ];
-
-    for (const args of commands) {
-        const result = spawnSync('pnpm', [...args], {
-            cwd: process.cwd(),
-            env: process.env,
-            encoding: 'utf8',
-        });
-
-        if (result.status === 0) {
-            continue;
-        }
-
-        throw new Error(
-            [
-                `smoke prerequisite build failed: pnpm ${args.join(' ')}`,
-                `exit=${String(result.status)}`,
-                result.stdout ?? '',
-                result.stderr ?? '',
-            ].join('\n')
-        );
-    }
-}
-
 function runSmokeCommand(label: string, args: readonly string[], env?: NodeJS.ProcessEnv): void {
     const result = spawnSync('pnpm', [...args], {
         cwd: process.cwd(),
@@ -91,8 +61,6 @@ smokeDescribe('example smoke tests', () => {
     const nuxtSqliteFile = `/tmp/tango-smoke-nuxt-${randomUUID()}.sqlite`;
 
     beforeAll(async () => {
-        ensureSmokeBuildPrerequisites();
-
         // Ensure a clean database state for repeatable smoke runs.
         await rm(expressSqliteFile, { force: true });
         await rm(nextSqliteFile, { force: true });

--- a/tests/smoke/scaffolded-new.smoke.test.ts
+++ b/tests/smoke/scaffolded-new.smoke.test.ts
@@ -1,0 +1,252 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import { join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { randomUUID } from 'node:crypto';
+
+const smokeDescribe = process.env.TANGO_RUN_SMOKE === 'true' ? describe.sequential : describe.skip;
+const workspaceRoot = process.cwd();
+
+type HostScenario = {
+    framework: 'express' | 'next' | 'nuxt';
+    projectName: string;
+    includeSeed: boolean;
+};
+
+function runCommand(
+    label: string,
+    command: string,
+    args: readonly string[],
+    cwd: string,
+    env?: NodeJS.ProcessEnv
+): void {
+    const result = spawnSync(command, [...args], {
+        cwd,
+        env: {
+            ...process.env,
+            ...env,
+        },
+        encoding: 'utf8',
+    });
+
+    if (result.status === 0) {
+        return;
+    }
+
+    throw new Error(
+        [
+            `${label} failed: ${command} ${args.join(' ')}`,
+            `cwd=${cwd}`,
+            `exit=${String(result.status)}`,
+            result.stdout ?? '',
+            result.stderr ?? '',
+        ].join('\n')
+    );
+}
+
+function ensureScaffoldSmokeBuildPrerequisites(): void {
+    runCommand('build:test:packages', 'pnpm', ['run', 'build:test:packages'], workspaceRoot);
+}
+
+function discoverPackageDirs(dir: string): string[] {
+    const entries = spawnSync('find', [dir, '-name', 'package.json', '-not', '-path', '*/node_modules/*'], {
+        cwd: workspaceRoot,
+        encoding: 'utf8',
+    });
+
+    if (entries.status !== 0) {
+        throw new Error(entries.stderr || 'failed to discover package directories');
+    }
+
+    return entries.stdout
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((packageJsonPath) => resolve(workspaceRoot, packageJsonPath.replace(/\/package\.json$/, '')));
+}
+
+async function packLocalTangoPackages(): Promise<{ packDir: string; packages: Map<string, string> }> {
+    const packDir = resolve(await mkdtemp(join(tmpdir(), 'tango-scaffold-packs-')));
+    const packageDirs = discoverPackageDirs('packages');
+    const map = new Map<string, string>();
+
+    for (const packageDir of packageDirs) {
+        const packageJson = JSON.parse(await readFile(join(packageDir, 'package.json'), 'utf8')) as { name?: string };
+
+        if (!packageJson.name?.startsWith('@danceroutine/tango')) {
+            continue;
+        }
+
+        const before = new Set(await readdir(packDir));
+        runCommand(
+            `pack ${packageJson.name}`,
+            'pnpm',
+            ['--dir', packageDir, 'pack', '--pack-destination', packDir],
+            workspaceRoot
+        );
+        const after = await readdir(packDir);
+        const newFile = after.find((entry) => !before.has(entry));
+        if (!newFile) {
+            throw new Error(`Failed to find packed tarball for ${packageJson.name}`);
+        }
+        map.set(packageJson.name, join(packDir, newFile));
+    }
+
+    return { packDir, packages: map };
+}
+
+async function rewriteScaffoldedTangoDeps(projectDir: string, packedPackages: Map<string, string>): Promise<void> {
+    const packageJsonPath = join(projectDir, 'package.json');
+    const packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8')) as {
+        dependencies?: Record<string, string>;
+        devDependencies?: Record<string, string>;
+        pnpm?: {
+            overrides?: Record<string, string>;
+        };
+    };
+    const overrides: Record<string, string> = {};
+
+    for (const section of ['dependencies', 'devDependencies'] as const) {
+        const entries = packageJson[section];
+        if (!entries) {
+            continue;
+        }
+        for (const [name] of Object.entries(entries)) {
+            if (!name.startsWith('@danceroutine/tango')) {
+                continue;
+            }
+            const packedPath = packedPackages.get(name);
+            if (!packedPath) {
+                throw new Error(`Missing packed tarball for ${name}`);
+            }
+            const fileSpec = `file:${packedPath}`;
+            entries[name] = fileSpec;
+            overrides[name] = fileSpec;
+        }
+    }
+
+    packageJson.pnpm = {
+        ...packageJson.pnpm,
+        overrides: {
+            ...packageJson.pnpm?.overrides,
+            ...overrides,
+        },
+    };
+
+    await writeFile(packageJsonPath, `${JSON.stringify(packageJson, null, 4)}\n`, 'utf8');
+}
+
+async function scaffoldFreshProject(
+    scenario: HostScenario,
+    packedPackages: Map<string, string>
+): Promise<{ dir: string; sqliteFile: string }> {
+    const dir = await mkdtemp(join(tmpdir(), `tango-new-${scenario.framework}-`));
+    const sqliteFile = `/tmp/tango-new-${scenario.framework}-${randomUUID()}.sqlite`;
+
+    runCommand(
+        `tango new ${scenario.framework}`,
+        'node',
+        [
+            'packages/cli/bin/tango.js',
+            'new',
+            scenario.projectName,
+            '--framework',
+            scenario.framework,
+            '--path',
+            dir,
+            '--package-manager',
+            'pnpm',
+            '--dialect',
+            'sqlite',
+            '--seed',
+            String(scenario.includeSeed),
+        ],
+        workspaceRoot
+    );
+
+    await rewriteScaffoldedTangoDeps(dir, packedPackages);
+
+    runCommand('scaffold install', 'pnpm', ['install'], dir);
+    runCommand('scaffold typecheck', 'pnpm', ['run', 'typecheck'], dir, { TANGO_SQLITE_FILENAME: sqliteFile });
+    runCommand('scaffold codegen:relations', 'pnpm', ['run', 'codegen:relations'], dir, {
+        TANGO_SQLITE_FILENAME: sqliteFile,
+    });
+    runCommand('scaffold make:migrations', 'pnpm', ['run', 'make:migrations', '--name', 'initial'], dir, {
+        TANGO_SQLITE_FILENAME: sqliteFile,
+    });
+    runCommand('scaffold setup:schema', 'pnpm', ['run', 'setup:schema'], dir, { TANGO_SQLITE_FILENAME: sqliteFile });
+    if (scenario.includeSeed) {
+        runCommand('scaffold bootstrap', 'pnpm', ['run', 'bootstrap'], dir, { TANGO_SQLITE_FILENAME: sqliteFile });
+    }
+
+    return { dir, sqliteFile };
+}
+
+smokeDescribe('fresh tango new scaffold smoke tests', () => {
+    const scenarios: HostScenario[] = [
+        { framework: 'express', projectName: 'express-scaffold-smoke', includeSeed: true },
+        { framework: 'next', projectName: 'next-scaffold-smoke', includeSeed: false },
+        { framework: 'nuxt', projectName: 'nuxt-scaffold-smoke', includeSeed: false },
+    ];
+
+    const createdDirs: string[] = [];
+    const sqliteFiles: string[] = [];
+    let packedPackages = new Map<string, string>();
+    let packDir: string | null = null;
+
+    beforeAll(async () => {
+        ensureScaffoldSmokeBuildPrerequisites();
+        const packed = await packLocalTangoPackages();
+        packDir = packed.packDir;
+        packedPackages = packed.packages;
+    }, 180_000);
+
+    afterAll(async () => {
+        for (const dir of createdDirs) {
+            await rm(dir, { recursive: true, force: true });
+        }
+        for (const sqliteFile of sqliteFiles) {
+            await rm(sqliteFile, { force: true });
+        }
+        if (packDir) {
+            await rm(packDir, { recursive: true, force: true });
+        }
+    });
+
+    for (const scenario of scenarios) {
+        it(`boots a fresh ${scenario.framework} scaffold through tango new`, async () => {
+            const result = await scaffoldFreshProject(scenario, packedPackages);
+            createdDirs.push(result.dir);
+            sqliteFiles.push(result.sqliteFile);
+
+            const packageJson = JSON.parse(await readFile(join(result.dir, 'package.json'), 'utf8')) as {
+                scripts: Record<string, string>;
+            };
+
+            expect(packageJson.scripts['make:migrations']).not.toContain('npm_config_name');
+            expect(packageJson.scripts['make:migrations']).not.toContain('--name');
+
+            if (scenario.framework === 'express') {
+                await expectPathMissing(join(result.dir, 'src/app/layout.tsx'));
+                await expectPathMissing(join(result.dir, 'nuxt.config.ts'));
+                return;
+            }
+
+            if (scenario.framework === 'next') {
+                await expectPathMissing(join(result.dir, 'src/tango.ts'));
+                await expectPathMissing(join(result.dir, 'nuxt.config.ts'));
+                return;
+            }
+
+            runCommand('scaffold build', 'pnpm', ['run', 'build'], result.dir, {
+                TANGO_SQLITE_FILENAME: result.sqliteFile,
+            });
+            await expect(readFile(join(result.dir, 'app/pages/index.server.vue'), 'utf8')).resolves.toContain('Tango + Nuxt');
+        }, 240_000);
+    }
+});
+
+async function expectPathMissing(path: string): Promise<void> {
+    await expect(readFile(path, 'utf8')).rejects.toThrow();
+}

--- a/tests/smoke/scaffolded-new.smoke.test.ts
+++ b/tests/smoke/scaffolded-new.smoke.test.ts
@@ -45,10 +45,6 @@ function runCommand(
     );
 }
 
-function ensureScaffoldSmokeBuildPrerequisites(): void {
-    runCommand('build:test:packages', 'pnpm', ['run', 'build:test:packages'], workspaceRoot);
-}
-
 function discoverPackageDirs(dir: string): string[] {
     const entries = spawnSync('find', [dir, '-name', 'package.json', '-not', '-path', '*/node_modules/*'], {
         cwd: workspaceRoot,
@@ -196,7 +192,6 @@ smokeDescribe('fresh tango new scaffold smoke tests', () => {
     let packDir: string | null = null;
 
     beforeAll(async () => {
-        ensureScaffoldSmokeBuildPrerequisites();
         const packed = await packLocalTangoPackages();
         packDir = packed.packDir;
         packedPackages = packed.packages;


### PR DESCRIPTION
## Summary
- keep each `tango new` scaffold host-specific and clarify which generated files are durable app code versus generated support surface
- make scaffold README command examples package-manager-correct, including pnpm migration naming without a literal `--`
- add a fresh-app smoke that bootstraps new Express, Next, and Nuxt projects against local Tango packages through install, typecheck, relation codegen, migrations, schema setup, and framework-specific validation

## Validation
- `pnpm run build:test:packages && pnpm exec vitest run packages/codegen/src/frameworks/contracts/template/tests/TemplateBuilder.test.ts packages/codegen/src/frameworks/strategies/express/tests/ExpressScaffoldStrategy.test.ts packages/codegen/src/frameworks/strategies/next/tests/NextScaffoldStrategy.test.ts packages/codegen/src/frameworks/strategies/nuxt/tests/NuxtScaffoldStrategy.test.ts packages/codegen/src/frameworks/scaffold/tests/scaffoldProject.test.ts packages/codegen/src/commands/tests/registerCodegenCommands.test.ts`
- `pnpm --filter @danceroutine/tango-codegen typecheck:prod`
- `TANGO_RUN_SMOKE=true pnpm run build:test:packages && TANGO_RUN_SMOKE=true pnpm exec vitest run tests/smoke/scaffolded-new.smoke.test.ts`

Closes #35
Closes #38
Closes #39