### PR TITLE
feat(adapters): add request-scoped write transactions

### DIFF
--- a/.changeset/olive-steaks-rush.md
+++ b/.changeset/olive-steaks-rush.md
@@ -1,0 +1,12 @@
+---
+'@danceroutine/tango-adapters-core': minor
+'@danceroutine/tango-adapters-express': minor
+'@danceroutine/tango-adapters-next': minor
+'@danceroutine/tango-adapters-nuxt': minor
+---
+
+Add opt-in request-scoped write transactions to the Express, Next.js, and Nuxt adapters.
+
+Setting `transaction: 'writes'` on an adapted resource now wraps `POST`, `PUT`, `PATCH`, and `DELETE` handlers in a single `transaction.atomic(...)` boundary, so multi-step writes can commit or roll back as one request-level unit. `GET`, `HEAD`, and `OPTIONS` continue to run outside that wrapper.
+
+The first release is scoped to the Tango runtime your application installs as its default runtime. It keeps the existing nested transaction and `tx.onCommit(...)` semantics, and it leaves request abort and disconnect handling to the follow-up design work tracked separately.

--- a/docs/how-to/build-your-api-with-viewsets.md
+++ b/docs/how-to/build-your-api-with-viewsets.md
@@ -78,6 +78,43 @@ export const { GET, POST, PATCH, PUT, DELETE } = adapter.adaptViewSet(new PostVi
 
 The `[[...tango]]` catch-all segment lets the adapter handle both `/api/posts` and `/api/posts/123` through the same viewset instance.
 
+### Opt into request-scoped write transactions
+
+If one resource should treat each write request as a single database unit of work, enable the adapter's writes-only transaction mode when you hand the viewset to the adapter.
+
+In Express:
+
+```ts
+const adapter = new ExpressAdapter();
+adapter.registerViewSet(app, '/api/posts', new PostViewSet(), {
+    transaction: 'writes',
+});
+```
+
+In Next.js:
+
+```ts
+const adapter = new NextAdapter();
+
+export const { GET, POST, PATCH, PUT, DELETE } = adapter.adaptViewSet(new PostViewSet(), {
+    transaction: 'writes',
+});
+```
+
+In Nuxt:
+
+```ts
+const adapter = new NuxtAdapter();
+
+export default adapter.adaptViewSet(new PostViewSet(), {
+    transaction: 'writes',
+});
+```
+
+That option wraps `POST`, `PUT`, `PATCH`, and `DELETE` requests in one `transaction.atomic(...)` boundary. `GET`, `HEAD`, and `OPTIONS` stay outside the wrapper. The current adapter transaction mode uses the Tango runtime your application installs as its default runtime.
+
+Use this when one request's database writes should commit or roll back as one unit. Keep using explicit `transaction.atomic(...)` blocks inside application code when the workflow needs a narrower boundary or when a non-standard mutating route should opt in manually.
+
 ## Add filtering to the list endpoint
 
 Once the CRUD surface is in place, the next question is usually which query parameters the posts list should accept. Filtering decides which records are eligible to appear in the list response. Pagination answers a different question, namely how a client moves through that result set. It is usually easier to define the filtering contract first, test that the eligible rows are correct, and then add pagination once the list semantics are stable.

--- a/docs/topics/orm-and-querysets.md
+++ b/docs/topics/orm-and-querysets.md
@@ -410,6 +410,12 @@ await transaction.atomic(async (tx) => {
 
 Nested `atomic()` blocks keep their own callback frame. If a nested savepoint rolls back, only that nested frame's callbacks are discarded. A successful nested block merges its callbacks into the parent in registration order.
 
+If you enable request-scoped write transactions in a host adapter, keep one extra boundary in mind:
+
+::: warning
+A non-robust `tx.onCommit(...)` callback can still throw after the database commit succeeds. If that happens inside a request-scoped adapter transaction wrapper, the request may return an error even though the write is already durable.
+:::
+
 ## Why Tango uses `tx.onCommit(...)` instead of a global helper
 
 Django exposes `transaction.on_commit(...)` as a package-level helper because ambient transaction state is a natural fit in Python code. Tango keeps reads and writes ambient inside `atomic(...)`, but it does not make post-commit registration ambient.

--- a/packages/adapters/core/package.json
+++ b/packages/adapters/core/package.json
@@ -44,9 +44,12 @@
         "directory": "packages/adapters/core"
     },
     "dependencies": {
+        "@danceroutine/tango-core": "workspace:*",
+        "@danceroutine/tango-orm": "workspace:*",
         "@danceroutine/tango-resources": "workspace:*"
     },
     "devDependencies": {
+        "@danceroutine/tango-testing": "workspace:*",
         "@types/node": "^22.9.0",
         "tsdown": "^0.4.0",
         "typescript": "^5.6.3",

--- a/packages/adapters/core/src/adapter/FrameworkAdapter.ts
+++ b/packages/adapters/core/src/adapter/FrameworkAdapter.ts
@@ -1,4 +1,5 @@
 import type { RequestContext, BaseUser } from '@danceroutine/tango-resources';
+import type { FrameworkTransactionPolicy } from './internal/InternalFrameworkTransactionPolicy';
 /**
  * Adapter interface for integrating Tango with a given framework.
  * @template TResponse - The response type.
@@ -19,6 +20,7 @@ export const FRAMEWORK_ADAPTER_BRAND = 'tango.adapter.framework' as const;
  */
 export interface FrameworkAdapterOptions<TRequest = unknown> {
     getUser?: (request: TRequest) => Promise<BaseUser | null> | BaseUser | null;
+    transaction?: FrameworkTransactionPolicy;
 }
 
 type FrameworkAdapterShape = {

--- a/packages/adapters/core/src/adapter/index.ts
+++ b/packages/adapters/core/src/adapter/index.ts
@@ -4,3 +4,9 @@
 
 export type { FrameworkAdapter, FrameworkAdapterOptions } from './FrameworkAdapter';
 export { FRAMEWORK_ADAPTER_BRAND, isFrameworkAdapter } from './FrameworkAdapter';
+export type { FrameworkTransactionPolicy } from './internal/InternalFrameworkTransactionPolicy';
+export {
+    BoundFrameworkAdapterRequestExecutor,
+    FrameworkAdapterRequestExecutor,
+    type MaterializedTangoResponse,
+} from './internal/FrameworkAdapterRequestExecutor';

--- a/packages/adapters/core/src/adapter/index.ts
+++ b/packages/adapters/core/src/adapter/index.ts
@@ -8,5 +8,4 @@ export type { FrameworkTransactionPolicy } from './internal/InternalFrameworkTra
 export {
     BoundFrameworkAdapterRequestExecutor,
     FrameworkAdapterRequestExecutor,
-    type MaterializedTangoResponse,
 } from './internal/FrameworkAdapterRequestExecutor';

--- a/packages/adapters/core/src/adapter/internal/FrameworkAdapterRequestExecutor.ts
+++ b/packages/adapters/core/src/adapter/internal/FrameworkAdapterRequestExecutor.ts
@@ -1,4 +1,4 @@
-import type { TangoResponse } from '@danceroutine/tango-core';
+import { TangoResponse } from '@danceroutine/tango-core';
 import { atomic } from '@danceroutine/tango-orm/transaction';
 import { InternalHttpMethod } from '../../domain/internal/InternalHttpMethod';
 import type { FrameworkTransactionPolicy } from './InternalFrameworkTransactionPolicy';
@@ -10,13 +10,6 @@ const TRANSACTIONAL_HTTP_METHODS = new Set<string>([
     InternalHttpMethod.PATCH,
     InternalHttpMethod.DELETE,
 ]);
-
-export type MaterializedTangoResponse = {
-    status: number;
-    statusText: string;
-    headers: Headers;
-    body?: Uint8Array<ArrayBuffer>;
-};
 
 type FrameworkHandler<TContext> =
     | ((ctx: TContext) => Promise<TangoResponse>)
@@ -54,17 +47,8 @@ export class FrameworkAdapterRequestExecutor {
         return atomic(async () => work());
     }
 
-    async materializeTangoResponse(response: TangoResponse): Promise<MaterializedTangoResponse> {
-        const webResponse = response.toWebResponse();
-        const body =
-            webResponse.body === null ? undefined : new Uint8Array<ArrayBuffer>(await webResponse.arrayBuffer());
-
-        return {
-            status: webResponse.status,
-            statusText: webResponse.statusText,
-            headers: new Headers(webResponse.headers),
-            body,
-        };
+    toWebResponse(response: TangoResponse): Response {
+        return response.toWebResponse();
     }
 }
 
@@ -78,13 +62,16 @@ export class BoundFrameworkAdapterRequestExecutor<TContext> {
         private readonly invocation: FrameworkHandlerInvocation<TContext>
     ) {}
 
-    async runMaterializedResponse(
+    async runResponse(
         method: string | undefined,
         transaction: FrameworkTransactionPolicy | undefined
-    ): Promise<MaterializedTangoResponse> {
-        return this.requestExecutor.runRequestTransaction(method, transaction, async () =>
-            this.requestExecutor.materializeTangoResponse(await this.invokeHandler())
-        );
+    ): Promise<TangoResponse> {
+        return this.requestExecutor.runRequestTransaction(method, transaction, async () => this.invokeHandler());
+    }
+
+    async runWebResponse(method: string | undefined, transaction: FrameworkTransactionPolicy | undefined): Promise<Response> {
+        const response = await this.runResponse(method, transaction);
+        return this.requestExecutor.toWebResponse(response);
     }
 
     private async invokeHandler(): Promise<TangoResponse> {

--- a/packages/adapters/core/src/adapter/internal/FrameworkAdapterRequestExecutor.ts
+++ b/packages/adapters/core/src/adapter/internal/FrameworkAdapterRequestExecutor.ts
@@ -1,0 +1,97 @@
+import type { TangoResponse } from '@danceroutine/tango-core';
+import { atomic } from '@danceroutine/tango-orm/transaction';
+import { InternalHttpMethod } from '../../domain/internal/InternalHttpMethod';
+import type { FrameworkTransactionPolicy } from './InternalFrameworkTransactionPolicy';
+import { InternalFrameworkTransactionPolicy } from './InternalFrameworkTransactionPolicy';
+
+const TRANSACTIONAL_HTTP_METHODS = new Set<string>([
+    InternalHttpMethod.POST,
+    InternalHttpMethod.PUT,
+    InternalHttpMethod.PATCH,
+    InternalHttpMethod.DELETE,
+]);
+
+export type MaterializedTangoResponse = {
+    status: number;
+    statusText: string;
+    headers: Headers;
+    body?: Uint8Array<ArrayBuffer>;
+};
+
+type FrameworkHandler<TContext> =
+    | ((ctx: TContext) => Promise<TangoResponse>)
+    | ((ctx: TContext, id: string) => Promise<TangoResponse>);
+
+type FrameworkHandlerInvocation<TContext> = {
+    ctx: TContext;
+    handler: FrameworkHandler<TContext>;
+    id?: string;
+};
+
+/**
+ * Shared request execution support for host adapters that decide whether a
+ * request should run inside a transaction.
+ */
+export class FrameworkAdapterRequestExecutor {
+    forHandler<TContext>(invocation: FrameworkHandlerInvocation<TContext>): BoundFrameworkAdapterRequestExecutor<TContext> {
+        return new BoundFrameworkAdapterRequestExecutor(this, invocation);
+    }
+
+    async runRequestTransaction<T>(
+        method: string | undefined,
+        transaction: FrameworkTransactionPolicy | undefined,
+        work: () => Promise<T>
+    ): Promise<T> {
+        if (transaction !== InternalFrameworkTransactionPolicy.WRITES) {
+            return work();
+        }
+
+        const normalizedMethod = String(method ?? '').toUpperCase();
+        if (!TRANSACTIONAL_HTTP_METHODS.has(normalizedMethod)) {
+            return work();
+        }
+
+        return atomic(async () => work());
+    }
+
+    async materializeTangoResponse(response: TangoResponse): Promise<MaterializedTangoResponse> {
+        const webResponse = response.toWebResponse();
+        const body =
+            webResponse.body === null ? undefined : new Uint8Array<ArrayBuffer>(await webResponse.arrayBuffer());
+
+        return {
+            status: webResponse.status,
+            statusText: webResponse.statusText,
+            headers: new Headers(webResponse.headers),
+            body,
+        };
+    }
+}
+
+/**
+ * Request-scoped executor that binds one Tango handler invocation to the
+ * shared request execution policy.
+ */
+export class BoundFrameworkAdapterRequestExecutor<TContext> {
+    constructor(
+        private readonly requestExecutor: FrameworkAdapterRequestExecutor,
+        private readonly invocation: FrameworkHandlerInvocation<TContext>
+    ) {}
+
+    async runMaterializedResponse(
+        method: string | undefined,
+        transaction: FrameworkTransactionPolicy | undefined
+    ): Promise<MaterializedTangoResponse> {
+        return this.requestExecutor.runRequestTransaction(method, transaction, async () =>
+            this.requestExecutor.materializeTangoResponse(await this.invokeHandler())
+        );
+    }
+
+    private async invokeHandler(): Promise<TangoResponse> {
+        const { ctx, handler, id } = this.invocation;
+        if (id && handler.length > 1) {
+            return (handler as (ctx: TContext, id: string) => Promise<TangoResponse>)(ctx, id);
+        }
+        return (handler as (ctx: TContext) => Promise<TangoResponse>)(ctx);
+    }
+}

--- a/packages/adapters/core/src/adapter/internal/InternalFrameworkTransactionPolicy.ts
+++ b/packages/adapters/core/src/adapter/internal/InternalFrameworkTransactionPolicy.ts
@@ -1,0 +1,6 @@
+export const InternalFrameworkTransactionPolicy = {
+    WRITES: 'writes',
+} as const;
+
+export type FrameworkTransactionPolicy =
+    (typeof InternalFrameworkTransactionPolicy)[keyof typeof InternalFrameworkTransactionPolicy];

--- a/packages/adapters/core/src/adapter/internal/tests/FrameworkAdapterRequestExecutor.test.ts
+++ b/packages/adapters/core/src/adapter/internal/tests/FrameworkAdapterRequestExecutor.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TangoResponse } from '@danceroutine/tango-core';
+import { InternalFrameworkTransactionPolicy } from '../InternalFrameworkTransactionPolicy';
+import {
+    BoundFrameworkAdapterRequestExecutor,
+    FrameworkAdapterRequestExecutor,
+} from '../FrameworkAdapterRequestExecutor';
+
+const atomicSpy = vi.hoisted(() => vi.fn(async (work: () => Promise<unknown>) => work()));
+
+vi.mock('@danceroutine/tango-orm/transaction', () => ({
+    atomic: atomicSpy,
+}));
+
+describe(FrameworkAdapterRequestExecutor, () => {
+    beforeEach(() => {
+        atomicSpy.mockClear();
+    });
+
+    describe(FrameworkAdapterRequestExecutor.prototype.runRequestTransaction, () => {
+        it('wraps write methods when the writes-only transaction policy is enabled', async () => {
+            const executor = new FrameworkAdapterRequestExecutor();
+            const work = vi.fn(async () => 'done');
+
+            await executor.runRequestTransaction('POST', InternalFrameworkTransactionPolicy.WRITES, work);
+            await executor.runRequestTransaction('PUT', InternalFrameworkTransactionPolicy.WRITES, work);
+            await executor.runRequestTransaction('PATCH', InternalFrameworkTransactionPolicy.WRITES, work);
+            await executor.runRequestTransaction('DELETE', InternalFrameworkTransactionPolicy.WRITES, work);
+
+            expect(atomicSpy).toHaveBeenCalledTimes(4);
+            expect(work).toHaveBeenCalledTimes(4);
+        });
+
+        it('does not wrap read or metadata methods', async () => {
+            const executor = new FrameworkAdapterRequestExecutor();
+            const work = vi.fn(async () => 'done');
+
+            await executor.runRequestTransaction('GET', InternalFrameworkTransactionPolicy.WRITES, work);
+            await executor.runRequestTransaction('HEAD', InternalFrameworkTransactionPolicy.WRITES, work);
+            await executor.runRequestTransaction('OPTIONS', InternalFrameworkTransactionPolicy.WRITES, work);
+
+            expect(atomicSpy).not.toHaveBeenCalled();
+            expect(work).toHaveBeenCalledTimes(3);
+        });
+
+        it('does not wrap requests when the method is missing', async () => {
+            const executor = new FrameworkAdapterRequestExecutor();
+            const work = vi.fn(async () => 'done');
+
+            await executor.runRequestTransaction(undefined, InternalFrameworkTransactionPolicy.WRITES, work);
+
+            expect(atomicSpy).not.toHaveBeenCalled();
+            expect(work).toHaveBeenCalledTimes(1);
+        });
+
+        it('does not wrap requests when no transaction policy is configured', async () => {
+            const executor = new FrameworkAdapterRequestExecutor();
+            const work = vi.fn(async () => 'done');
+
+            await executor.runRequestTransaction('POST', undefined, work);
+
+            expect(atomicSpy).not.toHaveBeenCalled();
+            expect(work).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe(FrameworkAdapterRequestExecutor.prototype.forHandler, () => {
+        it('creates a bound request executor', () => {
+            const executor = new FrameworkAdapterRequestExecutor();
+            const boundExecutor = executor.forHandler({
+                ctx: { requestId: 'req-1' },
+                handler: async () => TangoResponse.text('ok'),
+            });
+
+            expect(boundExecutor).toBeInstanceOf(BoundFrameworkAdapterRequestExecutor);
+        });
+    });
+});
+
+describe(BoundFrameworkAdapterRequestExecutor, () => {
+    describe(BoundFrameworkAdapterRequestExecutor.prototype.runMaterializedResponse, () => {
+        it('materializes the Tango response returned by application code', async () => {
+            const executor = new FrameworkAdapterRequestExecutor();
+            const boundExecutor = executor.forHandler({
+                ctx: { requestId: 'req-1' },
+                handler: async () => TangoResponse.text('hello', { status: 202 }),
+            });
+
+            const materialized = await boundExecutor.runMaterializedResponse('GET', undefined);
+
+            expect(materialized.status).toBe(202);
+            expect(materialized.headers.get('content-type')).toContain('text/plain');
+            expect(new TextDecoder().decode(materialized.body)).toBe('hello');
+        });
+
+        it('materializes empty responses without a body payload', async () => {
+            const executor = new FrameworkAdapterRequestExecutor();
+            const boundExecutor = executor.forHandler({
+                ctx: { requestId: 'req-1' },
+                handler: async () => new TangoResponse({ status: 204 }),
+            });
+
+            const materialized = await boundExecutor.runMaterializedResponse('GET', undefined);
+
+            expect(materialized.status).toBe(204);
+            expect(materialized.body).toBeUndefined();
+        });
+
+        it('passes the bound id to handlers that expect it', async () => {
+            const executor = new FrameworkAdapterRequestExecutor();
+            const handler = vi.fn(async (_ctx: { requestId: string }, id: string) =>
+                TangoResponse.json({ id }, { status: 200 })
+            );
+            const boundExecutor = executor.forHandler({
+                ctx: { requestId: 'req-1' },
+                handler,
+                id: 'post-42',
+            });
+
+            const materialized = await boundExecutor.runMaterializedResponse('GET', undefined);
+
+            expect(handler).toHaveBeenCalledWith({ requestId: 'req-1' }, 'post-42');
+            expect(new TextDecoder().decode(materialized.body)).toContain('post-42');
+        });
+
+        it('omits the id when handlers only expect the request context', async () => {
+            const executor = new FrameworkAdapterRequestExecutor();
+            const handler = vi.fn(async (ctx: { requestId: string }) =>
+                TangoResponse.json({ requestId: ctx.requestId }, { status: 200 })
+            );
+            const boundExecutor = executor.forHandler({
+                ctx: { requestId: 'req-1' },
+                handler,
+                id: 'post-42',
+            });
+
+            const materialized = await boundExecutor.runMaterializedResponse('GET', undefined);
+
+            expect(handler).toHaveBeenCalledWith({ requestId: 'req-1' });
+            expect(new TextDecoder().decode(materialized.body)).toContain('req-1');
+        });
+    });
+});

--- a/packages/adapters/core/src/adapter/internal/tests/FrameworkAdapterRequestExecutor.test.ts
+++ b/packages/adapters/core/src/adapter/internal/tests/FrameworkAdapterRequestExecutor.test.ts
@@ -12,6 +12,16 @@ vi.mock('@danceroutine/tango-orm/transaction', () => ({
     atomic: atomicSpy,
 }));
 
+function streamFromText(text: string): ReadableStream<Uint8Array> {
+    const encoded = new TextEncoder().encode(text);
+    return new ReadableStream<Uint8Array>({
+        start(controller) {
+            controller.enqueue(encoded);
+            controller.close();
+        },
+    });
+}
+
 describe(FrameworkAdapterRequestExecutor, () => {
     beforeEach(() => {
         atomicSpy.mockClear();
@@ -78,32 +88,49 @@ describe(FrameworkAdapterRequestExecutor, () => {
 });
 
 describe(BoundFrameworkAdapterRequestExecutor, () => {
-    describe(BoundFrameworkAdapterRequestExecutor.prototype.runMaterializedResponse, () => {
-        it('materializes the Tango response returned by application code', async () => {
+    describe(BoundFrameworkAdapterRequestExecutor.prototype.runResponse, () => {
+        it('returns the Tango response produced by application code', async () => {
             const executor = new FrameworkAdapterRequestExecutor();
             const boundExecutor = executor.forHandler({
                 ctx: { requestId: 'req-1' },
                 handler: async () => TangoResponse.text('hello', { status: 202 }),
             });
 
-            const materialized = await boundExecutor.runMaterializedResponse('GET', undefined);
+            const response = await boundExecutor.runResponse('GET', undefined);
+            const webResponse = response.toWebResponse();
 
-            expect(materialized.status).toBe(202);
-            expect(materialized.headers.get('content-type')).toContain('text/plain');
-            expect(new TextDecoder().decode(materialized.body)).toBe('hello');
+            expect(webResponse.status).toBe(202);
+            expect(webResponse.headers.get('content-type')).toContain('text/plain');
+            expect(await webResponse.text()).toBe('hello');
         });
 
-        it('materializes empty responses without a body payload', async () => {
+        it('preserves streaming responses without buffering them first', async () => {
+            const executor = new FrameworkAdapterRequestExecutor();
+            const boundExecutor = executor.forHandler({
+                ctx: { requestId: 'req-1' },
+                handler: async () => TangoResponse.stream(streamFromText('hello stream'), { status: 206 }),
+            });
+
+            const response = await boundExecutor.runResponse('GET', undefined);
+            const webResponse = response.toWebResponse();
+
+            expect(response.body).toBeInstanceOf(ReadableStream);
+            expect(webResponse.status).toBe(206);
+            expect(await webResponse.text()).toBe('hello stream');
+        });
+
+        it('returns empty responses without a body payload', async () => {
             const executor = new FrameworkAdapterRequestExecutor();
             const boundExecutor = executor.forHandler({
                 ctx: { requestId: 'req-1' },
                 handler: async () => new TangoResponse({ status: 204 }),
             });
 
-            const materialized = await boundExecutor.runMaterializedResponse('GET', undefined);
+            const response = await boundExecutor.runResponse('GET', undefined);
+            const webResponse = response.toWebResponse();
 
-            expect(materialized.status).toBe(204);
-            expect(materialized.body).toBeUndefined();
+            expect(webResponse.status).toBe(204);
+            expect(webResponse.body).toBeNull();
         });
 
         it('passes the bound id to handlers that expect it', async () => {
@@ -117,10 +144,11 @@ describe(BoundFrameworkAdapterRequestExecutor, () => {
                 id: 'post-42',
             });
 
-            const materialized = await boundExecutor.runMaterializedResponse('GET', undefined);
+            const response = await boundExecutor.runResponse('GET', undefined);
+            const webResponse = response.toWebResponse();
 
             expect(handler).toHaveBeenCalledWith({ requestId: 'req-1' }, 'post-42');
-            expect(new TextDecoder().decode(materialized.body)).toContain('post-42');
+            expect(await webResponse.text()).toContain('post-42');
         });
 
         it('omits the id when handlers only expect the request context', async () => {
@@ -134,10 +162,26 @@ describe(BoundFrameworkAdapterRequestExecutor, () => {
                 id: 'post-42',
             });
 
-            const materialized = await boundExecutor.runMaterializedResponse('GET', undefined);
+            const response = await boundExecutor.runResponse('GET', undefined);
+            const webResponse = response.toWebResponse();
 
             expect(handler).toHaveBeenCalledWith({ requestId: 'req-1' });
-            expect(new TextDecoder().decode(materialized.body)).toContain('req-1');
+            expect(await webResponse.text()).toContain('req-1');
+        });
+    });
+
+    describe(BoundFrameworkAdapterRequestExecutor.prototype.runWebResponse, () => {
+        it('converts Tango responses to native web responses after the handler runs', async () => {
+            const executor = new FrameworkAdapterRequestExecutor();
+            const boundExecutor = executor.forHandler({
+                ctx: { requestId: 'req-1' },
+                handler: async () => TangoResponse.text('native', { status: 203 }),
+            });
+
+            const response = await boundExecutor.runWebResponse('GET', undefined);
+
+            expect(response.status).toBe(203);
+            expect(await response.text()).toBe('native');
         });
     });
 });

--- a/packages/adapters/core/src/index.ts
+++ b/packages/adapters/core/src/index.ts
@@ -5,7 +5,7 @@
 export * as adapter from './adapter/index';
 export * as domain from './domain/index';
 
-export type { FrameworkAdapter, FrameworkAdapterOptions } from './adapter/index';
+export type { FrameworkAdapter, FrameworkAdapterOptions, FrameworkTransactionPolicy } from './adapter/index';
 export { FRAMEWORK_ADAPTER_BRAND, isFrameworkAdapter } from './adapter/index';
 // Exported because adapters-core is an internal package aimed at consumers that would act as the public interface
 export {

--- a/packages/adapters/express/README.md
+++ b/packages/adapters/express/README.md
@@ -90,6 +90,16 @@ async function main(): Promise<void> {
 
 `ExpressAdapter` also exposes `toQueryParams(req)` for application code that wants the same normalized query contract resources use internally. That helper returns `TangoQueryParams` from `@danceroutine/tango-core` and stays focused on Express-to-Tango normalization.
 
+If one resource should treat each write request as a single database unit of work, enable the adapter's writes-only transaction mode:
+
+```ts
+adapter.registerViewSet(app, '/api/todos', viewset, {
+    transaction: 'writes',
+});
+```
+
+That option wraps `POST`, `PUT`, `PATCH`, and `DELETE` requests in one `transaction.atomic(...)` boundary. `GET`, `HEAD`, and `OPTIONS` stay outside the wrapper. The current adapter transaction mode uses the Tango runtime your application installs as its default runtime.
+
 ## Public API
 
 The root export includes:

--- a/packages/adapters/express/package.json
+++ b/packages/adapters/express/package.json
@@ -47,6 +47,7 @@
         "express": "^4.21.1 || ^5.0.0"
     },
     "devDependencies": {
+        "@danceroutine/tango-orm": "workspace:*",
         "@danceroutine/tango-testing": "workspace:*",
         "@types/express": "^5.0.0",
         "@types/node": "^22.9.0",

--- a/packages/adapters/express/src/adapter/ExpressAdapter.ts
+++ b/packages/adapters/express/src/adapter/ExpressAdapter.ts
@@ -4,6 +4,7 @@ import { RequestContext } from '@danceroutine/tango-resources';
 import { TangoQueryParams, TangoResponse } from '@danceroutine/tango-core';
 import {
     FRAMEWORK_ADAPTER_BRAND,
+    FrameworkAdapterRequestExecutor,
     type FrameworkAdapter,
     type FrameworkAdapterOptions,
 } from '@danceroutine/tango-adapters-core/adapter';
@@ -53,6 +54,7 @@ export interface ExpressRouteRegistrar {
  */
 export class ExpressAdapter implements FrameworkAdapter<Response, RequestHandler, ExpressRequest> {
     readonly __tangoBrand: typeof FRAMEWORK_ADAPTER_BRAND = FRAMEWORK_ADAPTER_BRAND;
+    private readonly requestExecutor = new FrameworkAdapterRequestExecutor();
 
     /**
      * Normalize an Express request into Tango query params.
@@ -244,7 +246,9 @@ export class ExpressAdapter implements FrameworkAdapter<Response, RequestHandler
 
                 const rawId = req.params.id;
                 const id = Array.isArray(rawId) ? rawId[0] : rawId;
-                const response = (await this.callHandler(handler, ctx, id)).toWebResponse();
+                const response = await this.requestExecutor
+                    .forHandler({ handler, ctx, id })
+                    .runMaterializedResponse(req.method, options.transaction);
 
                 res.status(response.status);
 
@@ -257,29 +261,26 @@ export class ExpressAdapter implements FrameworkAdapter<Response, RequestHandler
                     return;
                 }
 
-                const text = await response.text();
-                res.send(text);
+                res.send(this.normalizeResponseBody(response.body, response.headers));
             } catch (error) {
                 next(error);
             }
         };
     }
 
+    private normalizeResponseBody(body: Uint8Array<ArrayBuffer>, headers: Headers): string | Buffer {
+        const contentType = headers.get('content-type')?.toLowerCase() ?? '';
+        if (contentType.startsWith('text/') || contentType.includes('json')) {
+            return new TextDecoder().decode(body);
+        }
+
+        return Buffer.from(body);
+    }
+
     private normalizeParams(params: Record<string, string | string[]>): Record<string, string> {
         return Object.fromEntries(
             Object.entries(params).map(([key, value]) => [key, Array.isArray(value) ? (value[0] ?? '') : value])
         );
-    }
-
-    private async callHandler(
-        handler: (ctx: RequestContext, ...args: unknown[]) => Promise<TangoResponse>,
-        ctx: RequestContext,
-        id?: string
-    ): Promise<TangoResponse> {
-        if (id && handler.length > 1) {
-            return handler(ctx, id);
-        }
-        return handler(ctx);
     }
 
     private toRequestFromExpress(req: ExpressRequest): Request {

--- a/packages/adapters/express/src/adapter/ExpressAdapter.ts
+++ b/packages/adapters/express/src/adapter/ExpressAdapter.ts
@@ -1,4 +1,6 @@
 import type { Request as ExpressRequest, Response as ExpressResponse, NextFunction, RequestHandler } from 'express';
+import { Readable } from 'node:stream';
+import type { ReadableStream as NodeReadableStream } from 'node:stream/web';
 import { Router } from 'express';
 import { RequestContext } from '@danceroutine/tango-resources';
 import { TangoQueryParams, TangoResponse } from '@danceroutine/tango-core';
@@ -246,9 +248,11 @@ export class ExpressAdapter implements FrameworkAdapter<Response, RequestHandler
 
                 const rawId = req.params.id;
                 const id = Array.isArray(rawId) ? rawId[0] : rawId;
-                const response = await this.requestExecutor
-                    .forHandler({ handler, ctx, id })
-                    .runMaterializedResponse(req.method, options.transaction);
+                const tangoResponse = await this.requestExecutor.forHandler({ handler, ctx, id }).runResponse(
+                    req.method,
+                    options.transaction
+                );
+                const response = tangoResponse.toWebResponse();
 
                 res.status(response.status);
 
@@ -256,16 +260,35 @@ export class ExpressAdapter implements FrameworkAdapter<Response, RequestHandler
                     res.setHeader(key, value);
                 });
 
-                if (!response.body) {
+                if (response.body === null) {
                     res.end();
                     return;
                 }
 
-                res.send(this.normalizeResponseBody(response.body, response.headers));
+                if (tangoResponse.body !== null) {
+                    await this.pipeReadableStream(response.body, res);
+                    return;
+                }
+
+                const body = new Uint8Array<ArrayBuffer>(await response.arrayBuffer());
+                res.send(this.normalizeResponseBody(body, response.headers));
             } catch (error) {
                 next(error);
             }
         };
+    }
+
+    private async pipeReadableStream(
+        body: ReadableStream<Uint8Array<ArrayBuffer>>,
+        res: ExpressResponse
+    ): Promise<void> {
+        await new Promise<void>((resolve, reject) => {
+            const stream = Readable.fromWeb(body as unknown as NodeReadableStream);
+            stream.on('error', reject);
+            res.on('error', reject);
+            res.on('finish', () => resolve());
+            stream.pipe(res);
+        });
     }
 
     private normalizeResponseBody(body: Uint8Array<ArrayBuffer>, headers: Headers): string | Buffer {

--- a/packages/adapters/express/src/adapter/tests/ExpressAdapter.test.ts
+++ b/packages/adapters/express/src/adapter/tests/ExpressAdapter.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NextFunction, Request, Response } from 'express';
+import { PassThrough } from 'node:stream';
 import { TangoQueryParams, TangoResponse } from '@danceroutine/tango-core';
 import { isFrameworkAdapter } from '@danceroutine/tango-adapters-core';
 import { aDBClient, aTangoConfig, anExpressRequest, anExpressResponse } from '@danceroutine/tango-testing';
@@ -19,6 +20,16 @@ function textResponse(text: string, status: number = 200, headers?: HeadersInit)
 
 function bodyResponse(body: BodyInit | null, status: number = 200, headers?: HeadersInit): TangoResponse {
     return new TangoResponse({ body, status, headers });
+}
+
+function streamFromText(text: string): ReadableStream<Uint8Array> {
+    const encoded = new TextEncoder().encode(text);
+    return new ReadableStream<Uint8Array>({
+        start(controller) {
+            controller.enqueue(encoded);
+            controller.close();
+        },
+    });
 }
 
 function emptyResponse(status: number): TangoResponse {
@@ -195,6 +206,35 @@ describe(ExpressAdapter, () => {
         expect(res.status).toHaveBeenCalledWith(204);
         expect(res.end).toHaveBeenCalled();
         expect(res.send).not.toHaveBeenCalled();
+    });
+
+    it('streams readable responses to Express without buffering them first', async () => {
+        const adapter = new ExpressAdapter();
+        const routeHandler = adapter.adapt(async () =>
+            TangoResponse.stream(streamFromText('streamed body'), {
+                status: 206,
+                headers: { 'content-type': 'text/plain' },
+            })
+        );
+
+        const req = anExpressRequest({ method: 'GET', originalUrl: '/stream', url: '/stream' });
+        const res = new PassThrough() as PassThrough & Response;
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk) => {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        });
+        res.status = vi.fn().mockReturnValue(res);
+        res.setHeader = vi.fn().mockReturnValue(res);
+        res.send = vi.fn().mockReturnValue(res);
+        const next = vi.fn() as unknown as NextFunction;
+
+        await routeHandler(req, res, next);
+
+        expect(res.status).toHaveBeenCalledWith(206);
+        expect(res.setHeader).toHaveBeenCalledWith('content-type', 'text/plain');
+        expect(res.send).not.toHaveBeenCalled();
+        expect(Buffer.concat(chunks).toString()).toBe('streamed body');
+        expect(next).not.toHaveBeenCalled();
     });
 
     it('passes handler failures to the next middleware', async () => {

--- a/packages/adapters/express/src/adapter/tests/ExpressAdapter.test.ts
+++ b/packages/adapters/express/src/adapter/tests/ExpressAdapter.test.ts
@@ -1,8 +1,10 @@
-import { describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NextFunction, Request, Response } from 'express';
 import { TangoQueryParams, TangoResponse } from '@danceroutine/tango-core';
 import { isFrameworkAdapter } from '@danceroutine/tango-adapters-core';
-import { anExpressRequest, anExpressResponse } from '@danceroutine/tango-testing';
+import { aDBClient, aTangoConfig, anExpressRequest, anExpressResponse } from '@danceroutine/tango-testing';
+import { getTangoRuntime, initializeTangoRuntime, resetTangoRuntime } from '@danceroutine/tango-orm/runtime';
+import { atomic } from '@danceroutine/tango-orm/transaction';
 import { ExpressAdapter } from '..';
 
 type RouteHandler = (req: Request, res: Response, next: NextFunction) => Promise<void>;
@@ -39,7 +41,31 @@ function findRegisteredHandler(methodMock: ReturnType<typeof vi.fn>, path: strin
     return call[1] as RouteHandler;
 }
 
+function setupTransactionalRuntime() {
+    const runtime = initializeTangoRuntime(() => aTangoConfig());
+    const client = aDBClient();
+    const release = vi.fn(async () => {});
+
+    vi.spyOn(runtime, 'leaseTransactionClient').mockResolvedValue({ client, release });
+    const runtimeQuery = vi.spyOn(runtime, 'query').mockResolvedValue({ rows: [] });
+
+    return {
+        runtime,
+        client,
+        release,
+        runtimeQuery,
+    };
+}
+
 describe(ExpressAdapter, () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterEach(async () => {
+        await resetTangoRuntime();
+    });
+
     it('satisfies the shared framework adapter typeguard', () => {
         expect(isFrameworkAdapter(new ExpressAdapter())).toBe(true);
     });
@@ -185,6 +211,114 @@ describe(ExpressAdapter, () => {
         await routeHandler(req, res, next);
 
         expect(next).toHaveBeenCalledWith(expected);
+    });
+
+    it('wraps POST handlers in one request-scoped transaction when writes mode is enabled', async () => {
+        const { client, release, runtimeQuery } = setupTransactionalRuntime();
+        const adapter = new ExpressAdapter();
+        const routeHandler = adapter.adapt(
+            async () => {
+                const runtimeClient = await getTangoRuntime().getClient();
+                await runtimeClient.query('INSERT INTO todos VALUES ($1)', [1]);
+                return jsonResponse({ ok: true }, 201);
+            },
+            { transaction: 'writes' }
+        );
+
+        const req = anExpressRequest({ method: 'POST', originalUrl: '/todos', url: '/todos' });
+        const res = anExpressResponse();
+        const next = vi.fn() as unknown as NextFunction;
+
+        await routeHandler(req, res, next);
+
+        expect(client.begin).toHaveBeenCalledOnce();
+        expect(client.query).toHaveBeenCalledWith('INSERT INTO todos VALUES ($1)', [1]);
+        expect(client.commit).toHaveBeenCalledOnce();
+        expect(client.rollback).not.toHaveBeenCalled();
+        expect(runtimeQuery).not.toHaveBeenCalled();
+        expect(release).toHaveBeenCalledOnce();
+        expect(res.status).toHaveBeenCalledWith(201);
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('does not wrap GET handlers in a request transaction when writes mode is enabled', async () => {
+        const { client, runtimeQuery } = setupTransactionalRuntime();
+        const adapter = new ExpressAdapter();
+        const routeHandler = adapter.adapt(
+            async () => {
+                const runtimeClient = await getTangoRuntime().getClient();
+                await runtimeClient.query('SELECT 1');
+                return jsonResponse({ ok: true }, 200);
+            },
+            { transaction: 'writes' }
+        );
+
+        const req = anExpressRequest({ method: 'GET', originalUrl: '/todos', url: '/todos' });
+        const res = anExpressResponse();
+        const next = vi.fn() as unknown as NextFunction;
+
+        await routeHandler(req, res, next);
+
+        expect(client.begin).not.toHaveBeenCalled();
+        expect(client.commit).not.toHaveBeenCalled();
+        expect(client.rollback).not.toHaveBeenCalled();
+        expect(runtimeQuery).toHaveBeenCalledWith('SELECT 1', undefined);
+        expect(next).not.toHaveBeenCalled();
+    });
+
+    it('rolls back request-scoped write transactions before forwarding handler errors', async () => {
+        const { client, release, runtimeQuery } = setupTransactionalRuntime();
+        const adapter = new ExpressAdapter();
+        const expected = new Error('boom');
+        const routeHandler = adapter.adapt(
+            async () => {
+                const runtimeClient = await getTangoRuntime().getClient();
+                await runtimeClient.query('INSERT INTO todos VALUES ($1)', [1]);
+                throw expected;
+            },
+            { transaction: 'writes' }
+        );
+
+        const req = anExpressRequest({ method: 'POST', originalUrl: '/todos', url: '/todos' });
+        const res = anExpressResponse();
+        const next = vi.fn() as unknown as NextFunction;
+
+        await routeHandler(req, res, next);
+
+        expect(client.begin).toHaveBeenCalledOnce();
+        expect(client.query).toHaveBeenCalledWith('INSERT INTO todos VALUES ($1)', [1]);
+        expect(client.rollback).toHaveBeenCalledOnce();
+        expect(client.commit).not.toHaveBeenCalled();
+        expect(runtimeQuery).not.toHaveBeenCalled();
+        expect(release).toHaveBeenCalledOnce();
+        expect(next).toHaveBeenCalledWith(expected);
+    });
+
+    it('keeps nested atomic work valid inside a wrapped write request', async () => {
+        const { client } = setupTransactionalRuntime();
+        const adapter = new ExpressAdapter();
+        const routeHandler = adapter.adapt(
+            async () => {
+                await atomic(async () => {
+                    const runtimeClient = await getTangoRuntime().getClient();
+                    await runtimeClient.query('INSERT INTO todos VALUES ($1)', [1]);
+                });
+                return jsonResponse({ ok: true }, 201);
+            },
+            { transaction: 'writes' }
+        );
+
+        const req = anExpressRequest({ method: 'POST', originalUrl: '/todos', url: '/todos' });
+        const res = anExpressResponse();
+        const next = vi.fn() as unknown as NextFunction;
+
+        await routeHandler(req, res, next);
+
+        expect(client.begin).toHaveBeenCalledOnce();
+        expect(client.createSavepoint).toHaveBeenCalledWith('tango_sp_0');
+        expect(client.releaseSavepoint).toHaveBeenCalledWith('tango_sp_0');
+        expect(client.commit).toHaveBeenCalledOnce();
+        expect(next).not.toHaveBeenCalled();
     });
 
     it('sets JSON content-type for JSON-like bodies when absent', async () => {

--- a/packages/adapters/next/README.md
+++ b/packages/adapters/next/README.md
@@ -43,6 +43,16 @@ For detail requests, the adapter resolves the identifier, passes it as the secon
 
 `NextAdapter` also exposes `toQueryParams(searchParams)` for route modules and server components that want the same normalized query contract resources use internally. That helper returns `TangoQueryParams` from `@danceroutine/tango-core`.
 
+If one resource should treat each write request as a single database unit of work, pass the adapter's writes-only transaction mode when you adapt the viewset:
+
+```ts
+export const { GET, POST, PATCH, PUT, DELETE } = adapter.adaptViewSet(viewset, {
+    transaction: 'writes',
+});
+```
+
+That option wraps `POST`, `PUT`, `PATCH`, and `DELETE` requests in one `transaction.atomic(...)` boundary. `GET`, `HEAD`, and `OPTIONS` stay outside the wrapper. The current adapter transaction mode uses the Tango runtime your application installs as its default runtime.
+
 ## Public API
 
 The root export includes:

--- a/packages/adapters/next/src/adapter/NextAdapter.ts
+++ b/packages/adapters/next/src/adapter/NextAdapter.ts
@@ -350,15 +350,9 @@ export class NextAdapter implements FrameworkAdapter<Response, NextRouteHandler,
                 }
 
                 const id = params?.id;
-                const response = await this.requestExecutor
+                return await this.requestExecutor
                     .forHandler({ handler, ctx, id })
-                    .runMaterializedResponse(request.method, options.transaction);
-
-                return new Response(response.body, {
-                    headers: response.headers,
-                    status: response.status,
-                    statusText: response.statusText,
-                });
+                    .runWebResponse(request.method, options.transaction);
             } catch (error) {
                 return this.internalServerError(error);
             }

--- a/packages/adapters/next/src/adapter/NextAdapter.ts
+++ b/packages/adapters/next/src/adapter/NextAdapter.ts
@@ -10,6 +10,7 @@ import {
 } from '@danceroutine/tango-core';
 import {
     FRAMEWORK_ADAPTER_BRAND,
+    FrameworkAdapterRequestExecutor,
     type FrameworkAdapter,
     type FrameworkAdapterOptions,
 } from '@danceroutine/tango-adapters-core/adapter';
@@ -94,6 +95,7 @@ type ActionMatch =
 export class NextAdapter implements FrameworkAdapter<Response, NextRouteHandler, NextRequest> {
     readonly __tangoBrand: typeof FRAMEWORK_ADAPTER_BRAND = FRAMEWORK_ADAPTER_BRAND;
     private readonly logger = getLogger('tango.adapter.next');
+    private readonly requestExecutor = new FrameworkAdapterRequestExecutor();
     /**
      * Normalize Next.js-style route search params into Tango query params.
      */
@@ -348,11 +350,15 @@ export class NextAdapter implements FrameworkAdapter<Response, NextRouteHandler,
                 }
 
                 const id = params?.id;
-                if (id && handler.length > 1) {
-                    return (await handler(ctx, id)).toWebResponse();
-                }
+                const response = await this.requestExecutor
+                    .forHandler({ handler, ctx, id })
+                    .runMaterializedResponse(request.method, options.transaction);
 
-                return (await handler(ctx)).toWebResponse();
+                return new Response(response.body, {
+                    headers: response.headers,
+                    status: response.status,
+                    statusText: response.statusText,
+                });
             } catch (error) {
                 return this.internalServerError(error);
             }

--- a/packages/adapters/next/src/adapter/tests/NextAdapter.test.ts
+++ b/packages/adapters/next/src/adapter/tests/NextAdapter.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NextRequest } from 'next/server';
 import { TangoQueryParams, TangoRequest, TangoResponse } from '@danceroutine/tango-core';
 import { isFrameworkAdapter } from '@danceroutine/tango-adapters-core';
+import { BoundFrameworkAdapterRequestExecutor } from '@danceroutine/tango-adapters-core/adapter';
 import { NextAdapter } from '..';
 
 function jsonResponse(data: unknown, status: number = 200): TangoResponse {
@@ -12,7 +13,18 @@ function emptyResponse(status: number): TangoResponse {
     return new TangoResponse({ status });
 }
 
+type BoundRequestExecutorRunner = {
+    runMaterializedResponse: (
+        method: string | undefined,
+        transaction: 'writes' | undefined,
+    ) => Promise<unknown>;
+};
+
 describe(NextAdapter, () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
     it('satisfies the shared framework adapter typeguard', () => {
         expect(isFrameworkAdapter(new NextAdapter())).toBe(true);
     });
@@ -129,6 +141,52 @@ describe(NextAdapter, () => {
         expect(body).toEqual({ error: 'boom', details: null });
         expect(consoleSpy).toHaveBeenCalled();
         consoleSpy.mockRestore();
+    });
+
+    it('forwards the POST request method and policy to request execution support', async () => {
+        const runMaterializedResponseSpy = vi
+            .spyOn(
+                BoundFrameworkAdapterRequestExecutor.prototype as unknown as BoundRequestExecutorRunner,
+                'runMaterializedResponse'
+            )
+            .mockImplementation(async (_method, _transaction) => ({
+                status: 201,
+                statusText: 'Created',
+                headers: new Headers({ 'content-type': 'application/json' }),
+                body: new TextEncoder().encode(JSON.stringify({ ok: true })),
+            }));
+        const adapter = new NextAdapter();
+        const routeHandler = adapter.adapt(async () => jsonResponse({ ok: true }, 201), { transaction: 'writes' });
+
+        const req = { method: 'POST', url: 'http://localhost/users' } as unknown as NextRequest;
+        const response = await routeHandler(req, { params: Promise.resolve({}) });
+
+        expect(response.status).toBe(201);
+        expect(runMaterializedResponseSpy).toHaveBeenCalledWith('POST', 'writes');
+        runMaterializedResponseSpy.mockRestore();
+    });
+
+    it('forwards the GET request method and policy to request execution support', async () => {
+        const runMaterializedResponseSpy = vi
+            .spyOn(
+                BoundFrameworkAdapterRequestExecutor.prototype as unknown as BoundRequestExecutorRunner,
+                'runMaterializedResponse'
+            )
+            .mockImplementation(async (_method, _transaction) => ({
+                status: 200,
+                statusText: 'OK',
+                headers: new Headers({ 'content-type': 'application/json' }),
+                body: new TextEncoder().encode(JSON.stringify({ ok: true })),
+            }));
+        const adapter = new NextAdapter();
+        const routeHandler = adapter.adapt(async () => jsonResponse({ ok: true }, 200), { transaction: 'writes' });
+
+        const req = { method: 'GET', url: 'http://localhost/users' } as unknown as NextRequest;
+        const response = await routeHandler(req, { params: Promise.resolve({}) });
+
+        expect(response.status).toBe(200);
+        expect(runMaterializedResponseSpy).toHaveBeenCalledWith('GET', 'writes');
+        runMaterializedResponseSpy.mockRestore();
     });
 
     it('adapts full CRUD handlers for catch-all routes', async () => {

--- a/packages/adapters/next/src/adapter/tests/NextAdapter.test.ts
+++ b/packages/adapters/next/src/adapter/tests/NextAdapter.test.ts
@@ -14,11 +14,21 @@ function emptyResponse(status: number): TangoResponse {
 }
 
 type BoundRequestExecutorRunner = {
-    runMaterializedResponse: (
+    runWebResponse: (
         method: string | undefined,
         transaction: 'writes' | undefined,
-    ) => Promise<unknown>;
+    ) => Promise<Response>;
 };
+
+function streamFromText(text: string): ReadableStream<Uint8Array> {
+    const encoded = new TextEncoder().encode(text);
+    return new ReadableStream<Uint8Array>({
+        start(controller) {
+            controller.enqueue(encoded);
+            controller.close();
+        },
+    });
+}
 
 describe(NextAdapter, () => {
     beforeEach(() => {
@@ -144,17 +154,12 @@ describe(NextAdapter, () => {
     });
 
     it('forwards the POST request method and policy to request execution support', async () => {
-        const runMaterializedResponseSpy = vi
+        const runWebResponseSpy = vi
             .spyOn(
                 BoundFrameworkAdapterRequestExecutor.prototype as unknown as BoundRequestExecutorRunner,
-                'runMaterializedResponse'
+                'runWebResponse'
             )
-            .mockImplementation(async (_method, _transaction) => ({
-                status: 201,
-                statusText: 'Created',
-                headers: new Headers({ 'content-type': 'application/json' }),
-                body: new TextEncoder().encode(JSON.stringify({ ok: true })),
-            }));
+            .mockImplementation(async () => Response.json({ ok: true }, { status: 201 }));
         const adapter = new NextAdapter();
         const routeHandler = adapter.adapt(async () => jsonResponse({ ok: true }, 201), { transaction: 'writes' });
 
@@ -162,22 +167,17 @@ describe(NextAdapter, () => {
         const response = await routeHandler(req, { params: Promise.resolve({}) });
 
         expect(response.status).toBe(201);
-        expect(runMaterializedResponseSpy).toHaveBeenCalledWith('POST', 'writes');
-        runMaterializedResponseSpy.mockRestore();
+        expect(runWebResponseSpy).toHaveBeenCalledWith('POST', 'writes');
+        runWebResponseSpy.mockRestore();
     });
 
     it('forwards the GET request method and policy to request execution support', async () => {
-        const runMaterializedResponseSpy = vi
+        const runWebResponseSpy = vi
             .spyOn(
                 BoundFrameworkAdapterRequestExecutor.prototype as unknown as BoundRequestExecutorRunner,
-                'runMaterializedResponse'
+                'runWebResponse'
             )
-            .mockImplementation(async (_method, _transaction) => ({
-                status: 200,
-                statusText: 'OK',
-                headers: new Headers({ 'content-type': 'application/json' }),
-                body: new TextEncoder().encode(JSON.stringify({ ok: true })),
-            }));
+            .mockImplementation(async () => Response.json({ ok: true }, { status: 200 }));
         const adapter = new NextAdapter();
         const routeHandler = adapter.adapt(async () => jsonResponse({ ok: true }, 200), { transaction: 'writes' });
 
@@ -185,8 +185,24 @@ describe(NextAdapter, () => {
         const response = await routeHandler(req, { params: Promise.resolve({}) });
 
         expect(response.status).toBe(200);
-        expect(runMaterializedResponseSpy).toHaveBeenCalledWith('GET', 'writes');
-        runMaterializedResponseSpy.mockRestore();
+        expect(runWebResponseSpy).toHaveBeenCalledWith('GET', 'writes');
+        runWebResponseSpy.mockRestore();
+    });
+
+    it('preserves streaming responses without buffering them in the adapter', async () => {
+        const adapter = new NextAdapter();
+        const routeHandler = adapter.adapt(async () =>
+            TangoResponse.stream(streamFromText('next-stream'), {
+                status: 206,
+                headers: { 'content-type': 'text/plain' },
+            })
+        );
+
+        const req = { method: 'GET', url: 'http://localhost/users' } as unknown as NextRequest;
+        const response = await routeHandler(req, { params: Promise.resolve({}) });
+
+        expect(response.status).toBe(206);
+        expect(await response.text()).toBe('next-stream');
     });
 
     it('adapts full CRUD handlers for catch-all routes', async () => {

--- a/packages/adapters/nuxt/README.md
+++ b/packages/adapters/nuxt/README.md
@@ -50,6 +50,16 @@ That gives the adapter one handler for the collection route at `/api/todos` and 
 
 Use `adaptViewSet(...)` when you already have a ready viewset instance in hand. Use `adaptViewSetFactory(...)` when constructing the viewset requires asynchronous setup. The factory result is memoized inside the adapter, and initialization failures clear that memoized promise so a later request can retry cleanly.
 
+If one resource should treat each write request as a single database unit of work, pass the adapter's writes-only transaction mode when you adapt the viewset:
+
+```ts
+export default adapter.adaptViewSet(new TodoViewSet(), {
+    transaction: 'writes',
+});
+```
+
+That option wraps `POST`, `PUT`, `PATCH`, and `DELETE` requests in one `transaction.atomic(...)` boundary. `GET`, `HEAD`, and `OPTIONS` stay outside the wrapper. The current adapter transaction mode uses the Tango runtime your application installs as its default runtime.
+
 ## Public API
 
 The root export includes:

--- a/packages/adapters/nuxt/src/adapter/NuxtAdapter.ts
+++ b/packages/adapters/nuxt/src/adapter/NuxtAdapter.ts
@@ -348,15 +348,9 @@ export class NuxtAdapter implements FrameworkAdapter<Response, NuxtEventHandler,
                 }
 
                 const id = params.id;
-                const response = await this.requestExecutor
+                return await this.requestExecutor
                     .forHandler({ handler, ctx, id })
-                    .runMaterializedResponse(event.method, options.transaction);
-
-                return new Response(response.body, {
-                    headers: response.headers,
-                    status: response.status,
-                    statusText: response.statusText,
-                });
+                    .runWebResponse(event.method, options.transaction);
             } catch (error) {
                 return this.internalServerError(error);
             }

--- a/packages/adapters/nuxt/src/adapter/NuxtAdapter.ts
+++ b/packages/adapters/nuxt/src/adapter/NuxtAdapter.ts
@@ -12,6 +12,7 @@ import {
 } from '@danceroutine/tango-core';
 import {
     FRAMEWORK_ADAPTER_BRAND,
+    FrameworkAdapterRequestExecutor,
     type FrameworkAdapter,
     type FrameworkAdapterOptions,
 } from '@danceroutine/tango-adapters-core/adapter';
@@ -120,6 +121,7 @@ export function toNuxtQueryParams(searchParams: URLSearchParams | NuxtQueryRecor
 export class NuxtAdapter implements FrameworkAdapter<Response, NuxtEventHandler, H3Event> {
     readonly __tangoBrand: typeof FRAMEWORK_ADAPTER_BRAND = FRAMEWORK_ADAPTER_BRAND;
     private readonly logger = getLogger('tango.adapter.nuxt');
+    private readonly requestExecutor = new FrameworkAdapterRequestExecutor();
 
     /**
      * Normalize h3 query params into Tango query params.
@@ -346,11 +348,15 @@ export class NuxtAdapter implements FrameworkAdapter<Response, NuxtEventHandler,
                 }
 
                 const id = params.id;
-                if (id && handler.length > 1) {
-                    return (await handler(ctx, id)).toWebResponse();
-                }
+                const response = await this.requestExecutor
+                    .forHandler({ handler, ctx, id })
+                    .runMaterializedResponse(event.method, options.transaction);
 
-                return (await handler(ctx)).toWebResponse();
+                return new Response(response.body, {
+                    headers: response.headers,
+                    status: response.status,
+                    statusText: response.statusText,
+                });
             } catch (error) {
                 return this.internalServerError(error);
             }

--- a/packages/adapters/nuxt/src/adapter/tests/NuxtAdapter.test.ts
+++ b/packages/adapters/nuxt/src/adapter/tests/NuxtAdapter.test.ts
@@ -74,11 +74,21 @@ function createEvent(
 }
 
 type BoundRequestExecutorRunner = {
-    runMaterializedResponse: (
+    runWebResponse: (
         method: string | undefined,
         transaction: 'writes' | undefined,
-    ) => Promise<unknown>;
+    ) => Promise<Response>;
 };
+
+function streamFromText(text: string): ReadableStream<Uint8Array> {
+    const encoded = new TextEncoder().encode(text);
+    return new ReadableStream<Uint8Array>({
+        start(controller) {
+            controller.enqueue(encoded);
+            controller.close();
+        },
+    });
+}
 
 describe(NuxtAdapter, () => {
     beforeEach(() => {
@@ -245,47 +255,52 @@ describe(NuxtAdapter, () => {
     });
 
     it('forwards the POST request method and policy to request execution support', async () => {
-        const runMaterializedResponseSpy = vi
+        const runWebResponseSpy = vi
             .spyOn(
                 BoundFrameworkAdapterRequestExecutor.prototype as unknown as BoundRequestExecutorRunner,
-                'runMaterializedResponse'
+                'runWebResponse'
             )
-            .mockImplementation(async (_method, _transaction) => ({
-                status: 201,
-                statusText: 'Created',
-                headers: new Headers({ 'content-type': 'application/json' }),
-                body: new TextEncoder().encode(JSON.stringify({ ok: true })),
-            }));
+            .mockImplementation(async () => Response.json({ ok: true }, { status: 201 }));
         const adapter = new NuxtAdapter();
         const handler = adapter.adapt(async () => jsonResponse({ ok: true }, 201), { transaction: 'writes' });
 
         const response = await handler(createEvent({ method: 'POST' }));
 
         expect(response.status).toBe(201);
-        expect(runMaterializedResponseSpy).toHaveBeenCalledWith('POST', 'writes');
-        runMaterializedResponseSpy.mockRestore();
+        expect(runWebResponseSpy).toHaveBeenCalledWith('POST', 'writes');
+        runWebResponseSpy.mockRestore();
     });
 
     it('forwards the GET request method and policy to request execution support', async () => {
-        const runMaterializedResponseSpy = vi
+        const runWebResponseSpy = vi
             .spyOn(
                 BoundFrameworkAdapterRequestExecutor.prototype as unknown as BoundRequestExecutorRunner,
-                'runMaterializedResponse'
+                'runWebResponse'
             )
-            .mockImplementation(async (_method, _transaction) => ({
-                status: 200,
-                statusText: 'OK',
-                headers: new Headers({ 'content-type': 'application/json' }),
-                body: new TextEncoder().encode(JSON.stringify({ ok: true })),
-            }));
+            .mockImplementation(async () => Response.json({ ok: true }, { status: 200 }));
         const adapter = new NuxtAdapter();
         const handler = adapter.adapt(async () => jsonResponse({ ok: true }, 200), { transaction: 'writes' });
 
         const response = await handler(createEvent({ method: 'GET' }));
 
         expect(response.status).toBe(200);
-        expect(runMaterializedResponseSpy).toHaveBeenCalledWith('GET', 'writes');
-        runMaterializedResponseSpy.mockRestore();
+        expect(runWebResponseSpy).toHaveBeenCalledWith('GET', 'writes');
+        runWebResponseSpy.mockRestore();
+    });
+
+    it('preserves streaming responses without buffering them in the adapter', async () => {
+        const adapter = new NuxtAdapter();
+        const handler = adapter.adapt(async () =>
+            TangoResponse.stream(streamFromText('nuxt-stream'), {
+                status: 206,
+                headers: { 'content-type': 'text/plain' },
+            })
+        );
+
+        const response = await handler(createEvent({ method: 'GET', url: 'http://localhost/users' }));
+
+        expect(response.status).toBe(206);
+        expect(await response.text()).toBe('nuxt-stream');
     });
 
     it('adapts full CRUD handlers for catch-all routes', async () => {

--- a/packages/adapters/nuxt/src/adapter/tests/NuxtAdapter.test.ts
+++ b/packages/adapters/nuxt/src/adapter/tests/NuxtAdapter.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { H3Event } from 'h3';
 import { TangoQueryParams, TangoRequest, TangoResponse } from '@danceroutine/tango-core';
 import { isFrameworkAdapter } from '@danceroutine/tango-adapters-core';
+import { BoundFrameworkAdapterRequestExecutor } from '@danceroutine/tango-adapters-core/adapter';
 import { NuxtAdapter, toNuxtQueryParams } from '..';
 
 function jsonResponse(data: unknown, status: number = 200): TangoResponse {
@@ -72,7 +73,18 @@ function createEvent(
     } as unknown as H3Event;
 }
 
+type BoundRequestExecutorRunner = {
+    runMaterializedResponse: (
+        method: string | undefined,
+        transaction: 'writes' | undefined,
+    ) => Promise<unknown>;
+};
+
 describe(NuxtAdapter, () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
     it('satisfies the shared framework adapter typeguard', () => {
         expect(isFrameworkAdapter(new NuxtAdapter())).toBe(true);
     });
@@ -230,6 +242,50 @@ describe(NuxtAdapter, () => {
         expect(body).toEqual({ error: 'boom', details: null });
         expect(consoleSpy).toHaveBeenCalled();
         consoleSpy.mockRestore();
+    });
+
+    it('forwards the POST request method and policy to request execution support', async () => {
+        const runMaterializedResponseSpy = vi
+            .spyOn(
+                BoundFrameworkAdapterRequestExecutor.prototype as unknown as BoundRequestExecutorRunner,
+                'runMaterializedResponse'
+            )
+            .mockImplementation(async (_method, _transaction) => ({
+                status: 201,
+                statusText: 'Created',
+                headers: new Headers({ 'content-type': 'application/json' }),
+                body: new TextEncoder().encode(JSON.stringify({ ok: true })),
+            }));
+        const adapter = new NuxtAdapter();
+        const handler = adapter.adapt(async () => jsonResponse({ ok: true }, 201), { transaction: 'writes' });
+
+        const response = await handler(createEvent({ method: 'POST' }));
+
+        expect(response.status).toBe(201);
+        expect(runMaterializedResponseSpy).toHaveBeenCalledWith('POST', 'writes');
+        runMaterializedResponseSpy.mockRestore();
+    });
+
+    it('forwards the GET request method and policy to request execution support', async () => {
+        const runMaterializedResponseSpy = vi
+            .spyOn(
+                BoundFrameworkAdapterRequestExecutor.prototype as unknown as BoundRequestExecutorRunner,
+                'runMaterializedResponse'
+            )
+            .mockImplementation(async (_method, _transaction) => ({
+                status: 200,
+                statusText: 'OK',
+                headers: new Headers({ 'content-type': 'application/json' }),
+                body: new TextEncoder().encode(JSON.stringify({ ok: true })),
+            }));
+        const adapter = new NuxtAdapter();
+        const handler = adapter.adapt(async () => jsonResponse({ ok: true }, 200), { transaction: 'writes' });
+
+        const response = await handler(createEvent({ method: 'GET' }));
+
+        expect(response.status).toBe(200);
+        expect(runMaterializedResponseSpy).toHaveBeenCalledWith('GET', 'writes');
+        runMaterializedResponseSpy.mockRestore();
     });
 
     it('adapts full CRUD handlers for catch-all routes', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,7 +76,7 @@ importers:
     dependencies:
       '@danceroutine/tango-adapters-nuxt':
         specifier: ^1.5.0
-        version: 1.10.1(better-sqlite3@11.10.0)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@9.39.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(yaml@2.8.3))(pg@8.18.0)
+        version: 1.10.1(better-sqlite3@11.10.0)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@5.9.3))(yaml@2.8.3))(pg@8.20.0)
       '@danceroutine/tango-config':
         specifier: ^1.5.0
         version: 1.10.1
@@ -85,16 +85,16 @@ importers:
         version: 1.10.1
       '@danceroutine/tango-migrations':
         specifier: ^1.5.0
-        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)
       '@danceroutine/tango-openapi':
         specifier: ^1.5.0
-        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)
       '@danceroutine/tango-orm':
         specifier: ^1.5.0
-        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)
       '@danceroutine/tango-resources':
         specifier: ^1.5.0
-        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)
       '@danceroutine/tango-schema':
         specifier: ^1.5.0
         version: 1.10.1
@@ -103,7 +103,7 @@ importers:
         version: 11.10.0
       nuxt:
         specifier: ^4.4.2
-        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@9.39.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(yaml@2.8.3)
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@5.9.3))(yaml@2.8.3)
       vue:
         specifier: ^3.5.31
         version: 3.5.31(typescript@5.9.3)
@@ -113,7 +113,7 @@ importers:
     devDependencies:
       '@danceroutine/tango-cli':
         specifier: ^1.5.0
-        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)
       '@types/node':
         specifier: ^22.9.0
         version: 22.19.0
@@ -125,7 +125,7 @@ importers:
         version: 5.9.3
       vue-tsc:
         specifier: ^3.1.2
-        version: 3.2.6(typescript@5.9.3)
+        version: 3.2.7(typescript@5.9.3)
 
   .temp/blog-app.stale-1776973299:
     dependencies:
@@ -137,10 +137,10 @@ importers:
         version: 1.10.1
       '@danceroutine/tango-migrations':
         specifier: ^1.5.0
-        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)
       '@danceroutine/tango-orm':
         specifier: ^1.5.0
-        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)
       '@danceroutine/tango-schema':
         specifier: ^1.5.0
         version: 1.10.1
@@ -162,7 +162,7 @@ importers:
     devDependencies:
       '@danceroutine/tango-cli':
         specifier: ^1.5.0
-        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)
       '@types/node':
         specifier: ^22.9.0
         version: 22.19.0
@@ -209,7 +209,7 @@ importers:
         version: 11.10.0
       express:
         specifier: ^4.21.2
-        version: 4.22.1
+        version: 4.22.2
       zod:
         specifier: ^4.0.0
         version: 4.3.6
@@ -258,7 +258,7 @@ importers:
         version: 11.10.0
       express:
         specifier: ^4.21.2
-        version: 4.22.1
+        version: 4.22.2
       zod:
         specifier: ^4.0.0
         version: 4.3.6
@@ -307,7 +307,7 @@ importers:
         version: 11.10.0
       express:
         specifier: ^4.21.2
-        version: 4.22.1
+        version: 4.22.2
       zod:
         specifier: ^4.0.0
         version: 4.3.6
@@ -356,7 +356,7 @@ importers:
         version: 11.10.0
       express:
         specifier: ^4.21.2
-        version: 4.22.1
+        version: 4.22.2
       zod:
         specifier: ^4.0.0
         version: 4.3.6
@@ -405,7 +405,7 @@ importers:
         version: 11.10.0
       express:
         specifier: ^4.21.2
-        version: 4.22.1
+        version: 4.22.2
       zod:
         specifier: ^4.0.0
         version: 4.3.6
@@ -869,12 +869,6 @@ importers:
         specifier: workspace:*
         version: link:../../resources
     devDependencies:
-      '@danceroutine/tango-orm':
-        specifier: workspace:*
-        version: link:../../orm
-      '@danceroutine/tango-testing':
-        specifier: workspace:*
-        version: link:../../testing
       '@types/node':
         specifier: ^22.9.0
         version: 22.19.0
@@ -906,12 +900,6 @@ importers:
         specifier: ^1.15.6
         version: 1.15.10
     devDependencies:
-      '@danceroutine/tango-orm':
-        specifier: workspace:*
-        version: link:../../orm
-      '@danceroutine/tango-testing':
-        specifier: workspace:*
-        version: link:../../testing
       '@types/node':
         specifier: ^22.9.0
         version: 22.19.0
@@ -4128,6 +4116,10 @@ packages:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
     engines: {node: '>=6.5'}
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -4210,6 +4202,9 @@ packages:
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
 
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
@@ -4311,6 +4306,9 @@ packages:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
 
+  better-sqlite3@11.10.0:
+    resolution: {integrity: sha512-EwhOpyXiOEL/lKzHz9AW1msWFNzGc/z+LzeB3/jnFJpxu+th2yqvzsSWas1v9jgs9+xiXJcD5A8CJxAG2TaghQ==}
+
   better-sqlite3@12.10.0:
     resolution: {integrity: sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==}
     engines: {node: 20.x || 22.x || 23.x || 24.x || 25.x || 26.x}
@@ -4330,6 +4328,10 @@ packages:
 
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  body-parser@1.20.5:
+    resolution: {integrity: sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   body-parser@2.2.2:
     resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
@@ -4474,6 +4476,10 @@ packages:
     resolution: {integrity: sha512-5mOlNS0mhX0707P2I0aZ2V/cmHUEO/fL7VFLqszkhUsxt7RwnmrInf/eEQKlf5GzvYeHIjT+Ov1HRfNmymlG0w==}
     engines: {node: '>=18'}
 
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
   cliui@9.0.1:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
@@ -4531,6 +4537,10 @@ packages:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
     engines: {node: ^14.18.0 || >=16.10.0}
 
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
     engines: {node: '>=18'}
@@ -4550,6 +4560,9 @@ packages:
 
   cookie-es@3.1.1:
     resolution: {integrity: sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg==}
+
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -4825,6 +4838,14 @@ packages:
       sqlite3:
         optional: true
 
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -4881,6 +4902,10 @@ packages:
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   detect-indent@6.1.0:
     resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==}
@@ -5144,6 +5169,10 @@ packages:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
 
+  express@4.22.2:
+    resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
+    engines: {node: '>= 0.10.0'}
+
   express@5.2.1:
     resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
     engines: {node: '>= 18'}
@@ -5200,6 +5229,10 @@ packages:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
 
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
+    engines: {node: '>= 0.8'}
+
   finalhandler@2.1.1:
     resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
     engines: {node: '>= 18.0.0'}
@@ -5232,6 +5265,10 @@ packages:
 
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
+    engines: {node: '>= 0.6'}
 
   fresh@2.0.0:
     resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
@@ -5410,6 +5447,10 @@ packages:
   human-signals@5.0.0:
     resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
     engines: {node: '>=16.17.0'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -5774,9 +5815,16 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
@@ -5791,6 +5839,10 @@ packages:
 
   mermaid@11.14.0:
     resolution: {integrity: sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==}
+
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
 
   micromark-util-character@2.1.1:
     resolution: {integrity: sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==}
@@ -5811,13 +5863,26 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   mime@4.1.0:
     resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
@@ -5881,6 +5946,9 @@ packages:
     resolution: {integrity: sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==}
     engines: {node: '>=10'}
 
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
+
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
@@ -5903,6 +5971,10 @@ packages:
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -6174,6 +6246,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@0.1.13:
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
@@ -6585,6 +6660,10 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
+
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
     engines: {node: '>= 0.10'}
@@ -6661,6 +6740,10 @@ packages:
   regexp-tree@0.1.27:
     resolution: {integrity: sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==}
     hasBin: true
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
@@ -6777,6 +6860,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
+
   send@1.2.1:
     resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
     engines: {node: '>= 18'}
@@ -6791,6 +6878,10 @@ packages:
 
   serve-placeholder@2.0.2:
     resolution: {integrity: sha512-/TMG8SboeiQbZJWRlfTCqMs2DD3SZgWp0kDQePz9yUuCnDfDh/92gf7/PxGhzXTKBIPASIHxFcZndoNbp6QOLQ==}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
 
   serve-static@2.2.1:
     resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
@@ -7160,6 +7251,10 @@ packages:
     resolution: {integrity: sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==}
     engines: {node: '>=20'}
 
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
@@ -7370,6 +7465,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
 
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
@@ -7748,9 +7847,17 @@ packages:
     engines: {node: '>= 14.6'}
     hasBin: true
 
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
   yargs-parser@22.0.0:
     resolution: {integrity: sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yargs@18.0.0:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
@@ -8263,28 +8370,28 @@ snapshots:
 
   '@colordx/core@5.0.0': {}
 
-  '@danceroutine/tango-adapters-core@1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)':
+  '@danceroutine/tango-adapters-core@1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)':
     dependencies:
-      '@danceroutine/tango-resources': 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      '@danceroutine/tango-resources': 1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)
     transitivePeerDependencies:
       - better-sqlite3
       - pg
 
-  '@danceroutine/tango-adapters-nuxt@1.10.1(better-sqlite3@11.10.0)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@9.39.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(yaml@2.8.3))(pg@8.18.0)':
+  '@danceroutine/tango-adapters-nuxt@1.10.1(better-sqlite3@11.10.0)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@5.9.3))(yaml@2.8.3))(pg@8.20.0)':
     dependencies:
-      '@danceroutine/tango-adapters-core': 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      '@danceroutine/tango-adapters-core': 1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)
       '@danceroutine/tango-core': 1.10.1
-      '@danceroutine/tango-resources': 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      '@danceroutine/tango-resources': 1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)
       h3: 1.15.10
-      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@9.39.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(yaml@2.8.3)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@5.9.3))(yaml@2.8.3)
     transitivePeerDependencies:
       - better-sqlite3
       - pg
 
-  '@danceroutine/tango-cli@1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)':
+  '@danceroutine/tango-cli@1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)':
     dependencies:
       '@danceroutine/tango-codegen': 1.10.1
-      '@danceroutine/tango-migrations': 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      '@danceroutine/tango-migrations': 1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)
       yargs: 17.7.2
     transitivePeerDependencies:
       - better-sqlite3
@@ -8305,7 +8412,7 @@ snapshots:
 
   '@danceroutine/tango-core@1.10.1': {}
 
-  '@danceroutine/tango-migrations@1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)':
+  '@danceroutine/tango-migrations@1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)':
     dependencies:
       '@danceroutine/tango-codegen': 1.10.1
       '@danceroutine/tango-config': 1.10.1
@@ -8316,17 +8423,17 @@ snapshots:
       yargs: 17.7.2
     optionalDependencies:
       better-sqlite3: 11.10.0
-      pg: 8.18.0
+      pg: 8.20.0
 
-  '@danceroutine/tango-openapi@1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)':
+  '@danceroutine/tango-openapi@1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)':
     dependencies:
-      '@danceroutine/tango-resources': 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      '@danceroutine/tango-resources': 1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)
       zod: 4.3.6
     transitivePeerDependencies:
       - better-sqlite3
       - pg
 
-  '@danceroutine/tango-orm@1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)':
+  '@danceroutine/tango-orm@1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)':
     dependencies:
       '@danceroutine/tango-config': 1.10.1
       '@danceroutine/tango-core': 1.10.1
@@ -8334,12 +8441,12 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       better-sqlite3: 11.10.0
-      pg: 8.18.0
+      pg: 8.20.0
 
-  '@danceroutine/tango-resources@1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)':
+  '@danceroutine/tango-resources@1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)':
     dependencies:
       '@danceroutine/tango-core': 1.10.1
-      '@danceroutine/tango-orm': 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      '@danceroutine/tango-orm': 1.10.1(better-sqlite3@11.10.0)(pg@8.20.0)
       zod: 4.3.6
     transitivePeerDependencies:
       - better-sqlite3
@@ -9056,6 +9163,75 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
+  '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(better-sqlite3@11.10.0)(db0@0.3.4(better-sqlite3@11.10.0))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@5.9.3))(yaml@2.8.3))(typescript@5.9.3)':
+    dependencies:
+      '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
+      '@nuxt/devalue': 2.0.2
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@unhead/vue': 2.1.12(vue@3.5.31(typescript@5.9.3))
+      '@vue/shared': 3.5.31
+      consola: 3.4.2
+      defu: 6.1.4
+      destr: 2.0.5
+      devalue: 5.6.4
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      h3: 1.15.10
+      impound: 1.1.5
+      klona: 2.0.6
+      mocked-exports: 0.1.1
+      nitropack: 2.13.2(better-sqlite3@11.10.0)
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@5.9.3))(yaml@2.8.3)
+      nypm: 0.6.5
+      ohash: 2.0.11
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      rou3: 0.8.1
+      std-env: 4.0.0
+      ufo: 1.6.3
+      unctx: 2.5.0
+      unstorage: 1.17.5(db0@0.3.4(better-sqlite3@11.10.0))(ioredis@5.10.1)
+      vue: 3.5.31(typescript@5.9.3)
+      vue-bundle-renderer: 2.2.0
+      vue-devtools-stub: 0.1.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/core'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - db0
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - ioredis
+      - magicast
+      - mysql2
+      - react-native-b4a
+      - rolldown
+      - sqlite3
+      - supports-color
+      - typescript
+      - uploadthing
+      - xml2js
+
   '@nuxt/nitro-server@4.4.2(@babel/core@7.29.0)(better-sqlite3@12.10.0)(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@5.9.3))(yaml@2.8.3))(typescript@5.9.3)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0)
@@ -9210,6 +9386,66 @@ snapshots:
       ofetch: 2.0.0-alpha.3
       rc9: 3.0.0
       std-env: 3.10.0
+
+  '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@22.19.0)(eslint@10.3.0(jiti@2.6.1))(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@5.9.3))(yaml@2.8.3))(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))(vue@3.5.31(typescript@5.9.3))(yaml@2.8.3)':
+    dependencies:
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.60.1)
+      '@vitejs/plugin-vue': 6.0.5(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))
+      '@vitejs/plugin-vue-jsx': 5.1.5(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))
+      autoprefixer: 10.5.0(postcss@8.5.8)
+      consola: 3.4.2
+      cssnano: 7.1.4(postcss@8.5.8)
+      defu: 6.1.4
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      get-port-please: 3.2.0
+      jiti: 2.6.1
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      mocked-exports: 0.1.1
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@5.9.3))(yaml@2.8.3)
+      nypm: 0.6.5
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      postcss: 8.5.8
+      seroval: 1.5.1
+      std-env: 4.0.0
+      ufo: 1.6.3
+      unenv: 2.0.0-rc.24
+      vite: 7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite-node: 5.3.0(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
+      vite-plugin-checker: 0.12.0(eslint@10.3.0(jiti@2.6.1))(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@5.9.3))
+      vue: 3.5.31(typescript@5.9.3)
+      vue-bundle-renderer: 2.2.0
+    optionalDependencies:
+      '@babel/plugin-syntax-jsx': 7.28.6(@babel/core@7.29.0)
+      rollup-plugin-visualizer: 7.0.1(rollup@4.60.1)
+    transitivePeerDependencies:
+      - '@biomejs/biome'
+      - '@types/node'
+      - eslint
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - optionator
+      - oxlint
+      - rollup
+      - sass
+      - sass-embedded
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - vls
+      - vti
+      - vue-tsc
+      - yaml
 
   '@nuxt/vite-builder@4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@22.19.0)(eslint@10.3.0(jiti@2.6.1))(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@5.9.3))(yaml@2.8.3))(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))(vue@3.5.31(typescript@5.9.3))(yaml@2.8.3)':
     dependencies:
@@ -10688,6 +10924,11 @@ snapshots:
     dependencies:
       event-target-shim: 5.0.1
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -10784,6 +11025,8 @@ snapshots:
     dependencies:
       sprintf-js: 1.0.3
 
+  array-flatten@1.1.1: {}
+
   array-union@2.1.0: {}
 
   assertion-error@2.0.1: {}
@@ -10872,6 +11115,11 @@ snapshots:
     dependencies:
       is-windows: 1.0.2
 
+  better-sqlite3@11.10.0:
+    dependencies:
+      bindings: 1.5.0
+      prebuild-install: 7.1.3
+
   better-sqlite3@12.10.0:
     dependencies:
       bindings: 1.5.0
@@ -10892,6 +11140,23 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
+
+  body-parser@1.20.5:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.15.1
+      raw-body: 2.5.3
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   body-parser@2.2.2:
     dependencies:
@@ -11060,6 +11325,12 @@ snapshots:
       is-wsl: 3.1.1
       is64bit: 2.0.0
 
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
   cliui@9.0.1:
     dependencies:
       string-width: 7.2.0
@@ -11104,6 +11375,10 @@ snapshots:
 
   consola@3.4.2: {}
 
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
@@ -11115,6 +11390,8 @@ snapshots:
   cookie-es@2.0.0: {}
 
   cookie-es@3.1.1: {}
+
+  cookie-signature@1.0.7: {}
 
   cookie-signature@1.2.2: {}
 
@@ -11415,9 +11692,17 @@ snapshots:
 
   dayjs@1.11.20: {}
 
+  db0@0.3.4(better-sqlite3@11.10.0):
+    optionalDependencies:
+      better-sqlite3: 11.10.0
+
   db0@0.3.4(better-sqlite3@12.10.0):
     optionalDependencies:
       better-sqlite3: 12.10.0
+
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
 
   debug@4.4.3:
     dependencies:
@@ -11455,6 +11740,8 @@ snapshots:
   dequal@2.0.3: {}
 
   destr@2.0.5: {}
+
+  destroy@1.2.0: {}
 
   detect-indent@6.1.0: {}
 
@@ -11772,6 +12059,42 @@ snapshots:
 
   expect-type@1.2.2: {}
 
+  express@4.22.2:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.5
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.2
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.13
+      proxy-addr: 2.0.7
+      qs: 6.15.1
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.2
+      serve-static: 1.16.3
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   express@5.2.1:
     dependencies:
       accepts: 2.0.0
@@ -11851,6 +12174,18 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
+  finalhandler@1.3.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   finalhandler@2.1.1:
     dependencies:
       debug: 4.4.3
@@ -11891,6 +12226,8 @@ snapshots:
   forwarded@0.2.0: {}
 
   fraction.js@5.3.4: {}
+
+  fresh@0.5.2: {}
 
   fresh@2.0.0: {}
 
@@ -12091,6 +12428,10 @@ snapshots:
   human-id@4.1.2: {}
 
   human-signals@5.0.0: {}
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
 
   iconv-lite@0.6.3:
     dependencies:
@@ -12447,7 +12788,11 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  media-typer@0.3.0: {}
+
   media-typer@1.1.0: {}
+
+  merge-descriptors@1.0.3: {}
 
   merge-descriptors@2.0.0: {}
 
@@ -12479,6 +12824,8 @@ snapshots:
       ts-dedent: 2.2.0
       uuid: 11.1.0
 
+  methods@1.1.2: {}
+
   micromark-util-character@2.1.1:
     dependencies:
       micromark-util-symbol: 2.0.1
@@ -12501,11 +12848,19 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.1
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
+
+  mime@1.6.0: {}
 
   mime@4.1.0: {}
 
@@ -12559,6 +12914,8 @@ snapshots:
 
   mrmime@2.0.1: {}
 
+  ms@2.0.0: {}
+
   ms@2.1.3: {}
 
   muggle-string@0.4.1: {}
@@ -12576,6 +12933,8 @@ snapshots:
   napi-build-utils@2.0.0: {}
 
   natural-compare@1.4.0: {}
+
+  negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
 
@@ -12601,6 +12960,109 @@ snapshots:
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
+
+  nitropack@2.13.2(better-sqlite3@11.10.0):
+    dependencies:
+      '@cloudflare/kv-asset-handler': 0.4.2
+      '@rollup/plugin-alias': 6.0.0(rollup@4.60.1)
+      '@rollup/plugin-commonjs': 29.0.2(rollup@4.60.1)
+      '@rollup/plugin-inject': 5.0.5(rollup@4.60.1)
+      '@rollup/plugin-json': 6.1.0(rollup@4.60.1)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.60.1)
+      '@rollup/plugin-replace': 6.0.3(rollup@4.60.1)
+      '@rollup/plugin-terser': 1.0.0(rollup@4.60.1)
+      '@vercel/nft': 1.5.0(rollup@4.60.1)
+      archiver: 7.0.1
+      c12: 3.3.3(magicast@0.5.2)
+      chokidar: 5.0.0
+      citty: 0.2.1
+      compatx: 0.2.0
+      confbox: 0.2.4
+      consola: 3.4.2
+      cookie-es: 2.0.0
+      croner: 10.0.1
+      crossws: 0.3.5
+      db0: 0.3.4(better-sqlite3@11.10.0)
+      defu: 6.1.4
+      destr: 2.0.5
+      dot-prop: 10.1.0
+      esbuild: 0.27.4
+      escape-string-regexp: 5.0.0
+      etag: 1.8.1
+      exsolve: 1.0.8
+      globby: 16.2.0
+      gzip-size: 7.0.0
+      h3: 1.15.10
+      hookable: 5.5.3
+      httpxy: 0.3.1
+      ioredis: 5.10.1
+      jiti: 2.6.1
+      klona: 2.0.6
+      knitwork: 1.3.0
+      listhen: 1.9.0
+      magic-string: 0.30.21
+      magicast: 0.5.2
+      mime: 4.1.0
+      mlly: 1.8.2
+      node-fetch-native: 1.6.7
+      node-mock-http: 1.0.4
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      pkg-types: 2.3.0
+      pretty-bytes: 7.1.0
+      radix3: 1.1.2
+      rollup: 4.60.1
+      rollup-plugin-visualizer: 7.0.1(rollup@4.60.1)
+      scule: 1.3.0
+      semver: 7.7.4
+      serve-placeholder: 2.0.2
+      serve-static: 2.2.1
+      source-map: 0.7.6
+      std-env: 4.0.0
+      ufo: 1.6.3
+      ultrahtml: 1.6.0
+      uncrypto: 0.1.3
+      unctx: 2.5.0
+      unenv: 2.0.0-rc.24
+      unimport: 6.0.2
+      unplugin-utils: 0.3.1
+      unstorage: 1.17.5(db0@0.3.4(better-sqlite3@11.10.0))(ioredis@5.10.1)
+      untyped: 2.0.0
+      unwasm: 0.5.3
+      youch: 4.1.1
+      youch-core: 0.3.3
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - drizzle-orm
+      - encoding
+      - idb-keyval
+      - mysql2
+      - react-native-b4a
+      - rolldown
+      - sqlite3
+      - supports-color
+      - uploadthing
 
   nitropack@2.13.2(better-sqlite3@12.10.0):
     dependencies:
@@ -12743,6 +13205,138 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@5.9.3))(yaml@2.8.3):
+    dependencies:
+      '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@5.9.3)
+      '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)
+      '@nuxt/devtools': 3.2.4(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue@3.5.31(typescript@5.9.3))
+      '@nuxt/kit': 4.4.2(magicast@0.5.2)
+      '@nuxt/nitro-server': 4.4.2(@babel/core@7.29.0)(better-sqlite3@11.10.0)(db0@0.3.4(better-sqlite3@11.10.0))(ioredis@5.10.1)(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@5.9.3))(yaml@2.8.3))(typescript@5.9.3)
+      '@nuxt/schema': 4.4.2
+      '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.5.2))
+      '@nuxt/vite-builder': 4.4.2(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@types/node@22.19.0)(eslint@10.3.0(jiti@2.6.1))(magicast@0.5.2)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@5.9.3))(yaml@2.8.3))(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vue-tsc@3.2.7(typescript@5.9.3))(vue@3.5.31(typescript@5.9.3))(yaml@2.8.3)
+      '@unhead/vue': 2.1.12(vue@3.5.31(typescript@5.9.3))
+      '@vue/shared': 3.5.31
+      c12: 3.3.3(magicast@0.5.2)
+      chokidar: 5.0.0
+      compatx: 0.2.0
+      consola: 3.4.2
+      cookie-es: 2.0.0
+      defu: 6.1.4
+      devalue: 5.6.4
+      errx: 0.1.0
+      escape-string-regexp: 5.0.0
+      exsolve: 1.0.8
+      hookable: 6.1.0
+      ignore: 7.0.5
+      impound: 1.1.5
+      jiti: 2.6.1
+      klona: 2.0.6
+      knitwork: 1.3.0
+      magic-string: 0.30.21
+      mlly: 1.8.2
+      nanotar: 0.3.0
+      nypm: 0.6.5
+      ofetch: 1.5.1
+      ohash: 2.0.11
+      on-change: 6.0.2
+      oxc-minify: 0.117.0(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)
+      oxc-parser: 0.117.0(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)
+      oxc-transform: 0.117.0(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)
+      oxc-walker: 0.7.0(oxc-parser@0.117.0(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1))
+      pathe: 2.0.3
+      perfect-debounce: 2.1.0
+      picomatch: 4.0.3
+      pkg-types: 2.3.0
+      rou3: 0.8.1
+      scule: 1.3.0
+      semver: 7.7.4
+      std-env: 4.0.0
+      tinyglobby: 0.2.15
+      ufo: 1.6.3
+      ultrahtml: 1.6.0
+      uncrypto: 0.1.3
+      unctx: 2.5.0
+      unimport: 6.0.2
+      unplugin: 3.0.0
+      unrouting: 0.1.7
+      untyped: 2.0.0
+      vue: 3.5.31(typescript@5.9.3)
+      vue-router: 5.0.4(@vue/compiler-sfc@3.5.31)(vue@3.5.31(typescript@5.9.3))
+    optionalDependencies:
+      '@parcel/watcher': 2.5.6
+      '@types/node': 22.19.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@babel/core'
+      - '@babel/plugin-proposal-decorators'
+      - '@babel/plugin-syntax-jsx'
+      - '@biomejs/biome'
+      - '@capacitor/preferences'
+      - '@deno/kv'
+      - '@electric-sql/pglite'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@libsql/client'
+      - '@netlify/blobs'
+      - '@pinia/colada'
+      - '@planetscale/database'
+      - '@rollup/plugin-babel'
+      - '@upstash/redis'
+      - '@vercel/blob'
+      - '@vercel/functions'
+      - '@vercel/kv'
+      - '@vitejs/devtools'
+      - '@vue/compiler-sfc'
+      - aws4fetch
+      - bare-abort-controller
+      - bare-buffer
+      - better-sqlite3
+      - bufferutil
+      - cac
+      - commander
+      - db0
+      - drizzle-orm
+      - encoding
+      - eslint
+      - idb-keyval
+      - ioredis
+      - less
+      - lightningcss
+      - magicast
+      - meow
+      - mysql2
+      - optionator
+      - oxlint
+      - pinia
+      - react-native-b4a
+      - rolldown
+      - rollup
+      - rollup-plugin-visualizer
+      - sass
+      - sass-embedded
+      - sqlite3
+      - stylelint
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - typescript
+      - uploadthing
+      - utf-8-validate
+      - vite
+      - vls
+      - vti
+      - vue-tsc
+      - xml2js
+      - yaml
 
   nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@12.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.10.0))(eslint@10.3.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.7(typescript@5.9.3))(yaml@2.8.3):
     dependencies:
@@ -13267,6 +13861,8 @@ snapshots:
       lru-cache: 11.2.7
       minipass: 7.1.3
 
+  path-to-regexp@0.1.13: {}
+
   path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
@@ -13632,6 +14228,13 @@ snapshots:
 
   range-parser@1.2.1: {}
 
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
   raw-body@3.0.2:
     dependencies:
       bytes: 3.1.2
@@ -13727,6 +14330,8 @@ snapshots:
       regex-utilities: 2.3.0
 
   regexp-tree@0.1.27: {}
+
+  require-directory@2.1.1: {}
 
   resolve-from@5.0.0: {}
 
@@ -13879,6 +14484,24 @@ snapshots:
 
   semver@7.8.0: {}
 
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   send@1.2.1:
     dependencies:
       debug: 4.4.3
@@ -13902,6 +14525,15 @@ snapshots:
   serve-placeholder@2.0.2:
     dependencies:
       defu: 6.1.4
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
+    transitivePeerDependencies:
+      - supports-color
 
   serve-static@2.2.1:
     dependencies:
@@ -14354,6 +14986,11 @@ snapshots:
     dependencies:
       tagged-tag: 1.0.0
 
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -14515,6 +15152,20 @@ snapshots:
       escape-string-regexp: 5.0.0
       ufo: 1.6.3
 
+  unstorage@1.17.5(db0@0.3.4(better-sqlite3@11.10.0))(ioredis@5.10.1):
+    dependencies:
+      anymatch: 3.1.3
+      chokidar: 5.0.0
+      destr: 2.0.5
+      h3: 1.15.10
+      lru-cache: 11.2.7
+      node-fetch-native: 1.6.7
+      ofetch: 1.5.1
+      ufo: 1.6.3
+    optionalDependencies:
+      db0: 0.3.4(better-sqlite3@11.10.0)
+      ioredis: 5.10.1
+
   unstorage@1.17.5(db0@0.3.4(better-sqlite3@12.10.0))(ioredis@5.10.1):
     dependencies:
       anymatch: 3.1.3
@@ -14565,6 +15216,8 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  utils-merge@1.0.1: {}
 
   uuid@11.1.0: {}
 
@@ -14911,7 +15564,19 @@ snapshots:
 
   yaml@2.8.3: {}
 
+  yargs-parser@21.1.1: {}
+
   yargs-parser@22.0.0: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yargs@18.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,540 @@ importers:
         specifier: ^4.0.6
         version: 4.0.6(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3)
 
+  .temp/blog-app:
+    dependencies:
+      '@danceroutine/tango-adapters-nuxt':
+        specifier: ^1.5.0
+        version: 1.10.1(better-sqlite3@11.10.0)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@9.39.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(yaml@2.8.3))(pg@8.18.0)
+      '@danceroutine/tango-config':
+        specifier: ^1.5.0
+        version: 1.10.1
+      '@danceroutine/tango-core':
+        specifier: ^1.5.0
+        version: 1.10.1
+      '@danceroutine/tango-migrations':
+        specifier: ^1.5.0
+        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      '@danceroutine/tango-openapi':
+        specifier: ^1.5.0
+        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      '@danceroutine/tango-orm':
+        specifier: ^1.5.0
+        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      '@danceroutine/tango-resources':
+        specifier: ^1.5.0
+        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      '@danceroutine/tango-schema':
+        specifier: ^1.5.0
+        version: 1.10.1
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      nuxt:
+        specifier: ^4.4.2
+        version: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@9.39.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(yaml@2.8.3)
+      vue:
+        specifier: ^3.5.31
+        version: 3.5.31(typescript@5.9.3)
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: ^1.5.0
+        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vue-tsc:
+        specifier: ^3.1.2
+        version: 3.2.6(typescript@5.9.3)
+
+  .temp/blog-app.stale-1776973299:
+    dependencies:
+      '@danceroutine/tango-config':
+        specifier: ^1.5.0
+        version: 1.10.1
+      '@danceroutine/tango-core':
+        specifier: ^1.5.0
+        version: 1.10.1
+      '@danceroutine/tango-migrations':
+        specifier: ^1.5.0
+        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      '@danceroutine/tango-orm':
+        specifier: ^1.5.0
+        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      '@danceroutine/tango-schema':
+        specifier: ^1.5.0
+        version: 1.10.1
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      next:
+        specifier: ^15.1.6
+        version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: ^1.5.0
+        version: 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      '@types/react':
+        specifier: ^19.0.6
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.2
+        version: 19.2.3(@types/react@19.2.14)
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  .temp/dogfood-runner: {}
+
+  .temp/express-dogfood-1773544911:
+    dependencies:
+      '@danceroutine/tango-adapters-express':
+        specifier: workspace:*
+        version: link:../../packages/adapters/express
+      '@danceroutine/tango-config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@danceroutine/tango-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@danceroutine/tango-migrations':
+        specifier: workspace:*
+        version: link:../../packages/migrations
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../packages/orm
+      '@danceroutine/tango-resources':
+        specifier: workspace:*
+        version: link:../../packages/resources
+      '@danceroutine/tango-schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      express:
+        specifier: ^4.21.2
+        version: 4.22.1
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  .temp/express-hardening-1773546487:
+    dependencies:
+      '@danceroutine/tango-adapters-express':
+        specifier: workspace:*
+        version: link:../../packages/adapters/express
+      '@danceroutine/tango-config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@danceroutine/tango-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@danceroutine/tango-migrations':
+        specifier: workspace:*
+        version: link:../../packages/migrations
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../packages/orm
+      '@danceroutine/tango-resources':
+        specifier: workspace:*
+        version: link:../../packages/resources
+      '@danceroutine/tango-schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      express:
+        specifier: ^4.21.2
+        version: 4.22.1
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  .temp/express-hardening-1773546506:
+    dependencies:
+      '@danceroutine/tango-adapters-express':
+        specifier: workspace:*
+        version: link:../../packages/adapters/express
+      '@danceroutine/tango-config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@danceroutine/tango-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@danceroutine/tango-migrations':
+        specifier: workspace:*
+        version: link:../../packages/migrations
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../packages/orm
+      '@danceroutine/tango-resources':
+        specifier: workspace:*
+        version: link:../../packages/resources
+      '@danceroutine/tango-schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      express:
+        specifier: ^4.21.2
+        version: 4.22.1
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  .temp/express-hardening-1773546629:
+    dependencies:
+      '@danceroutine/tango-adapters-express':
+        specifier: workspace:*
+        version: link:../../packages/adapters/express
+      '@danceroutine/tango-config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@danceroutine/tango-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@danceroutine/tango-migrations':
+        specifier: workspace:*
+        version: link:../../packages/migrations
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../packages/orm
+      '@danceroutine/tango-resources':
+        specifier: workspace:*
+        version: link:../../packages/resources
+      '@danceroutine/tango-schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      express:
+        specifier: ^4.21.2
+        version: 4.22.1
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  .temp/express-todo:
+    dependencies:
+      '@danceroutine/tango-adapters-express':
+        specifier: workspace:*
+        version: link:../../packages/adapters/express
+      '@danceroutine/tango-config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@danceroutine/tango-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@danceroutine/tango-migrations':
+        specifier: workspace:*
+        version: link:../../packages/migrations
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../packages/orm
+      '@danceroutine/tango-resources':
+        specifier: workspace:*
+        version: link:../../packages/resources
+      '@danceroutine/tango-schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      express:
+        specifier: ^4.21.2
+        version: 4.22.1
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  .temp/next-hardening-1773546649:
+    dependencies:
+      '@danceroutine/tango-adapters-next':
+        specifier: workspace:*
+        version: link:../../packages/adapters/next
+      '@danceroutine/tango-config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@danceroutine/tango-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@danceroutine/tango-migrations':
+        specifier: workspace:*
+        version: link:../../packages/migrations
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../packages/orm
+      '@danceroutine/tango-resources':
+        specifier: workspace:*
+        version: link:../../packages/resources
+      '@danceroutine/tango-schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      next:
+        specifier: ^15.1.6
+        version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      '@types/react':
+        specifier: ^19.0.6
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.2
+        version: 19.2.3(@types/react@19.2.14)
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  .temp/next-hardening-1773546702:
+    dependencies:
+      '@danceroutine/tango-adapters-next':
+        specifier: workspace:*
+        version: link:../../packages/adapters/next
+      '@danceroutine/tango-config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@danceroutine/tango-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@danceroutine/tango-migrations':
+        specifier: workspace:*
+        version: link:../../packages/migrations
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../packages/orm
+      '@danceroutine/tango-resources':
+        specifier: workspace:*
+        version: link:../../packages/resources
+      '@danceroutine/tango-schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      next:
+        specifier: ^15.1.6
+        version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      '@types/react':
+        specifier: ^19.0.6
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.2
+        version: 19.2.3(@types/react@19.2.14)
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  .temp/next-todo:
+    dependencies:
+      '@danceroutine/tango-adapters-next':
+        specifier: workspace:*
+        version: link:../../packages/adapters/next
+      '@danceroutine/tango-config':
+        specifier: workspace:*
+        version: link:../../packages/config
+      '@danceroutine/tango-core':
+        specifier: workspace:*
+        version: link:../../packages/core
+      '@danceroutine/tango-migrations':
+        specifier: workspace:*
+        version: link:../../packages/migrations
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../packages/orm
+      '@danceroutine/tango-resources':
+        specifier: workspace:*
+        version: link:../../packages/resources
+      '@danceroutine/tango-schema':
+        specifier: workspace:*
+        version: link:../../packages/schema
+      better-sqlite3:
+        specifier: ^11.10.0
+        version: 11.10.0
+      next:
+        specifier: ^15.1.6
+        version: 15.5.12(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.0.0
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.4(react@19.2.4)
+      zod:
+        specifier: ^4.0.0
+        version: 4.3.6
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: workspace:*
+        version: link:../../packages/cli
+      '@types/node':
+        specifier: ^22.9.0
+        version: 22.19.0
+      '@types/react':
+        specifier: ^19.0.6
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.0.2
+        version: 19.2.3(@types/react@19.2.14)
+      tsx:
+        specifier: ^4.20.6
+        version: 4.20.6
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+
+  .temp/pnpm-test:
+    devDependencies:
+      '@danceroutine/tango-cli':
+        specifier: link:/Users/pedro/coding/tango/packages/cli
+        version: link:../../packages/cli
+
   docs:
     devDependencies:
       '@types/node':
@@ -260,10 +794,19 @@ importers:
 
   packages/adapters/core:
     dependencies:
+      '@danceroutine/tango-core':
+        specifier: workspace:*
+        version: link:../../core
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../orm
       '@danceroutine/tango-resources':
         specifier: workspace:*
         version: link:../../resources
     devDependencies:
+      '@danceroutine/tango-testing':
+        specifier: workspace:*
+        version: link:../../testing
       '@types/node':
         specifier: ^22.9.0
         version: 22.19.0
@@ -289,6 +832,9 @@ importers:
         specifier: workspace:*
         version: link:../../resources
     devDependencies:
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../orm
       '@danceroutine/tango-testing':
         specifier: workspace:*
         version: link:../../testing
@@ -323,6 +869,12 @@ importers:
         specifier: workspace:*
         version: link:../../resources
     devDependencies:
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../orm
+      '@danceroutine/tango-testing':
+        specifier: workspace:*
+        version: link:../../testing
       '@types/node':
         specifier: ^22.9.0
         version: 22.19.0
@@ -354,6 +906,12 @@ importers:
         specifier: ^1.15.6
         version: 1.15.10
     devDependencies:
+      '@danceroutine/tango-orm':
+        specifier: workspace:*
+        version: link:../../orm
+      '@danceroutine/tango-testing':
+        specifier: workspace:*
+        version: link:../../testing
       '@types/node':
         specifier: ^22.9.0
         version: 22.19.0
@@ -1028,6 +1586,58 @@ packages:
 
   '@colordx/core@5.0.0':
     resolution: {integrity: sha512-twwxohWH8hWWh5ZJ5z6ZNn/JyMrq08K+NzxXKVGTpH+XmMPDAYYzqvszc3OPhYhqqxmfnbCSa/YHcS7pCnChmw==}
+
+  '@danceroutine/tango-adapters-core@1.10.1':
+    resolution: {integrity: sha512-S2LLIk72cOvUZnQHuPMzUDt20sW/w97rXEgU6v0C9DShe5FAzHGmthXE9bQmY9uWPAKvElEFse4tb1GEcUK5DA==}
+
+  '@danceroutine/tango-adapters-nuxt@1.10.1':
+    resolution: {integrity: sha512-ZgajImSve148oezVRY6C/lyPCTpRdtAf2/hSUxDHbRJ4OCOpXX/zAQqqaz1WqJRLjAEBYtQbuetICz6sWV0gvw==}
+    peerDependencies:
+      nuxt: ^4.4.2
+
+  '@danceroutine/tango-cli@1.10.1':
+    resolution: {integrity: sha512-hstyjM85Z6nj6Vget7GbdS/CGn7VcWyu6UYw2XheXxIZNmTZn81PhMavUOFkbkACiGm3uqcIROSP8gYQoAnncg==}
+    hasBin: true
+
+  '@danceroutine/tango-codegen@1.10.1':
+    resolution: {integrity: sha512-3y+Kdn2wyQz5H2HwOVAgsAgxStfr1peJBb7u2NZ9QHdKv74qSZsbpsFU6w5gPHoXjVL6kTALNuLRq4PHZUrktQ==}
+
+  '@danceroutine/tango-config@1.10.1':
+    resolution: {integrity: sha512-o+1ru/Ffff2CPu7O+kHzMVkwimIcOIzmIBa5oTxHBfvD/m0ZX9BseBQ93HzS7CWU+ClTesLPEr+e7Di0WWqEyQ==}
+
+  '@danceroutine/tango-core@1.10.1':
+    resolution: {integrity: sha512-LLsnpjTUgsbALHQMeYpsjz07UDaq15/OPAXNfnYY57RsdmvRqAieslXWPTeDCiChj3s6ofOfjUYucSefuWeTaw==}
+
+  '@danceroutine/tango-migrations@1.10.1':
+    resolution: {integrity: sha512-tRCdbIo9yDnXeGtjRLzAN/luciZB7U0DqQb+6C6UFK+M2Gms+YyFa6JE3N+GXEnInC9lUCHXG4RajprDjIJNkA==}
+    peerDependencies:
+      better-sqlite3: ^11.7.0
+      pg: ^8.13.1
+    peerDependenciesMeta:
+      better-sqlite3:
+        optional: true
+      pg:
+        optional: true
+
+  '@danceroutine/tango-openapi@1.10.1':
+    resolution: {integrity: sha512-VXfC1P+FbycuQCtm+NvqB2b4jV7vevtsYZZDr2Dg8+5dTBDLscPqWx3sjn3xwmptKfXTvBkj0zuoL3uaX5UZug==}
+
+  '@danceroutine/tango-orm@1.10.1':
+    resolution: {integrity: sha512-5UlUPqUT7xvisdRzfmWuk2jh9PDxNJBQCqdj5RYGz7Yp+y95qC+utHSoUqhrbY2/GRYZwzkMHVr+iSiat0GNxQ==}
+    peerDependencies:
+      better-sqlite3: ^11.7.0
+      pg: ^8.13.1
+    peerDependenciesMeta:
+      better-sqlite3:
+        optional: true
+      pg:
+        optional: true
+
+  '@danceroutine/tango-resources@1.10.1':
+    resolution: {integrity: sha512-ifWYq9DPMqpa68Cv96ZL/mQtAxgm47Z93J8VZVtIv73ZR4su1dj/O2PzSurV+6hXi6pPAxRO7mwQoyldvMBmoA==}
+
+  '@danceroutine/tango-schema@1.10.1':
+    resolution: {integrity: sha512-R2E14kHkTbnf7XwPBTId3MF764hbNVE4/pD5x4/2UZFbW3kMFfPmYO5sggLbnOA1KGF76ewCGi6bV2pzBGC/fw==}
 
   '@docsearch/css@3.8.2':
     resolution: {integrity: sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==}
@@ -7652,6 +8262,93 @@ snapshots:
   '@cloudflare/kv-asset-handler@0.4.2': {}
 
   '@colordx/core@5.0.0': {}
+
+  '@danceroutine/tango-adapters-core@1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)':
+    dependencies:
+      '@danceroutine/tango-resources': 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+    transitivePeerDependencies:
+      - better-sqlite3
+      - pg
+
+  '@danceroutine/tango-adapters-nuxt@1.10.1(better-sqlite3@11.10.0)(nuxt@4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@9.39.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(yaml@2.8.3))(pg@8.18.0)':
+    dependencies:
+      '@danceroutine/tango-adapters-core': 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      '@danceroutine/tango-core': 1.10.1
+      '@danceroutine/tango-resources': 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      h3: 1.15.10
+      nuxt: 4.4.2(@babel/core@7.29.0)(@babel/plugin-syntax-jsx@7.28.6(@babel/core@7.29.0))(@emnapi/core@1.6.0)(@emnapi/runtime@1.8.1)(@parcel/watcher@2.5.6)(@types/node@22.19.0)(@vue/compiler-sfc@3.5.31)(better-sqlite3@11.10.0)(cac@6.7.14)(db0@0.3.4(better-sqlite3@11.10.0))(eslint@9.39.0(jiti@2.6.1))(ioredis@5.10.1)(magicast@0.5.2)(optionator@0.9.4)(oxlint@1.51.0(oxlint-tsgolint@0.15.0))(rollup-plugin-visualizer@7.0.1(rollup@4.60.1))(rollup@4.60.1)(terser@5.46.1)(tsx@4.20.6)(typescript@5.9.3)(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(terser@5.46.1)(tsx@4.20.6)(yaml@2.8.3))(vue-tsc@3.2.6(typescript@5.9.3))(yaml@2.8.3)
+    transitivePeerDependencies:
+      - better-sqlite3
+      - pg
+
+  '@danceroutine/tango-cli@1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)':
+    dependencies:
+      '@danceroutine/tango-codegen': 1.10.1
+      '@danceroutine/tango-migrations': 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - better-sqlite3
+      - pg
+
+  '@danceroutine/tango-codegen@1.10.1':
+    dependencies:
+      '@danceroutine/tango-core': 1.10.1
+      '@danceroutine/tango-schema': 1.10.1
+      jiti: 2.6.1
+      yargs: 17.7.2
+
+  '@danceroutine/tango-config@1.10.1':
+    dependencies:
+      dotenv: 16.6.1
+      jiti: 2.6.1
+      zod: 4.3.6
+
+  '@danceroutine/tango-core@1.10.1': {}
+
+  '@danceroutine/tango-migrations@1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)':
+    dependencies:
+      '@danceroutine/tango-codegen': 1.10.1
+      '@danceroutine/tango-config': 1.10.1
+      '@danceroutine/tango-core': 1.10.1
+      '@danceroutine/tango-schema': 1.10.1
+      jiti: 2.6.1
+      kleur: 4.1.5
+      yargs: 17.7.2
+    optionalDependencies:
+      better-sqlite3: 11.10.0
+      pg: 8.18.0
+
+  '@danceroutine/tango-openapi@1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)':
+    dependencies:
+      '@danceroutine/tango-resources': 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - better-sqlite3
+      - pg
+
+  '@danceroutine/tango-orm@1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)':
+    dependencies:
+      '@danceroutine/tango-config': 1.10.1
+      '@danceroutine/tango-core': 1.10.1
+      '@danceroutine/tango-schema': 1.10.1
+      zod: 4.3.6
+    optionalDependencies:
+      better-sqlite3: 11.10.0
+      pg: 8.18.0
+
+  '@danceroutine/tango-resources@1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)':
+    dependencies:
+      '@danceroutine/tango-core': 1.10.1
+      '@danceroutine/tango-orm': 1.10.1(better-sqlite3@11.10.0)(pg@8.18.0)
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - better-sqlite3
+      - pg
+
+  '@danceroutine/tango-schema@1.10.1':
+    dependencies:
+      '@danceroutine/tango-core': 1.10.1
+      zod: 4.3.6
 
   '@docsearch/css@3.8.2': {}
 


### PR DESCRIPTION
## Summary
- add opt-in `transaction: 'writes'` support to the shared framework adapter options
- wrap Express, Next.js, and Nuxt write handlers in request-scoped transactions through a shared bound request executor
- document the adapter contract, `tx.onCommit(...)` caveat, and the current default-runtime limitation

## Why
This lets one adapted write request commit or roll back its database work as one unit without forcing every application to add explicit transaction wrappers around routine CRUD handlers.

## Validation
- `pnpm --filter @danceroutine/tango-adapters-core test`
- `pnpm --filter @danceroutine/tango-adapters-core typecheck`
- `pnpm --filter @danceroutine/tango-adapters-express test`
- `pnpm --filter @danceroutine/tango-adapters-express typecheck`
- `pnpm --filter @danceroutine/tango-adapters-next test`
- `pnpm --filter @danceroutine/tango-adapters-next typecheck`
- `pnpm --filter @danceroutine/tango-adapters-nuxt test`
- `pnpm --filter @danceroutine/tango-adapters-nuxt typecheck`
- `pnpm docs:build`

## Follow-up
- Runtime binding beyond the process-default runtime is tracked in #83.
- Abort and disconnect semantics for request-scoped adapter transactions are tracked in #82.

Closes #44.
