### PR TITLE
fix: add check-only CI lint script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
               run: pnpm install --frozen-lockfile
 
             - name: Run linters
-              run: pnpm lint
+              run: pnpm run lint:ci
 
     typecheck:
         name: Type Check

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "type": "module",
     "scripts": {
         "prelint": "pnpm format",
-        "lint": "pnpm run lint:ox && pnpm run lint:eslint && pnpm format:check",
+        "lint": "pnpm run lint:ci",
+        "lint:ci": "pnpm run lint:ox && pnpm run lint:eslint && pnpm format:check",
         "lint:ox": "oxlint --format stylish",
         "lint:eslint": "eslint .",
         "format": "prettier --write .",


### PR DESCRIPTION
## Summary
- add a check-only `lint:ci` script that skips the `prelint` formatter lifecycle
- keep local `pnpm lint` formatting behavior by delegating it to `lint:ci`
- update CI to run `pnpm run lint:ci` so formatting violations fail instead of being auto-corrected

## Validation
- `pnpm exec prettier --check package.json .github/workflows/ci.yml`
- `pnpm run lint:ci`