### PR TITLE
fix: avoid pre-wrapping resource icontains filters

### DIFF
--- a/.changeset/clean-icontains-wildcards.md
+++ b/.changeset/clean-icontains-wildcards.md
@@ -1,0 +1,5 @@
+---
+"@danceroutine/tango-resources": patch
+---
+
+- `FilterSet` now passes raw `icontains` values to the ORM so SQL wildcard wrapping happens once in the query compiler.

--- a/packages/resources/src/filters/FilterSet.ts
+++ b/packages/resources/src/filters/FilterSet.ts
@@ -270,7 +270,7 @@ export class FilterSet<T extends Record<string, unknown>> {
 
         if (lookup === 'icontains') {
             const lookupKey = `${String(field)}__icontains` as FilterKey<T>;
-            return { [lookupKey]: `%${FilterSet.toScalarString(value)}%` } as FilterInput<T>;
+            return { [lookupKey]: FilterSet.toScalarString(value) } as FilterInput<T>;
         }
 
         const lookupKey = `${String(field)}__${lookup}` as FilterKey<T>;
@@ -389,7 +389,7 @@ export class FilterSet<T extends Record<string, unknown>> {
                 return { [resolver.column]: value } as FilterInput<T>;
 
             case InternalFilterType.ILIKE: {
-                const pattern = `%${FilterSet.toScalarString(value)}%`;
+                const pattern = FilterSet.toScalarString(value);
                 const filter: Partial<Record<FilterKey<T>, FilterValue>> = {};
                 resolver.columns.forEach((col) => {
                     filter[`${String(col)}__icontains` as FilterKey<T>] = pattern;

--- a/packages/resources/src/filters/tests/FilterSet.test.ts
+++ b/packages/resources/src/filters/tests/FilterSet.test.ts
@@ -37,8 +37,7 @@ describe(FilterSet, () => {
         const result = filters.apply(params);
 
         expect(result).toHaveLength(1);
-        expect(result[0]).toHaveProperty('name__icontains');
-        expect(result[0]).toHaveProperty('email__icontains');
+        expect(result[0]).toEqual({ name__icontains: 'john', email__icontains: 'john' });
     });
 
     it('applies range filter', () => {
@@ -134,7 +133,7 @@ describe(FilterSet, () => {
         });
 
         const result = filters.apply(query('tags__slug=tango&author__email__icontains=example.com'));
-        expect(result).toEqual([{ tags__slug: 'tango' }, { author__email__icontains: '%example.com%' }]);
+        expect(result).toEqual([{ tags__slug: 'tango' }, { author__email__icontains: 'example.com' }]);
     });
 
     it('ignores malformed all-field lookup params that resolve to an empty relation path', () => {
@@ -238,7 +237,7 @@ describe(FilterSet, () => {
             active: (raw) => raw,
         });
 
-        expect(filters.apply(query('q=pedro'))).toEqual([{ name__icontains: '%pedro%', email__icontains: '%pedro%' }]);
+        expect(filters.apply(query('q=pedro'))).toEqual([{ name__icontains: 'pedro', email__icontains: 'pedro' }]);
     });
 
     it('leaves range and in resolvers unchanged when no matching parser override exists', () => {
@@ -278,7 +277,7 @@ describe(FilterSet, () => {
         });
 
         const result = filters.apply(query('q=pedro'));
-        expect(result).toEqual([{ name__icontains: '%pedro%', email__icontains: '%pedro%' }]);
+        expect(result).toEqual([{ name__icontains: 'pedro', email__icontains: 'pedro' }]);
     });
 
     it('defaults multi-field alias lookups to icontains when lookup is omitted', () => {
@@ -291,7 +290,7 @@ describe(FilterSet, () => {
         });
 
         const result = filters.apply(query('q=pedro'));
-        expect(result).toEqual([{ name__icontains: '%pedro%', email__icontains: '%pedro%' }]);
+        expect(result).toEqual([{ name__icontains: 'pedro', email__icontains: 'pedro' }]);
     });
 
     it('supports __all__ mode when explicitly enabled', () => {
@@ -363,7 +362,7 @@ describe(FilterSet, () => {
             { id__lte: '10' },
             { id__gt: '0' },
             { id__gte: '1' },
-            { name__icontains: '%foo%' },
+            { name__icontains: 'foo' },
             { name__contains: 'foo' },
             { name__startswith: 'fo' },
             { name__istartswith: 'fo' },
@@ -423,7 +422,7 @@ describe(FilterSet, () => {
         expect(internalClass.resolveLookupFilter('id', 'in', '1,2')).toEqual({ id__in: ['1', '2'] });
         expect(internalClass.resolveLookupFilter('id', 'in', [1, 2])).toEqual({ id__in: [1, 2] });
         expect(internalClass.resolveLookupFilter('name', 'icontains', 'foo')).toEqual({
-            name__icontains: '%foo%',
+            name__icontains: 'foo',
         });
 
         expect(internalClass.isFilterResolverDeclaration({ type: 'scalar', column: 'id' })).toBe(true);


### PR DESCRIPTION
## Summary
- stop `FilterSet` from adding `%` wildcards to `icontains` values before they reach the ORM
- keep wildcard ownership in `QueryCompiler.lookupToSQL()` so compiled SQL params stay `%term%` instead of `%%term%%`
- update resource filter tests to assert raw `icontains` filter values
- add a patch changeset for `@danceroutine/tango-resources`

## Validation
- `pnpm --filter @danceroutine/tango-resources exec vitest run src/filters/tests/FilterSet.test.ts`
- `pnpm --filter @danceroutine/tango-resources typecheck`
- `pnpm changeset status --since=origin/main`

## Notes
- Attempted `pnpm --filter @danceroutine/tango-orm exec vitest run src/query/compiler/tests/QueryCompiler.test.ts` in a fresh worktree on current `origin/main`, but test collection failed before reaching this change because `@danceroutine/tango-codegen/commands` resolves to an unbuilt `dist` subpath.
- Attempted to build `@danceroutine/tango-codegen` as a prerequisite, but current `origin/main` fails with `Failed to import module "unrun"` from `tsdown`.