### PR TITLE
fix: optimize queryset existence checks

### DIFF
--- a/.changeset/brave-plums-exist.md
+++ b/.changeset/brave-plums-exist.md
@@ -1,0 +1,5 @@
+---
+"@danceroutine/tango-orm": patch
+---
+
+Improve `QuerySet.exists()` so existence checks can stop after the first matching record.

--- a/packages/orm/src/manager/relations/ManyToManyRelatedQuerySet.ts
+++ b/packages/orm/src/manager/relations/ManyToManyRelatedQuerySet.ts
@@ -134,6 +134,24 @@ export class ManyToManyRelatedQuerySet<TTarget extends Record<string, unknown>> 
         return scopedQs.count();
     }
 
+    override async exists(): Promise<boolean> {
+        if (this.isStateTrivial()) {
+            const cache = this.bridge.getCache();
+            if (cache !== null) {
+                return cache.length > 0;
+            }
+        }
+        const ids = await this.bridge.fetchTargetIds();
+        if (ids.length === 0) {
+            return false;
+        }
+        if (this.isStateTrivial()) {
+            return true;
+        }
+        const scopedQs = new ModelQuerySet<TTarget>(this.executor, this.scopedState(ids));
+        return scopedQs.exists();
+    }
+
     protected override spawn<
         TNextBaseResult extends Record<string, unknown>,
         TNextHydrated extends Record<string, unknown>,

--- a/packages/orm/src/manager/relations/tests/ManyToManyRelatedQuerySet.test.ts
+++ b/packages/orm/src/manager/relations/tests/ManyToManyRelatedQuerySet.test.ts
@@ -205,7 +205,7 @@ describe(ManyToManyRelatedQuerySet, () => {
     it('delegates to a scoped existence query when state is non-trivial', async () => {
         const query = vi.fn(async (sql: string, _params?: readonly unknown[]) => {
             if (sql.startsWith('SELECT 1')) {
-                return { rows: [{ exists: 1 }] };
+                return { rows: [{ tango_exists: 1 }] };
             }
             return { rows: [] as Record<string, unknown>[] };
         });
@@ -217,7 +217,7 @@ describe(ManyToManyRelatedQuerySet, () => {
         await expect(queryset.filter({ name: 'docs' }).exists()).resolves.toBe(true);
         expect(query).toHaveBeenCalledTimes(1);
         const [sql, params] = query.mock.calls[0]!;
-        expect(sql).toContain('SELECT 1 AS exists FROM tags');
+        expect(sql).toContain('SELECT 1 AS tango_exists FROM tags');
         expect(sql).toContain('LIMIT 1');
         expect(sql).not.toContain('SELECT COUNT');
         expect(params).toEqual([10, 11, 'docs']);

--- a/packages/orm/src/manager/relations/tests/ManyToManyRelatedQuerySet.test.ts
+++ b/packages/orm/src/manager/relations/tests/ManyToManyRelatedQuerySet.test.ts
@@ -202,6 +202,27 @@ describe(ManyToManyRelatedQuerySet, () => {
         expect(params).toEqual(expect.arrayContaining([10, 11, 'docs']));
     });
 
+    it('delegates to a scoped existence query when state is non-trivial', async () => {
+        const query = vi.fn(async (sql: string, _params?: readonly unknown[]) => {
+            if (sql.startsWith('SELECT 1')) {
+                return { rows: [{ exists: 1 }] };
+            }
+            return { rows: [] as Record<string, unknown>[] };
+        });
+        const queryset = new ManyToManyRelatedQuerySet<TagRow>(
+            aQueryExecutor<TagRow>({ meta: targetMeta, query }),
+            buildBridge({ fetchTargetIds: async () => [10, 11] })
+        );
+
+        await expect(queryset.filter({ name: 'docs' }).exists()).resolves.toBe(true);
+        expect(query).toHaveBeenCalledTimes(1);
+        const [sql, params] = query.mock.calls[0]!;
+        expect(sql).toContain('SELECT 1 AS exists FROM tags');
+        expect(sql).toContain('LIMIT 1');
+        expect(sql).not.toContain('SELECT COUNT');
+        expect(params).toEqual([10, 11, 'docs']);
+    });
+
     it('combines successive filter calls into a conjunctive predicate', async () => {
         const run = vi.fn().mockResolvedValue([]);
         const executor = aQueryExecutor<TagRow>({ meta: targetMeta, run });

--- a/packages/orm/src/query/QuerySet.ts
+++ b/packages/orm/src/query/QuerySet.ts
@@ -535,7 +535,7 @@ export abstract class QuerySet<
     async exists(): Promise<boolean> {
         const compiler = new QueryCompiler(this.executor.meta, this.executor.adapter);
         const compiled = compiler.compileExists(this.withoutHydrationState());
-        const rows = await this.executor.client.query<{ exists: number }>(compiled.sql, compiled.params);
+        const rows = await this.executor.client.query<{ tango_exists: number }>(compiled.sql, compiled.params);
         return rows.rows.length > 0;
     }
 

--- a/packages/orm/src/query/QuerySet.ts
+++ b/packages/orm/src/query/QuerySet.ts
@@ -533,8 +533,10 @@ export abstract class QuerySet<
      * Return whether at least one row matches the current query state.
      */
     async exists(): Promise<boolean> {
-        const count = await this.count();
-        return count > 0;
+        const compiler = new QueryCompiler(this.executor.meta, this.executor.adapter);
+        const compiled = compiler.compileExists(this.withoutHydrationState());
+        const rows = await this.executor.client.query<{ exists: number }>(compiled.sql, compiled.params);
+        return rows.rows.length > 0;
     }
 
     private shapeFetchedRow<Out>(

--- a/packages/orm/src/query/compiler/QueryCompiler.ts
+++ b/packages/orm/src/query/compiler/QueryCompiler.ts
@@ -154,6 +154,47 @@ export class QueryCompiler {
         };
     }
 
+    compileExists<T, TSourceModel = unknown>(state: QuerySetState<T, TSourceModel>): CompiledQuery {
+        const validatedPlan = sqlSafetyAdapter.validate({
+            kind: SqlPlanKind.SELECT,
+            meta: this.meta,
+            selectFields: state.select?.map(String),
+            filterKeys: this.collectStateFilterKeys(state),
+            orderFields: state.order?.map((order) => String(order.by)),
+            relationNames: [],
+        });
+        const table = validatedPlan.meta.table;
+        const whereParts: string[] = [];
+        const params: unknown[] = [];
+
+        if (state.q) {
+            const result = this.compileQNode(state.q, params.length + 1, validatedPlan.filterKeys);
+            if (result.sql) {
+                whereParts.push(result.sql);
+                params.push(...result.params);
+            }
+        }
+
+        state.excludes?.forEach((exclude) => {
+            const result = this.compileQNode(
+                { kind: InternalQNodeType.NOT, node: exclude },
+                params.length + 1,
+                validatedPlan.filterKeys
+            );
+            if (result.sql) {
+                whereParts.push(result.sql);
+                params.push(...result.params);
+            }
+        });
+
+        const whereSQL = whereParts.length ? ` WHERE ${whereParts.join(' AND ')}` : '';
+        const offsetSQL = state.offset ? ` OFFSET ${state.offset}` : '';
+        return {
+            sql: `SELECT 1 AS exists FROM ${table}${whereSQL} LIMIT 1${offsetSQL}`,
+            params,
+        };
+    }
+
     compilePrefetch(node: CompiledHydrationNode, sourceValues: readonly (string | number)[]): CompiledPrefetchQuery {
         if (node.throughTable && node.throughSourceKey && node.throughTargetKey) {
             return this.compileManyToManyPrefetch(node, sourceValues);

--- a/packages/orm/src/query/compiler/QueryCompiler.ts
+++ b/packages/orm/src/query/compiler/QueryCompiler.ts
@@ -190,7 +190,7 @@ export class QueryCompiler {
         const whereSQL = whereParts.length ? ` WHERE ${whereParts.join(' AND ')}` : '';
         const offsetSQL = state.offset ? ` OFFSET ${state.offset}` : '';
         return {
-            sql: `SELECT 1 AS exists FROM ${table}${whereSQL} LIMIT 1${offsetSQL}`,
+            sql: `SELECT 1 AS tango_exists FROM ${table}${whereSQL} LIMIT 1${offsetSQL}`,
             params,
         };
     }

--- a/packages/orm/src/query/compiler/tests/QueryCompiler.test.ts
+++ b/packages/orm/src/query/compiler/tests/QueryCompiler.test.ts
@@ -627,6 +627,43 @@ describe(QueryCompiler, () => {
         expect(result.sql).toContain('OFFSET 20');
     });
 
+    it('compiles existence probes from scalar query state', () => {
+        const result = new QueryCompiler(mockMeta, postgresAdapter).compileExists<UserModel>({
+            q: { kind: 'atom', where: { email: 'test@example.com' } },
+            excludes: [{ kind: 'atom', where: { name__contains: 'bot' } }],
+            order: [{ by: 'age', dir: 'desc' }],
+            offset: 20,
+            select: ['id'],
+        });
+
+        expect(result.sql).toContain('SELECT 1 AS exists FROM users');
+        expect(result.sql).toContain('users.email = $1');
+        expect(result.sql).toContain('NOT');
+        expect(result.sql).toContain('users.name LIKE $2');
+        expect(result.sql).toContain('LIMIT 1 OFFSET 20');
+        expect(result.sql).not.toContain('ORDER BY');
+        expect(result.sql).not.toContain('users.*');
+        expect(result.params).toEqual(['test@example.com', '%bot%']);
+        expect(result.hydrationPlan).toBeUndefined();
+    });
+
+    it('compiles existence probes without predicates', () => {
+        const result = new QueryCompiler(mockMeta, postgresAdapter).compileExists({});
+
+        expect(result.sql).toBe('SELECT 1 AS exists FROM users LIMIT 1');
+        expect(result.params).toEqual([]);
+    });
+
+    it('omits empty existence predicates', () => {
+        const result = new QueryCompiler(mockMeta, postgresAdapter).compileExists<UserModel>({
+            q: { kind: 'atom', where: {} },
+            excludes: [{ kind: 'atom', where: {} }],
+        });
+
+        expect(result.sql).toBe('SELECT 1 AS exists FROM users LIMIT 1');
+        expect(result.params).toEqual([]);
+    });
+
     describe('SQLite', () => {
         it('uses SQLite placeholders', () => {
             const state = {

--- a/packages/orm/src/query/compiler/tests/QueryCompiler.test.ts
+++ b/packages/orm/src/query/compiler/tests/QueryCompiler.test.ts
@@ -636,7 +636,7 @@ describe(QueryCompiler, () => {
             select: ['id'],
         });
 
-        expect(result.sql).toContain('SELECT 1 AS exists FROM users');
+        expect(result.sql).toContain('SELECT 1 AS tango_exists FROM users');
         expect(result.sql).toContain('users.email = $1');
         expect(result.sql).toContain('NOT');
         expect(result.sql).toContain('users.name LIKE $2');
@@ -650,8 +650,14 @@ describe(QueryCompiler, () => {
     it('compiles existence probes without predicates', () => {
         const result = new QueryCompiler(mockMeta, postgresAdapter).compileExists({});
 
-        expect(result.sql).toBe('SELECT 1 AS exists FROM users LIMIT 1');
+        expect(result.sql).toBe('SELECT 1 AS tango_exists FROM users LIMIT 1');
         expect(result.params).toEqual([]);
+    });
+
+    it('compiles SQLite existence probes with a non-keyword result alias', () => {
+        const result = new QueryCompiler(mockMeta, sqliteAdapter).compileExists({});
+
+        expect(result.sql).toBe('SELECT 1 AS tango_exists FROM users LIMIT 1');
     });
 
     it('omits empty existence predicates', () => {
@@ -660,7 +666,7 @@ describe(QueryCompiler, () => {
             excludes: [{ kind: 'atom', where: {} }],
         });
 
-        expect(result.sql).toBe('SELECT 1 AS exists FROM users LIMIT 1');
+        expect(result.sql).toBe('SELECT 1 AS tango_exists FROM users LIMIT 1');
         expect(result.params).toEqual([]);
     });
 

--- a/packages/orm/src/query/tests/QuerySet.test.ts
+++ b/packages/orm/src/query/tests/QuerySet.test.ts
@@ -141,7 +141,9 @@ function createQueryExecutorFixture(
     tableMeta: TableMeta = meta
 ) {
     const run = vi.fn(async (_compiled: { sql: string; params: readonly unknown[] }) => rows);
-    const query = vi.fn(async (_sql: string, _params?: readonly unknown[]) => ({ rows: [{ count: rows.length }] }));
+    const query = vi.fn(async (sql: string, _params?: readonly unknown[]) => ({
+        rows: sql.startsWith('SELECT 1') ? (rows.length > 0 ? [{ exists: 1 }] : []) : [{ count: rows.length }],
+    }));
     const queryExecutor = aQueryExecutor<User>({ meta: tableMeta, dialect, query, run });
     return { queryExecutor, run, query };
 }
@@ -1370,7 +1372,7 @@ describe(QuerySet, () => {
         expect(parser.parse).toHaveBeenCalledWith({ id: 1, email: 'first@a.com', active: true });
     });
 
-    it('counts and checks existence using compiled query params', async () => {
+    it('answers scalar count and existence questions using compiled query params', async () => {
         const { queryExecutor, query } = createQueryExecutorFixture([{ id: 1, email: 'a@a.com', active: true }]);
         const qs = new ModelQuerySet<User>(queryExecutor).filter({ active: true });
 
@@ -1381,15 +1383,48 @@ describe(QuerySet, () => {
         expect(exists).toBe(true);
         expect(query).toHaveBeenCalledTimes(2);
         expect(query.mock.calls[0]?.[0]).toContain('SELECT COUNT(*) as count FROM');
+        expect(query.mock.calls[0]?.[1]).toEqual([true]);
+        expect(query.mock.calls[1]?.[0]).toContain('SELECT 1 AS exists FROM users');
+        expect(query.mock.calls[1]?.[0]).toContain('LIMIT 1');
+        expect(query.mock.calls[1]?.[0]).not.toContain('COUNT(*)');
+        expect(query.mock.calls[1]?.[1]).toEqual([true]);
     });
 
-    it('returns false from exists when count is zero', async () => {
+    it('returns false from exists when no row matches', async () => {
         const run = vi.fn(async () => [] as User[]);
-        const query = vi.fn(async () => ({ rows: [] as Array<{ count: number }> }));
+        const query = vi.fn(async () => ({ rows: [] as Array<{ exists: number }> }));
         const queryExecutor = aQueryExecutor<User>({ meta, query, run });
 
         const exists = await new ModelQuerySet<User>(queryExecutor).exists();
         expect(exists).toBe(false);
+    });
+
+    it('returns zero from count when no count row is returned', async () => {
+        const run = vi.fn(async () => [] as User[]);
+        const query = vi.fn(async () => ({ rows: [] as Array<{ count: number }> }));
+        const queryExecutor = aQueryExecutor<User>({ meta, query, run });
+
+        const count = await new ModelQuerySet<User>(queryExecutor).count();
+        expect(count).toBe(0);
+    });
+
+    it('checks existence without compiling eager-loading joins', async () => {
+        const query = vi.fn(async (_sql: string, _params?: readonly unknown[]) => ({ rows: [{ exists: 1 }] }));
+        const queryExecutor = aQueryExecutor<Record<string, unknown>>({ meta: relatedMeta, query });
+
+        const exists = await new ModelQuerySet<Record<string, unknown>>(queryExecutor)
+            .selectRelated('team')
+            .prefetchRelated('posts')
+            .filter({ team__name: 'Platform' })
+            .exists();
+
+        expect(exists).toBe(true);
+        const [sql, params] = query.mock.calls[0]!;
+        expect(sql).toContain('SELECT 1 AS exists FROM users');
+        expect(sql).toContain('EXISTS (SELECT 1 FROM teams');
+        expect(sql).not.toContain('LEFT JOIN');
+        expect(sql).not.toContain('__tango_join');
+        expect(params).toEqual(['Platform']);
     });
 
     it('normalizes sqlite bool columns before parser-based schema reads', async () => {

--- a/packages/orm/src/query/tests/QuerySet.test.ts
+++ b/packages/orm/src/query/tests/QuerySet.test.ts
@@ -142,7 +142,7 @@ function createQueryExecutorFixture(
 ) {
     const run = vi.fn(async (_compiled: { sql: string; params: readonly unknown[] }) => rows);
     const query = vi.fn(async (sql: string, _params?: readonly unknown[]) => ({
-        rows: sql.startsWith('SELECT 1') ? (rows.length > 0 ? [{ exists: 1 }] : []) : [{ count: rows.length }],
+        rows: sql.startsWith('SELECT 1') ? (rows.length > 0 ? [{ tango_exists: 1 }] : []) : [{ count: rows.length }],
     }));
     const queryExecutor = aQueryExecutor<User>({ meta: tableMeta, dialect, query, run });
     return { queryExecutor, run, query };
@@ -1384,7 +1384,7 @@ describe(QuerySet, () => {
         expect(query).toHaveBeenCalledTimes(2);
         expect(query.mock.calls[0]?.[0]).toContain('SELECT COUNT(*) as count FROM');
         expect(query.mock.calls[0]?.[1]).toEqual([true]);
-        expect(query.mock.calls[1]?.[0]).toContain('SELECT 1 AS exists FROM users');
+        expect(query.mock.calls[1]?.[0]).toContain('SELECT 1 AS tango_exists FROM users');
         expect(query.mock.calls[1]?.[0]).toContain('LIMIT 1');
         expect(query.mock.calls[1]?.[0]).not.toContain('COUNT(*)');
         expect(query.mock.calls[1]?.[1]).toEqual([true]);
@@ -1392,7 +1392,7 @@ describe(QuerySet, () => {
 
     it('returns false from exists when no row matches', async () => {
         const run = vi.fn(async () => [] as User[]);
-        const query = vi.fn(async () => ({ rows: [] as Array<{ exists: number }> }));
+        const query = vi.fn(async () => ({ rows: [] as Array<{ tango_exists: number }> }));
         const queryExecutor = aQueryExecutor<User>({ meta, query, run });
 
         const exists = await new ModelQuerySet<User>(queryExecutor).exists();
@@ -1409,7 +1409,7 @@ describe(QuerySet, () => {
     });
 
     it('checks existence without compiling eager-loading joins', async () => {
-        const query = vi.fn(async (_sql: string, _params?: readonly unknown[]) => ({ rows: [{ exists: 1 }] }));
+        const query = vi.fn(async (_sql: string, _params?: readonly unknown[]) => ({ rows: [{ tango_exists: 1 }] }));
         const queryExecutor = aQueryExecutor<Record<string, unknown>>({ meta: relatedMeta, query });
 
         const exists = await new ModelQuerySet<Record<string, unknown>>(queryExecutor)
@@ -1420,7 +1420,7 @@ describe(QuerySet, () => {
 
         expect(exists).toBe(true);
         const [sql, params] = query.mock.calls[0]!;
-        expect(sql).toContain('SELECT 1 AS exists FROM users');
+        expect(sql).toContain('SELECT 1 AS tango_exists FROM users');
         expect(sql).toContain('EXISTS (SELECT 1 FROM teams');
         expect(sql).not.toContain('LEFT JOIN');
         expect(sql).not.toContain('__tango_join');

--- a/packages/orm/src/tests/integration/orm.integration.test.ts
+++ b/packages/orm/src/tests/integration/orm.integration.test.ts
@@ -155,6 +155,9 @@ describe.each(selectedDialects())('ORM integration (%s)', (dialect) => {
 
             const count = await queryset.count();
             expect(count).toBe(3);
+
+            await expect(queryset.filter({ published: true }).exists()).resolves.toBe(true);
+            await expect(queryset.filter({ slug: 'missing' }).exists()).resolves.toBe(false);
         } finally {
             await rm(migrationsDir, { recursive: true, force: true });
         }


### PR DESCRIPTION
## Summary
- add a scalar existence compiler path that emits SELECT 1 ... LIMIT 1
- make QuerySet.exists() use the existence probe instead of count()
- preserve many-to-many related queryset cache and owner-scoping behavior for exists()

## Validation
- pnpm --filter @danceroutine/tango-orm exec vitest run src/query/compiler/tests/QueryCompiler.test.ts src/query/tests/QuerySet.test.ts src/manager/relations/tests/ManyToManyRelatedQuerySet.test.ts
- pnpm --filter @danceroutine/tango-orm typecheck
- pnpm --filter @danceroutine/tango-orm test

Note: the full ORM test run passes with existing Vitest hoist warnings for unrelated vi.unmock(...) calls.