### PR TITLE
feat(skills): add dogfooding skill with Verdaccio registry reference

### DIFF
--- a/.cursor/skills/dogfooding/SKILL.md
+++ b/.cursor/skills/dogfooding/SKILL.md
@@ -1,0 +1,124 @@
+---
+name: dogfooding
+description: Run dogfooding verification by spawning independent subagents with defined personas in isolated environments. Use when the user asks to dogfood docs, verify onboarding, validate that instructions work end-to-end, or invokes dogfooding with context-specific verification goals. For Tango docs that install from npm, provisions a local Verdaccio registry so subagents run documented commands verbatim.
+---
+
+# Dogfooding
+
+Use this skill only when the user explicitly requests dogfooding. Do not trigger it for ordinary doc edits, code review, or implementation work.
+
+Dogfooding validates instructions and first-run experience. Subagents follow materials as a newcomer would and report friction. They do not debug or fix the product under test.
+
+## Context the user provides
+
+Before spawning subagents, collect or infer these inputs. Ask once for anything still missing:
+
+| Input | Purpose |
+|-------|---------|
+| **Verification goal** | What success means (e.g. scaffold and run an app from Getting Started) |
+| **Materials** | Docs, plan files, or other instructions subagents must follow |
+| **Environment** | How packages and tools are made available. For Tango docs that use `pnpm dlx @danceroutine/...`, follow [local-verdaccio-registry.md](references/local-verdaccio-registry.md). |
+| **Personas** | Default is three (below); override if the user specifies fewer or different roles |
+| **Stop condition** | When each subagent stops (default: verification goal met or blocked) |
+
+## Workflow
+
+1. Announce `Executing dogfooding.`
+2. Restate the verification goal and materials back to yourself before setup.
+3. Prepare environments **before** launching subagents. You run setup; subagents never do.
+   - For Tango docs dogfooding (`pnpm dlx @danceroutine/...`, `pnpm add @danceroutine/...`), follow [local-verdaccio-registry.md](references/local-verdaccio-registry.md): build packages, start Verdaccio, publish `@danceroutine/*`, pre-flight the documented flow once, then provision per-subagent dirs.
+   - Otherwise, provision a fully functional environment so documented commands can succeed (local registry, tarball install, workspace clone, or equivalent).
+   - One working directory under `/tmp` per subagent; no shared paths or state. Each Tango subagent also gets an isolated pnpm `store-dir` (see reference).
+   - Verify the environment is consumable before handing it to a subagent.
+   - Include materials exactly as a real user would see them — edited files on disk, plan draft copy, or rendered paths. Do not paraphrase into prompts.
+4. Spawn one subagent per persona (default three). Pass absolute paths to materials and each isolated working directory.
+5. Wait for all subagent reports.
+6. Synthesize findings and present them to the user (see Synthesis).
+7. Close subagent threads after synthesis unless the user continues the loop.
+8. Tear down ephemeral harness resources (Verdaccio, `/tmp/tango-agent-*`, preflight dirs) unless the user continues the loop.
+
+## Hard constraints (include in every subagent prompt)
+
+- Use **only** the provided materials as the guide.
+- Do **not** inspect product or package source code.
+- Do **not** fix or patch the product if something breaks. A broken or confusing step is a finding to report.
+- Stop when the verification goal is met, or when blocked.
+
+## Default personas
+
+Spawn three subagents unless the user specifies otherwise:
+
+1. **Experienced Django developer** — knows Django models, migrations, the ORM, and typical project layout; evaluates Tango through that lens.
+2. **Experienced TypeScript developer** — knows TypeScript tooling, package managers, and typical app structure; may not know Django.
+3. **Inexperienced developer (junior level)** — limited production experience; needs every step spelled out.
+
+Give each persona independent framing so reports do not collapse into the same narrative.
+
+If the Task/subagent tool is unavailable, abort and tell the user dogfooding requires independent subagents. Do not run the passes yourself; shared context would bias the outcomes.
+
+## Subagent prompt checklist
+
+Each subagent prompt must include:
+
+- Persona name and mindset
+- Verification goal and stop condition (verbatim)
+- Absolute path to isolated working directory
+- Absolute paths to materials
+- Environment setup notes (what is pre-provisioned, how to install or run). For Verdaccio harnesses, tell subagents the registry is pre-provisioned — not a documented step.
+- All hard constraints from above
+- The report template below
+
+## Required report (each subagent)
+
+```markdown
+# Dogfooding report — [persona name]
+
+## Outcome
+[running | blocked]
+
+## What went well
+
+## What went wrong
+
+## Friction
+[Was the material straightforward to follow? Where did momentum stop?]
+
+## Continue with product?
+[Would this persona continue using the product based on this experience? Why or why not?]
+
+## Blocker details
+[If blocked: exact step, command output or error, and what was unclear]
+```
+
+## Synthesis
+
+After all subagents report:
+
+1. Deduplicate overlapping friction.
+2. Preserve persona-specific differences.
+3. Order by severity: blockers first, then confusion, then minor friction.
+4. Present to the user:
+   - **Blockers** — steps that prevent completion
+   - **Friction** — completable but painful or unclear
+   - **Positives** — what worked across personas
+   - **Recommended fixes** — concrete next changes tied to specific steps or materials
+
+Do not silently fix the product during dogfooding unless the user explicitly asks for fixes after synthesis.
+
+## Operating rules
+
+- Pre-flight each environment before subagents start. Do not make subagents build a monorepo or set up Verdaccio unless the materials tell the reader to do that.
+- On pnpm 10+, `better-sqlite3` build-script blocking is a genuine doc/product finding. If the goal is to test docs as-written, let subagents hit it and report it rather than pre-fixing with `pnpm approve-builds`.
+- Disclose harness deviations (e.g. pre-provisioned `.npmrc`/registry) in synthesis, not as doc friction.
+- When dogfooding doc changes from a plan in `~/.cursor/plans`, use the plan draft or edited files on disk — whichever matches what a reader would see.
+- Point subagents at actual material files rather than summaries.
+- Dogfooding is not a debugging session for the codebase.
+
+## Reporting to the user
+
+End with:
+
+- Verification goal restated
+- Per-persona outcome (running / blocked)
+- Synthesized findings
+- Prioritized fix list

--- a/.cursor/skills/dogfooding/references/local-verdaccio-registry.md
+++ b/.cursor/skills/dogfooding/references/local-verdaccio-registry.md
@@ -1,0 +1,178 @@
+# Local Verdaccio Registry Setup (for docs dogfooding)
+
+Goal: serve the locally built `@danceroutine/*` packages from a throwaway registry so
+subagents can run the documented commands **verbatim** (`pnpm dlx @danceroutine/tango-cli new ...`,
+`pnpm add @danceroutine/...`), with all non-Tango deps (express, better-sqlite3, tsx, ...)
+proxied from npmjs.
+
+Run all of this yourself BEFORE launching subagents, and pre-flight the full Getting Started
+flow once to confirm the registry is consumable. Subagents must never be the ones to set up
+the registry.
+
+## 1. Build the packages first
+
+Tarball contents come from each package's `files`/`dist`, so build before publishing:
+
+```bash
+cd <repo-root>
+pnpm run build:test:packages
+```
+
+## 2. Write a Verdaccio config (anonymous publish for the scope)
+
+```bash
+mkdir -p /tmp/tango-verdaccio/storage
+cat > /tmp/tango-verdaccio/config.yaml <<'EOF'
+storage: /tmp/tango-verdaccio/storage
+auth:
+  htpasswd:
+    file: /tmp/tango-verdaccio/htpasswd
+    max_users: -1
+uplinks:
+  npmjs:
+    url: https://registry.npmjs.org/
+packages:
+  '@danceroutine/*':
+    access: $all
+    publish: $anonymous
+    unpublish: $anonymous
+  '@*/*':
+    access: $all
+    publish: $authenticated
+    proxy: npmjs
+  '**':
+    access: $all
+    publish: $authenticated
+    proxy: npmjs
+log: { type: stdout, format: pretty, level: warn }
+EOF
+```
+
+Keep `storage` under `/tmp` and ephemeral. A fresh storage dir avoids
+"cannot publish over existing version" collisions on re-runs.
+
+## 3. Launch Verdaccio (background) and wait for it
+
+```bash
+npx --yes verdaccio@6 --config /tmp/tango-verdaccio/config.yaml --listen 4873 \
+  > /tmp/tango-verdaccio/verdaccio.log 2>&1 &
+# wait until it answers, then sanity-check
+sleep 6
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:4873/   # expect 200
+```
+
+Record the Verdaccio PID so you can kill it during teardown.
+
+## 4. Publish the Tango packages
+
+Verdaccio requires *some* auth token to publish, even anonymously. Use a fake one in an
+`.npmrc`, and point pnpm at it via the `npm_config_userconfig` ENV VAR.
+
+> Gotcha: `pnpm publish --userconfig ...` fails with "Unknown option: 'userconfig'".
+> You MUST pass it as the `npm_config_userconfig` environment variable instead.
+
+```bash
+cat > /tmp/tango-verdaccio/.npmrc <<'EOF'
+registry=http://localhost:4873/
+//localhost:4873/:_authToken=fake-token-for-anonymous
+EOF
+
+cd <repo-root>
+export npm_config_userconfig=/tmp/tango-verdaccio/.npmrc
+export npm_config_registry=http://localhost:4873/
+
+pnpm -r \
+  --filter '@danceroutine/*' \
+  --filter '!@danceroutine/tango-docs' \
+  --filter '!@danceroutine/tango-example-*' \
+  publish --registry http://localhost:4873/ --no-git-checks
+```
+
+Verify the key packages resolve (each should return 200):
+
+```bash
+for p in tango-cli tango-config tango-schema tango-orm tango-migrations \
+         tango-resources tango-codegen tango-adapters-express; do
+  curl -s -o /dev/null -w "%{http_code}  @danceroutine/$p\n" \
+    "http://localhost:4873/@danceroutine%2f$p"
+done
+```
+
+## 5. Per-subagent consumer environment
+
+Each subagent gets its own isolated `/tmp` working dir with its own `.npmrc`. Critically,
+give each one an **isolated pnpm store-dir** so concurrent subagents do not serve each other
+a stale CLI from a shared `pnpm dlx` cache.
+
+```bash
+# one per subagent, e.g. /tmp/tango-agent-1, /tmp/tango-agent-2, ...
+mkdir -p /tmp/tango-agent-1
+cat > /tmp/tango-agent-1/.npmrc <<'EOF'
+registry=http://localhost:4873/
+@danceroutine:registry=http://localhost:4873/
+store-dir=/tmp/tango-agent-1/.pnpm-store
+EOF
+```
+
+When the subagent runs commands in that dir, export the userconfig so pnpm/dlx use the
+local registry:
+
+```bash
+export npm_config_userconfig=/tmp/tango-agent-1/.npmrc
+export npm_config_registry=http://localhost:4873/
+```
+
+## 6. Pre-flight the documented flow yourself
+
+Confirm the docs are followable end to end before handing the env to subagents:
+
+```bash
+cd /tmp/tango-agent-preflight   # a scratch dir with its own .npmrc as above
+pnpm dlx @danceroutine/tango-cli new my-app --framework express --dialect sqlite
+cd my-app
+pnpm install
+pnpm run make:migrations --name initial
+pnpm run dev &   # starts on :3000
+sleep 9
+curl -s -X POST http://localhost:3000/api/todos -H 'content-type: application/json' \
+  -d '{"title":"preflight"}'
+curl -s http://localhost:3000/api/todos
+curl -s -o /dev/null -w "health:%{http_code} openapi:%{http_code}\n" \
+  http://localhost:3000/health http://localhost:3000/api/openapi.json
+pkill -f "tsx watch src/index.ts"
+```
+
+Verified behavior:
+- `pnpm dlx @danceroutine/tango-cli new ...` DOES resolve the `tango` bin even though the
+  package suffix is `tango-cli` (pnpm runs the sole bin). The `--package` workaround is not needed.
+- `pnpm install` pulls `@danceroutine/*` from Verdaccio and express/pg/better-sqlite3/tsx from
+  the npmjs uplink.
+
+## 7. Known failure mode to expect (pnpm 10)
+
+On pnpm 10+, dependency build scripts are blocked by default. `better-sqlite3` then never
+compiles its native binding, and `make:migrations`/`dev` crash with a missing
+`better_sqlite3.node`. To unblock during pre-flight:
+
+```bash
+pnpm approve-builds            # select better-sqlite3 and esbuild
+pnpm install
+# or, declaratively, add to the project package.json then reinstall:
+#   "pnpm": { "onlyBuiltDependencies": ["better-sqlite3", "esbuild"] }
+```
+
+This is a genuine product/doc finding, not a registry problem. If the dogfooding goal is to
+test the docs as-written, let the subagent HIT this and report it rather than pre-fixing it.
+
+## 8. Teardown
+
+```bash
+kill <verdaccio-pid> 2>/dev/null
+pkill -f verdaccio 2>/dev/null
+rm -rf /tmp/tango-verdaccio /tmp/tango-agent-* /tmp/tango-agent-preflight
+```
+
+## Honest deviation to disclose in reports
+
+The `.npmrc`/registry pointer is harness-provisioned setup, not a documented step. Each
+subagent should treat it as "registry pre-provisioned" rather than as part of the docs flow.


### PR DESCRIPTION
## Summary
- Adds a project-level `dogfooding` skill for verifying docs and onboarding flows via isolated subagent personas.
- Includes a Verdaccio registry reference so Tango docs dogfooding can run `pnpm dlx @danceroutine/...` commands verbatim against locally built packages.

## Test plan
- [x] Skill files added under `.cursor/skills/dogfooding/`
- [x] Reference doc covers build, publish, per-subagent isolation, preflight, and teardown