### PR TITLE
fix(orm): enforce uniform field sets in bulkCreate

### DIFF
--- a/.changeset/bulkcreate-uniform-fields.md
+++ b/.changeset/bulkcreate-uniform-fields.md
@@ -1,0 +1,7 @@
+---
+'@danceroutine/tango-orm': patch
+---
+
+Fix `bulkCreate(...)` so batches with mismatched row shapes fail clearly after hook processing instead of silently dropping extra keys or inserting `undefined` values.
+
+---

--- a/packages/orm/src/manager/ModelManager.ts
+++ b/packages/orm/src/manager/ModelManager.ts
@@ -421,6 +421,14 @@ export class ModelManager<TModelRow extends Record<string, unknown>, TSourceMode
         });
     }
 
+    /**
+     * Insert multiple rows in a single multi-row INSERT statement.
+     *
+     * All rows must share the same field set after hook processing. Rows with
+     * extra or missing fields relative to the first row will cause an error.
+     * If you need to insert rows with different field sets, use individual
+     * {@link create} calls instead.
+     */
     async bulkCreate(inputs: Partial<TModelRow>[]): Promise<TModelRow[]> {
         if (inputs.length === 0) {
             return [];
@@ -438,6 +446,7 @@ export class ModelManager<TModelRow extends Record<string, unknown>, TSourceMode
         if (preparedKeys.length === 0) {
             throw new Error(`Cannot create ${this.model.metadata.name} without any values.`);
         }
+        this.assertUniformRowShape(batchPrepared, new Set(preparedKeys));
 
         const validatedPlan = sqlSafetyAdapter.validate({
             kind: SqlPlanKind.INSERT,
@@ -600,5 +609,40 @@ export class ModelManager<TModelRow extends Record<string, unknown>, TSourceMode
 
     private getHookTransaction() {
         return TransactionEngine.forRuntime(this.runtime).getActiveTransaction();
+    }
+
+    private assertUniformRowShape(batch: Partial<TModelRow>[], referenceKeys: Set<string>): void {
+        const divergentRows = batch
+            .slice(1)
+            .map((row, i) => {
+                const rowKeys = new Set(Object.keys(row));
+                const missing = [...referenceKeys].filter((k) => !rowKeys.has(k)).sort();
+                const extra = [...rowKeys].filter((k) => !referenceKeys.has(k)).sort();
+                return { index: i + 1, missing, extra };
+            })
+            .filter((r) => r.missing.length > 0 || r.extra.length > 0);
+
+        if (divergentRows.length === 0) {
+            return;
+        }
+
+        const sortedReferenceKeys = [...referenceKeys].sort();
+        const indices = divergentRows.map((r) => r.index);
+        const details = divergentRows
+            .map((r) => {
+                const parts: string[] = [];
+                if (r.missing.length > 0) {
+                    parts.push(`missing [${r.missing.join(', ')}]`);
+                }
+                if (r.extra.length > 0) {
+                    parts.push(`extra [${r.extra.join(', ')}]`);
+                }
+                return `Row at index ${r.index}: ${parts.join(', ')}.`;
+            })
+            .join('\n');
+
+        throw new Error(
+            `bulkCreate failed after hook processing: rows at indices [${indices.join(', ')}] have mismatched fields.\n${details}\nExpected fields (from row at index 0): [${sortedReferenceKeys.join(', ')}].`
+        );
     }
 }

--- a/packages/orm/src/manager/tests/ModelManager.test.ts
+++ b/packages/orm/src/manager/tests/ModelManager.test.ts
@@ -708,6 +708,102 @@ describe(ModelManager, () => {
         );
     });
 
+    it('rejects bulkCreate when a later row has extra keys', async () => {
+        const manager = new ModelManager(UserModel, getTangoRuntime());
+        const client = await getTangoRuntime().getClient();
+        await client.query('CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, active INTEGER)');
+
+        await expect(
+            manager.bulkCreate([
+                { id: 1, email: 'first@example.com' },
+                { id: 2, email: 'second@example.com', active: true },
+            ])
+        ).rejects.toThrow(/rows at indices \[1\] have mismatched fields.*extra \[active\]/s);
+    });
+
+    it('rejects bulkCreate when a later row has missing keys', async () => {
+        const manager = new ModelManager(UserModel, getTangoRuntime());
+        const client = await getTangoRuntime().getClient();
+        await client.query('CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, active INTEGER)');
+
+        await expect(
+            manager.bulkCreate([
+                { id: 1, email: 'first@example.com', active: true },
+                { id: 2, active: false },
+            ])
+        ).rejects.toThrow(/rows at indices \[1\] have mismatched fields.*missing \[email\]/s);
+    });
+
+    it('reports all divergent rows in a single bulkCreate error', async () => {
+        const manager = new ModelManager(UserModel, getTangoRuntime());
+        const client = await getTangoRuntime().getClient();
+        await client.query('CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, active INTEGER)');
+
+        await expect(
+            manager.bulkCreate([
+                { id: 1, email: 'first@example.com', active: true },
+                { id: 2, active: false },
+                { id: 3, email: 'third@example.com', active: true },
+                { id: 4 },
+            ])
+        ).rejects.toThrow(/rows at indices \[1, 3\] have mismatched fields/);
+    });
+
+    it('rejects bulkCreate when beforeCreate hook produces divergent row shapes', async () => {
+        const manager = new ModelManager(
+            {
+                ...UserModel,
+                hooks: {
+                    beforeCreate: vi.fn(async ({ data }) => {
+                        if (data.id === 2) {
+                            return { ...data, extraField: 'injected' };
+                        }
+                        return data;
+                    }),
+                },
+            },
+            getTangoRuntime()
+        );
+        const client = await getTangoRuntime().getClient();
+        await client.query('CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, active INTEGER)');
+
+        await expect(
+            manager.bulkCreate([
+                { id: 1, email: 'first@example.com', active: true },
+                { id: 2, email: 'second@example.com', active: true },
+            ])
+        ).rejects.toThrow(/rows at indices \[1\] have mismatched fields.*extra \[extraField\]/s);
+    });
+
+    it('rejects bulkCreate when beforeBulkCreate hook returns divergent row shapes', async () => {
+        const manager = new ModelManager(
+            {
+                ...UserModel,
+                hooks: {
+                    beforeBulkCreate: vi.fn(async ({ rows }) => {
+                        return rows.map((row: Partial<UserRecord>, index: number) => {
+                            if (index === 1) {
+                                const { email: _email, ...rest } = row;
+                                return rest;
+                            }
+                            return row;
+                        });
+                    }),
+                },
+            },
+            getTangoRuntime()
+        );
+        const client = await getTangoRuntime().getClient();
+        await client.query('CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT, active INTEGER)');
+
+        await expect(
+            manager.bulkCreate([
+                { id: 1, email: 'first@example.com', active: true },
+                { id: 2, email: 'second@example.com', active: true },
+            ])
+        ).rejects.toThrow(/rows at indices \[1\] have mismatched fields.*missing \[email\]/s);
+    });
+
     it('passes the active transaction handle into hooks only while running inside atomic(...)', async () => {
         const tempDir = await mkdtemp(join(tmpdir(), 'tango-orm-hooks-'));
 


### PR DESCRIPTION
## Summary

- Validate that all rows in `ModelManager.bulkCreate(...)` share the same field set after hook processing
- Fail with a clear error when rows have extra or missing fields, instead of silently dropping keys or inserting `undefined` values
- Document the uniform-shape contract on `bulkCreate` and add regression tests for input-level and hook-driven divergence

Closes #59

## Test plan

- [x] `pnpm --filter @danceroutine/tango-orm typecheck`
- [x] `pnpm --filter @danceroutine/tango-orm test -- --run`