### PR TITLE
fix: escape generated migration string literals

### DIFF
--- a/.changeset/quiet-migrations-escape.md
+++ b/.changeset/quiet-migrations-escape.md
@@ -1,0 +1,5 @@
+---
+"@danceroutine/tango-migrations": patch
+---
+
+Escape string values when rendering generated migration source.

--- a/packages/migrations/src/commands/tests/registerMigrationsCommands.test.ts
+++ b/packages/migrations/src/commands/tests/registerMigrationsCommands.test.ts
@@ -156,8 +156,8 @@ describe(importRegisterMigrationsCommands, () => {
                 join(root, 'migrations', generatedMigrationName as string),
                 'utf8'
             );
-            expect(generatedMigration).toContain("op.table('posts').create");
-            expect(generatedMigration).toContain("op.table('users').create");
+            expect(generatedMigration).toContain('op.table("posts").create');
+            expect(generatedMigration).toContain('op.table("users").create');
 
             const relationTypes = await readFile(join(root, '.tango/relations.generated.d.ts'), 'utf8');
             expect(relationTypes).toContain('"blog/User"');
@@ -211,8 +211,8 @@ describe(importRegisterMigrationsCommands, () => {
                 join(root, 'migrations', generatedMigrationName as string),
                 'utf8'
             );
-            expect(generatedMigration).toContain("op.table('posts').create");
-            expect(generatedMigration).toContain("op.table('users').create");
+            expect(generatedMigration).toContain('op.table("posts").create');
+            expect(generatedMigration).toContain('op.table("users").create');
 
             const relationTypes = await readFile(join(root, '.tango/relations.generated.d.ts'), 'utf8');
             expect(relationTypes).toContain('typeof import("../src/models.ts")["models"]["UserModel"]');

--- a/packages/migrations/src/generator/MigrationGenerator.ts
+++ b/packages/migrations/src/generator/MigrationGenerator.ts
@@ -13,6 +13,7 @@ import type {
     ForeignKeyDrop,
 } from '../domain/MigrationOperation';
 import type { ColumnSpec } from '../builder/contracts/ColumnSpec';
+import { InternalColumnType } from '../domain/internal/InternalColumnType';
 import { InternalOperationKind } from '../domain/internal/InternalOperationKind';
 import { writeFile, mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
@@ -84,7 +85,7 @@ export class MigrationGenerator {
             `import { Migration, op, trustedSql, type Builder } from '@danceroutine/tango-migrations';`,
             ``,
             `export default class ${className} extends Migration {`,
-            `  id = '${id}';`,
+            `  id = ${this.renderStringLiteral(id)};`,
             ``,
             `  up(m: Builder) {`,
             `    m.run(`,
@@ -138,9 +139,9 @@ export class MigrationGenerator {
             case InternalOperationKind.FK_DROP:
                 return this.renderForeignKeyDrop(operation);
             case InternalOperationKind.FK_VALIDATE:
-                return `op.foreignKeyValidate({ table: '${operation.table}', name: '${operation.name}' })`;
+                return `op.foreignKeyValidate({ table: ${this.renderStringLiteral(operation.table)}, name: ${this.renderStringLiteral(operation.name)} })`;
             case 'custom':
-                return `/* custom operation '${operation.name}' cannot be code-generated */`;
+                return `/* custom operation ${this.renderCommentStringLiteral(operation.name)} cannot be code-generated */`;
             default:
                 return `/* unsupported operation */`;
         }
@@ -149,29 +150,29 @@ export class MigrationGenerator {
     private renderReverseOperation(operation: MigrationOperation): string {
         switch (operation.kind) {
             case InternalOperationKind.TABLE_CREATE:
-                return `op.table('${operation.table}').drop()`;
+                return `op.table(${this.renderStringLiteral(operation.table)}).drop()`;
             case InternalOperationKind.TABLE_DROP:
-                return `/* manual reverse required: recreate dropped table '${operation.table}' */`;
+                return `/* manual reverse required: recreate dropped table ${this.renderCommentStringLiteral(operation.table)} */`;
             case InternalOperationKind.COLUMN_ADD:
-                return `op.table('${operation.table}').dropColumn('${operation.column.name}')`;
+                return `op.table(${this.renderStringLiteral(operation.table)}).dropColumn(${this.renderStringLiteral(operation.column.name)})`;
             case InternalOperationKind.COLUMN_DROP:
-                return `/* manual reverse required: restore dropped column '${operation.column}' */`;
+                return `/* manual reverse required: restore dropped column ${this.renderCommentStringLiteral(operation.column)} */`;
             case InternalOperationKind.COLUMN_ALTER:
-                return `/* manual reverse required: revert ALTER COLUMN '${operation.column}' on '${operation.table}' */`;
+                return `/* manual reverse required: revert ALTER COLUMN ${this.renderCommentStringLiteral(operation.column)} on ${this.renderCommentStringLiteral(operation.table)} */`;
             case InternalOperationKind.COLUMN_RENAME:
-                return `op.table('${operation.table}').renameColumn('${operation.to}', '${operation.from}')`;
+                return `op.table(${this.renderStringLiteral(operation.table)}).renameColumn(${this.renderStringLiteral(operation.to)}, ${this.renderStringLiteral(operation.from)})`;
             case InternalOperationKind.INDEX_CREATE:
-                return `op.index.drop({ name: '${operation.name}', table: '${operation.table}' })`;
+                return `op.index.drop({ name: ${this.renderStringLiteral(operation.name)}, table: ${this.renderStringLiteral(operation.table)} })`;
             case InternalOperationKind.INDEX_DROP:
-                return `/* manual reverse required: recreate dropped index '${operation.name}' */`;
+                return `/* manual reverse required: recreate dropped index ${this.renderCommentStringLiteral(operation.name)} */`;
             case InternalOperationKind.FK_CREATE:
-                return `op.foreignKeyDrop({ table: '${operation.table}', name: '${operation.name ?? `${operation.table}_${operation.columns.join('_')}_fkey`}' })`;
+                return `op.foreignKeyDrop({ table: ${this.renderStringLiteral(operation.table)}, name: ${this.renderStringLiteral(operation.name ?? `${operation.table}_${operation.columns.join('_')}_fkey`)} })`;
             case InternalOperationKind.FK_DROP:
-                return `/* manual reverse required: recreate dropped FK '${operation.name}' */`;
+                return `/* manual reverse required: recreate dropped FK ${this.renderCommentStringLiteral(operation.name)} */`;
             case InternalOperationKind.FK_VALIDATE:
                 return `/* no reverse needed for FK_VALIDATE */`;
             case 'custom':
-                return `/* manual reverse required: custom operation '${operation.name}' */`;
+                return `/* manual reverse required: custom operation ${this.renderCommentStringLiteral(operation.name)} */`;
             default:
                 return `/* unsupported reverse operation */`;
         }
@@ -180,32 +181,36 @@ export class MigrationGenerator {
     private renderTableCreate(operation: TableCreate): string {
         const columnLines = operation.columns.map((col) => {
             const chain = this.renderColumnChain(col);
-            return `        cols.add('${col.name}', (b) => b${chain});`;
+            return `        cols.add(${this.renderStringLiteral(col.name)}, (b) => b${chain});`;
         });
 
-        return [`op.table('${operation.table}').create((cols) => {`, ...columnLines, `      })`].join('\n');
+        return [
+            `op.table(${this.renderStringLiteral(operation.table)}).create((cols) => {`,
+            ...columnLines,
+            `      })`,
+        ].join('\n');
     }
 
     private renderTableDrop(operation: TableDrop): string {
         if (operation.cascade) {
-            return `op.table('${operation.table}').drop({ cascade: true })`;
+            return `op.table(${this.renderStringLiteral(operation.table)}).drop({ cascade: true })`;
         }
-        return `op.table('${operation.table}').drop()`;
+        return `op.table(${this.renderStringLiteral(operation.table)}).drop()`;
     }
 
     private renderColumnAdd(operation: ColumnAdd): string {
         const chain = this.renderColumnChain(operation.column);
-        return `op.table('${operation.table}').addColumn('${operation.column.name}', (b) => b${chain})`;
+        return `op.table(${this.renderStringLiteral(operation.table)}).addColumn(${this.renderStringLiteral(operation.column.name)}, (b) => b${chain})`;
     }
 
     private renderColumnDrop(operation: ColumnDrop): string {
-        return `op.table('${operation.table}').dropColumn('${operation.column}')`;
+        return `op.table(${this.renderStringLiteral(operation.table)}).dropColumn(${this.renderStringLiteral(operation.column)})`;
     }
 
     private renderColumnAlter(operation: ColumnAlter): string {
         const parts: string[] = [];
         if (operation.to.type) {
-            parts.push(`type: '${operation.to.type}'`);
+            parts.push(`type: ${this.renderStringLiteral(operation.to.type)}`);
         }
         if (operation.to.notNull !== undefined) {
             parts.push(`notNull: ${operation.to.notNull}`);
@@ -216,27 +221,27 @@ export class MigrationGenerator {
             } else if (this.isNowDefault(operation.to.default)) {
                 parts.push(`default: { now: true }`);
             } else if (isTrustedSqlFragment(operation.to.default)) {
-                parts.push(`default: trustedSql(${JSON.stringify(operation.to.default.sql)})`);
+                parts.push(`default: trustedSql(${this.renderStringLiteral(operation.to.default.sql)})`);
             }
         }
-        return `op.table('${operation.table}').alterColumn('${operation.column}', { ${parts.join(', ')} })`;
+        return `op.table(${this.renderStringLiteral(operation.table)}).alterColumn(${this.renderStringLiteral(operation.column)}, { ${parts.join(', ')} })`;
     }
 
     private renderColumnRename(operation: ColumnRename): string {
-        return `op.table('${operation.table}').renameColumn('${operation.from}', '${operation.to}')`;
+        return `op.table(${this.renderStringLiteral(operation.table)}).renameColumn(${this.renderStringLiteral(operation.from)}, ${this.renderStringLiteral(operation.to)})`;
     }
 
     private renderIndexCreate(operation: IndexCreate): string {
         const parts: string[] = [
-            `name: '${operation.name}'`,
-            `table: '${operation.table}'`,
-            `on: [${operation.on.map((c) => `'${c}'`).join(', ')}]`,
+            `name: ${this.renderStringLiteral(operation.name)}`,
+            `table: ${this.renderStringLiteral(operation.table)}`,
+            `on: ${this.renderStringArrayLiteral(operation.on)}`,
         ];
         if (operation.unique) {
             parts.push(`unique: true`);
         }
         if (operation.where) {
-            parts.push(`where: trustedSql(${JSON.stringify(operation.where.sql)})`);
+            parts.push(`where: trustedSql(${this.renderStringLiteral(operation.where.sql)})`);
         }
         if (operation.concurrently) {
             parts.push(`concurrently: true`);
@@ -245,23 +250,23 @@ export class MigrationGenerator {
     }
 
     private renderIndexDrop(operation: IndexDrop): string {
-        return `op.index.drop({ name: '${operation.name}', table: '${operation.table}' })`;
+        return `op.index.drop({ name: ${this.renderStringLiteral(operation.name)}, table: ${this.renderStringLiteral(operation.table)} })`;
     }
 
     private renderForeignKeyCreate(operation: ForeignKeyCreate): string {
         const parts: string[] = [
-            `table: '${operation.table}'`,
-            `columns: [${operation.columns.map((c) => `'${c}'`).join(', ')}]`,
-            `references: { table: '${operation.refTable}', columns: [${operation.refColumns.map((c) => `'${c}'`).join(', ')}] }`,
+            `table: ${this.renderStringLiteral(operation.table)}`,
+            `columns: ${this.renderStringArrayLiteral(operation.columns)}`,
+            `references: { table: ${this.renderStringLiteral(operation.refTable)}, columns: ${this.renderStringArrayLiteral(operation.refColumns)} }`,
         ];
         if (operation.name) {
-            parts.push(`name: '${operation.name}'`);
+            parts.push(`name: ${this.renderStringLiteral(operation.name)}`);
         }
         if (operation.onDelete) {
-            parts.push(`onDelete: '${operation.onDelete}'`);
+            parts.push(`onDelete: ${this.renderStringLiteral(operation.onDelete)}`);
         }
         if (operation.onUpdate) {
-            parts.push(`onUpdate: '${operation.onUpdate}'`);
+            parts.push(`onUpdate: ${this.renderStringLiteral(operation.onUpdate)}`);
         }
         if (operation.notValid) {
             parts.push(`notValid: true`);
@@ -270,14 +275,14 @@ export class MigrationGenerator {
     }
 
     private renderForeignKeyDrop(operation: ForeignKeyDrop): string {
-        return `op.foreignKeyDrop({ table: '${operation.table}', name: '${operation.name}' })`;
+        return `op.foreignKeyDrop({ table: ${this.renderStringLiteral(operation.table)}, name: ${this.renderStringLiteral(operation.name)} })`;
     }
 
     private renderColumnChain(col: ColumnSpec): string {
         const parts: string[] = [];
 
         if (col.type) {
-            parts.push(`.${col.type}()`);
+            parts.push(`.${this.renderColumnTypeMethod(col.type)}()`);
         }
         if (col.notNull) {
             parts.push(`.notNull()`);
@@ -286,7 +291,7 @@ export class MigrationGenerator {
             if (this.isNowDefault(col.default)) {
                 parts.push(`.defaultNow()`);
             } else if (isTrustedSqlFragment(col.default)) {
-                parts.push(`.default(trustedSql(${JSON.stringify(col.default.sql)}))`);
+                parts.push(`.default(trustedSql(${this.renderStringLiteral(col.default.sql)}))`);
             }
         } else if (col.default === null) {
             parts.push(`.default(null)`);
@@ -300,16 +305,48 @@ export class MigrationGenerator {
         if (col.references) {
             const refParts: string[] = [];
             if (col.references.onDelete) {
-                refParts.push(`onDelete: '${col.references.onDelete}'`);
+                refParts.push(`onDelete: ${this.renderStringLiteral(col.references.onDelete)}`);
             }
             if (col.references.onUpdate) {
-                refParts.push(`onUpdate: '${col.references.onUpdate}'`);
+                refParts.push(`onUpdate: ${this.renderStringLiteral(col.references.onUpdate)}`);
             }
             const opts = refParts.length > 0 ? `, { ${refParts.join(', ')} }` : '';
-            parts.push(`.references('${col.references.table}', '${col.references.column}'${opts})`);
+            parts.push(
+                `.references(${this.renderStringLiteral(col.references.table)}, ${this.renderStringLiteral(col.references.column)}${opts})`
+            );
         }
 
         return parts.join('');
+    }
+
+    private renderStringLiteral(value: string): string {
+        return JSON.stringify(value);
+    }
+
+    private renderStringArrayLiteral(values: string[]): string {
+        return `[${values.map((value) => this.renderStringLiteral(value)).join(', ')}]`;
+    }
+
+    private renderCommentStringLiteral(value: string): string {
+        return this.renderStringLiteral(value).replaceAll('*/', '*\\/');
+    }
+
+    private renderColumnTypeMethod(type: ColumnSpec['type']): string {
+        switch (type) {
+            case InternalColumnType.SERIAL:
+            case InternalColumnType.INT:
+            case InternalColumnType.BIGINT:
+            case InternalColumnType.TEXT:
+            case InternalColumnType.BOOL:
+            case InternalColumnType.TIMESTAMPTZ:
+            case InternalColumnType.JSONB:
+            case InternalColumnType.UUID:
+                return type;
+            default:
+                throw new Error(
+                    `Unsupported column type in migration source generation: ${this.renderStringLiteral(type)}`
+                );
+        }
     }
 
     private timestamp(): string {

--- a/packages/migrations/src/generator/tests/MigrationGenerator.test.ts
+++ b/packages/migrations/src/generator/tests/MigrationGenerator.test.ts
@@ -34,8 +34,8 @@ describe(MigrationGenerator, () => {
             expect(source).toContain(
                 "import { Migration, op, trustedSql, type Builder } from '@danceroutine/tango-migrations'"
             );
-            expect(source).toContain("id = '001_create_users'");
-            expect(source).toContain("op.table('users').create");
+            expect(source).toContain('id = "001_create_users"');
+            expect(source).toContain('op.table("users").create');
             expect(source).toContain('.serial()');
             expect(source).toContain('.primaryKey()');
             expect(source).toContain('.notNull()');
@@ -43,7 +43,7 @@ describe(MigrationGenerator, () => {
             expect(source).toContain('.unique()');
             expect(source).toContain('.timestamptz()');
             expect(source).toContain('.defaultNow()');
-            expect(source).toContain("op.table('users').drop()");
+            expect(source).toContain('op.table("users").drop()');
         });
 
         it('renders a TABLE_DROP operation', () => {
@@ -53,13 +53,13 @@ describe(MigrationGenerator, () => {
 
             const source = generator.render('002_drop_old', operations);
 
-            expect(source).toContain("op.table('old_table').drop({ cascade: true })");
+            expect(source).toContain('op.table("old_table").drop({ cascade: true })');
         });
 
         it('renders a TABLE_DROP operation without cascade', () => {
             const operations: MigrationOperation[] = [{ kind: InternalOperationKind.TABLE_DROP, table: 'old_table' }];
             const source = generator.render('002b_drop_old', operations);
-            expect(source).toContain("op.table('old_table').drop()");
+            expect(source).toContain('op.table("old_table").drop()');
         });
 
         it('renders a COLUMN_ADD operation', () => {
@@ -73,8 +73,8 @@ describe(MigrationGenerator, () => {
 
             const source = generator.render('003_add_bio', operations);
 
-            expect(source).toContain("op.table('users').addColumn('bio', (b) => b.text())");
-            expect(source).toContain("op.table('users').dropColumn('bio')");
+            expect(source).toContain('op.table("users").addColumn("bio", (b) => b.text())');
+            expect(source).toContain('op.table("users").dropColumn("bio")');
         });
 
         it('renders a COLUMN_DROP operation', () => {
@@ -84,7 +84,7 @@ describe(MigrationGenerator, () => {
 
             const source = generator.render('004_drop_legacy', operations);
 
-            expect(source).toContain("op.table('users').dropColumn('legacy_field')");
+            expect(source).toContain('op.table("users").dropColumn("legacy_field")');
         });
 
         it('renders a COLUMN_RENAME operation', () => {
@@ -94,8 +94,8 @@ describe(MigrationGenerator, () => {
 
             const source = generator.render('005_rename_name', operations);
 
-            expect(source).toContain("op.table('users').renameColumn('name', 'full_name')");
-            expect(source).toContain("op.table('users').renameColumn('full_name', 'name')");
+            expect(source).toContain('op.table("users").renameColumn("name", "full_name")');
+            expect(source).toContain('op.table("users").renameColumn("full_name", "name")');
         });
 
         it('renders an INDEX_CREATE operation', () => {
@@ -114,9 +114,9 @@ describe(MigrationGenerator, () => {
             const source = generator.render('006_add_index', operations);
 
             expect(source).toContain(
-                `op.index.create({ name: 'users_email_idx', table: 'users', on: ['email'], unique: true, where: trustedSql(${JSON.stringify('deleted_at IS NULL')}), concurrently: true })`
+                `op.index.create({ name: "users_email_idx", table: "users", on: ["email"], unique: true, where: trustedSql(${JSON.stringify('deleted_at IS NULL')}), concurrently: true })`
             );
-            expect(source).toContain("op.index.drop({ name: 'users_email_idx', table: 'users' })");
+            expect(source).toContain('op.index.drop({ name: "users_email_idx", table: "users" })');
         });
 
         it('renders a FK_CREATE operation', () => {
@@ -136,12 +136,12 @@ describe(MigrationGenerator, () => {
             const source = generator.render('007_add_fk', operations);
 
             expect(source).toContain('op.foreignKey(');
-            expect(source).toContain("table: 'posts'");
-            expect(source).toContain("columns: ['author_id']");
-            expect(source).toContain("references: { table: 'users', columns: ['id'] }");
-            expect(source).toContain("name: 'posts_author_id_fkey'");
-            expect(source).toContain("onDelete: 'CASCADE'");
-            expect(source).toContain("onUpdate: 'CASCADE'");
+            expect(source).toContain('table: "posts"');
+            expect(source).toContain('columns: ["author_id"]');
+            expect(source).toContain('references: { table: "users", columns: ["id"] }');
+            expect(source).toContain('name: "posts_author_id_fkey"');
+            expect(source).toContain('onDelete: "CASCADE"');
+            expect(source).toContain('onUpdate: "CASCADE"');
         });
 
         it('renders column with references', () => {
@@ -163,7 +163,7 @@ describe(MigrationGenerator, () => {
 
             const source = generator.render('008_posts', operations);
 
-            expect(source).toContain(".references('users', 'id', { onDelete: 'CASCADE' })");
+            expect(source).toContain('.references("users", "id", { onDelete: "CASCADE" })');
         });
 
         it('renders multiple operations', () => {
@@ -187,10 +187,10 @@ describe(MigrationGenerator, () => {
 
             const source = generator.render('009_tags', operations);
 
-            expect(source).toContain("op.table('tags').create");
+            expect(source).toContain('op.table("tags").create');
             expect(source).toContain('op.index.create');
             expect(source).toContain('op.index.drop');
-            expect(source).toContain("op.table('tags').drop()");
+            expect(source).toContain('op.table("tags").drop()');
         });
 
         it('renders a COLUMN_ALTER operation', () => {
@@ -205,7 +205,7 @@ describe(MigrationGenerator, () => {
 
             const source = generator.render('010_alter_email', operations);
 
-            expect(source).toContain("op.table('users').alterColumn('email', { notNull: true })");
+            expect(source).toContain('op.table("users").alterColumn("email", { notNull: true })');
         });
 
         it('generates valid TypeScript module structure', () => {
@@ -237,9 +237,9 @@ describe(MigrationGenerator, () => {
 
             const source = generator.render('011_misc', operations);
             expect(source).toContain('op.foreignKeyValidate');
-            expect(source).toContain("op.foreignKeyDrop({ table: 'posts', name: 'posts_author_fkey' })");
-            expect(source).toContain("op.index.drop({ name: 'posts_idx', table: 'posts' })");
-            expect(source).toContain("custom operation 'seed.users'");
+            expect(source).toContain('op.foreignKeyDrop({ table: "posts", name: "posts_author_fkey" })');
+            expect(source).toContain('op.index.drop({ name: "posts_idx", table: "posts" })');
+            expect(source).toContain('custom operation "seed.users"');
             expect(source).toContain('unsupported operation');
             expect(source).toContain('manual reverse required');
             expect(source).toContain('no reverse needed for FK_VALIDATE');
@@ -294,14 +294,14 @@ describe(MigrationGenerator, () => {
 
             const source = generator.render('012_alter_defaults', operations);
             expect(source).toContain(
-                "alterColumn('created_at', { type: 'timestamptz', notNull: false, default: null })"
+                'alterColumn("created_at", { type: "timestamptz", notNull: false, default: null })'
             );
-            expect(source).toContain(`alterColumn('status', { default: trustedSql(${JSON.stringify('active')}) })`);
-            expect(source).toContain("alterColumn('updated_at', { default: { now: true } })");
-            expect(source).toContain("alterColumn('metadata', {  })");
-            expect(source).toContain(".references('users', 'id', { onDelete: 'CASCADE', onUpdate: 'CASCADE' })");
+            expect(source).toContain(`alterColumn("status", { default: trustedSql(${JSON.stringify('active')}) })`);
+            expect(source).toContain('alterColumn("updated_at", { default: { now: true } })');
+            expect(source).toContain('alterColumn("metadata", {  })');
+            expect(source).toContain('.references("users", "id", { onDelete: "CASCADE", onUpdate: "CASCADE" })');
             expect(source).toContain('notValid: true');
-            expect(source).toContain("op.foreignKeyDrop({ table: 'events', name: 'events_user_id_fkey' })");
+            expect(source).toContain('op.foreignKeyDrop({ table: "events", name: "events_user_id_fkey" })');
         });
 
         it('renders column chains for string and null defaults', () => {
@@ -333,9 +333,9 @@ describe(MigrationGenerator, () => {
                 },
             ]);
 
-            expect(source).toContain("cols.add('untyped', (b) => b);");
-            expect(source).toContain("cols.add('opaque_default', (b) => b.text());");
-            expect(source).toContain(".references('users', 'id')");
+            expect(source).toContain('cols.add("untyped", (b) => b);');
+            expect(source).toContain('cols.add("opaque_default", (b) => b.text());');
+            expect(source).toContain('.references("users", "id")');
         });
 
         it('renders index create without unique/where/concurrently flags', () => {
@@ -347,7 +347,91 @@ describe(MigrationGenerator, () => {
                     on: ['username'],
                 },
             ]);
-            expect(source).toContain("op.index.create({ name: 'users_plain_idx', table: 'users', on: ['username'] })");
+            expect(source).toContain('op.index.create({ name: "users_plain_idx", table: "users", on: ["username"] })');
+        });
+
+        it('renders source safely for names that contain source delimiters', () => {
+            const table = `users');\nthrow new Error("bad");/*`;
+            const column = `bio"'\n`;
+            const indexName = `users*/idx'`;
+            const fkName = `posts"author'\n`;
+            const refTable = `authors'`;
+            const refColumn = `id"`;
+            const customName = 'seed*/users';
+            const source = generator.render(`016_name'\n_escape`, [
+                {
+                    kind: InternalOperationKind.TABLE_CREATE,
+                    table,
+                    columns: [
+                        {
+                            name: column,
+                            type: 'int',
+                            references: { table: refTable, column: refColumn, onDelete: 'CASCADE' },
+                        },
+                    ],
+                },
+                {
+                    kind: InternalOperationKind.INDEX_CREATE,
+                    table,
+                    name: indexName,
+                    on: [column],
+                },
+                {
+                    kind: InternalOperationKind.FK_CREATE,
+                    table,
+                    name: fkName,
+                    columns: [column],
+                    refTable,
+                    refColumns: [refColumn],
+                    onUpdate: 'CASCADE',
+                },
+                {
+                    kind: InternalOperationKind.FK_VALIDATE,
+                    table,
+                    name: fkName,
+                },
+                {
+                    kind: 'custom',
+                    name: customName,
+                    args: {},
+                },
+            ]);
+
+            expect(source).toContain(`id = ${JSON.stringify(`016_name'\n_escape`)}`);
+            expect(source).toContain(`op.table(${JSON.stringify(table)}).create`);
+            expect(source).toContain(`cols.add(${JSON.stringify(column)}, (b) => b.int()`);
+            expect(source).toContain(
+                `.references(${JSON.stringify(refTable)}, ${JSON.stringify(refColumn)}, { onDelete: ${JSON.stringify('CASCADE')} })`
+            );
+            expect(source).toContain(
+                `op.index.create({ name: ${JSON.stringify(indexName)}, table: ${JSON.stringify(table)}, on: [${JSON.stringify(column)}] })`
+            );
+            expect(source).toContain(
+                `op.foreignKey({ table: ${JSON.stringify(table)}, columns: [${JSON.stringify(column)}], references: { table: ${JSON.stringify(refTable)}, columns: [${JSON.stringify(refColumn)}] }, name: ${JSON.stringify(fkName)}, onUpdate: ${JSON.stringify('CASCADE')} })`
+            );
+            expect(source).toContain(
+                `op.foreignKeyValidate({ table: ${JSON.stringify(table)}, name: ${JSON.stringify(fkName)} })`
+            );
+            expect(source).toContain(
+                `custom operation ${JSON.stringify(customName).replaceAll('*/', '*\\/')} cannot be code-generated`
+            );
+        });
+
+        it('rejects unsupported column types while rendering source', () => {
+            expect(() =>
+                generator.render('017_invalid_type', [
+                    {
+                        kind: InternalOperationKind.TABLE_CREATE,
+                        table: 'users',
+                        columns: [
+                            {
+                                name: 'id',
+                                type: 'text(); throw new Error("bad"); b.text' as 'text',
+                            },
+                        ],
+                    },
+                ])
+            ).toThrow('Unsupported column type in migration source generation');
         });
     });
 
@@ -379,7 +463,7 @@ describe(MigrationGenerator, () => {
                 const source = await readFile(path, 'utf8');
                 expect(path.startsWith(dir)).toBe(true);
                 expect(source).toContain('extends Migration');
-                expect(source).toContain("op.table('users').create");
+                expect(source).toContain('op.table("users").create');
             } finally {
                 await rm(dir, { recursive: true, force: true });
             }


### PR DESCRIPTION
## Summary
- render generated migration source string values through JSON.stringify helpers
- escape comment-embedded operation names and generated FK names safely
- reject unsupported column type method names during source generation
- update migration generator and CLI expectations for double-quoted generated literals

## Validation
- pnpm --filter @danceroutine/tango-migrations test -- src/generator/tests/MigrationGenerator.test.ts
- pnpm --filter @danceroutine/tango-migrations typecheck
- pnpm exec prettier --write packages/migrations/src/generator/MigrationGenerator.ts packages/migrations/src/generator/tests/MigrationGenerator.test.ts packages/migrations/src/commands/tests/registerMigrationsCommands.test.ts

## Notes
- In the fresh worktree, the isolated command test path was blocked before exercising this change because temporary app models resolve @danceroutine/tango-schema through the package entrypoint and core/schema builds currently fail with: Failed to import module "unrun".