### PR TITLE
fix: align scaffold database drivers

### DIFF
--- a/.changeset/fresh-database-drivers.md
+++ b/.changeset/fresh-database-drivers.md
@@ -1,0 +1,11 @@
+---
+'@danceroutine/tango-codegen': patch
+'@danceroutine/tango-migrations': patch
+'@danceroutine/tango-orm': patch
+---
+
+Scaffolded projects now install database packages for the selected dialect, and SQLite runtimes can start with SQLite-only dependencies.
+
+SQLite scaffolds include `better-sqlite3`, `@types/better-sqlite3`, and the matching native build allowlist. Postgres scaffolds include `pg` and `@types/pg`, with a package manifest scoped to Postgres packages.
+
+Migration generation now applies Postgres `serial` primary key projection for Postgres configs while preserving SQLite integer primary keys. SQLite runtime adapter setup also succeeds with SQLite-only dependencies.

--- a/packages/codegen/src/frameworks/contracts/template/TemplateBuilder.ts
+++ b/packages/codegen/src/frameworks/contracts/template/TemplateBuilder.ts
@@ -35,7 +35,7 @@ export abstract class TemplateBuilder implements BoundTemplate {
         framework: 'express' | 'next' | 'nuxt'
     ): string {
         const deps = TemplateBuilder.getTangoDependencyEntriesFor(dialect, framework);
-        const devDeps = TemplateBuilder.getTangoDevDependencyEntriesFor();
+        const devDeps = TemplateBuilder.getTangoDevDependencyEntriesFor(dialect);
         const depList = Object.entries(deps)
             .map(([pkg, ver]) => `${pkg}@${ver}`)
             .join(' ');
@@ -66,7 +66,6 @@ export abstract class TemplateBuilder implements BoundTemplate {
             case PACKAGE_MANAGER.BUN:
                 return serializedArgs.length > 0 ? `bun run ${scriptName} ${serializedArgs}` : `bun run ${scriptName}`;
             case PACKAGE_MANAGER.PNPM:
-            default:
                 return serializedArgs.length > 0
                     ? `pnpm run ${scriptName} ${serializedArgs}`
                     : `pnpm run ${scriptName}`;
@@ -91,7 +90,7 @@ export abstract class TemplateBuilder implements BoundTemplate {
     }
 
     private static getTangoDependencyEntriesFor(
-        _dialect: 'sqlite' | 'postgres',
+        dialect: 'sqlite' | 'postgres',
         framework: 'express' | 'next' | 'nuxt'
     ): Record<string, string> {
         const v = TemplateBuilder.getTangoVersion();
@@ -110,18 +109,23 @@ export abstract class TemplateBuilder implements BoundTemplate {
                 : framework === 'next'
                   ? { '@danceroutine/tango-adapters-next': v }
                   : { '@danceroutine/tango-adapters-nuxt': v };
-        const dialectDeps: Record<string, string> = {
-            'better-sqlite3': '^12.10.0',
-            pg: '^8.20.0',
-        };
+        const dialectDeps: Record<string, string> =
+            dialect === 'sqlite' ? { 'better-sqlite3': '^12.10.0' } : { pg: '^8.20.0' };
         return { ...core, ...adapter, ...dialectDeps };
     }
 
-    private static getTangoDevDependencyEntriesFor(): Record<string, string> {
+    private static getTangoDevDependencyEntriesFor(dialect: 'sqlite' | 'postgres'): Record<string, string> {
+        const dialectDevDeps: Record<string, string> =
+            dialect === 'sqlite' ? { '@types/better-sqlite3': '^7.6.12' } : { '@types/pg': '^8.20.0' };
+
         return {
             '@danceroutine/tango-cli': TemplateBuilder.getTangoVersion(),
-            '@types/better-sqlite3': '^7.6.12',
+            ...dialectDevDeps,
         };
+    }
+
+    private static getPnpmOnlyBuiltDependenciesFor(dialect: 'sqlite' | 'postgres'): readonly string[] {
+        return dialect === 'sqlite' ? ['better-sqlite3', 'esbuild'] : ['esbuild'];
     }
 
     /** Bind context and return this for chaining. Use before passing to add* methods. */
@@ -147,7 +151,11 @@ export abstract class TemplateBuilder implements BoundTemplate {
         return TemplateBuilder.getTangoDependencyEntriesFor(context.dialect, context.framework);
     }
 
-    protected getTangoDevDependencyEntries(_context: FrameworkScaffoldContext): Record<string, string> {
-        return TemplateBuilder.getTangoDevDependencyEntriesFor();
+    protected getTangoDevDependencyEntries(context: FrameworkScaffoldContext): Record<string, string> {
+        return TemplateBuilder.getTangoDevDependencyEntriesFor(context.dialect);
+    }
+
+    protected getPnpmOnlyBuiltDependencies(context: FrameworkScaffoldContext): readonly string[] {
+        return TemplateBuilder.getPnpmOnlyBuiltDependenciesFor(context.dialect);
     }
 }

--- a/packages/codegen/src/frameworks/contracts/template/tests/TemplateBuilder.test.ts
+++ b/packages/codegen/src/frameworks/contracts/template/tests/TemplateBuilder.test.ts
@@ -32,9 +32,10 @@ describe(TemplateBuilder, () => {
         expect(oneLiner).toContain('npm install ');
         expect(oneLiner).toContain('npm install -D ');
         expect(oneLiner).toContain('@danceroutine/tango-adapters-express@');
-        expect(oneLiner).toContain('better-sqlite3@^12.10.0');
         expect(oneLiner).toContain('pg@^8.20.0');
-        expect(oneLiner).toContain('@types/better-sqlite3@^7.6.12');
+        expect(oneLiner).toContain('@types/pg@^8.20.0');
+        expect(oneLiner).not.toContain('better-sqlite3@^12.10.0');
+        expect(oneLiner).not.toContain('@types/better-sqlite3@^7.6.12');
     });
 
     it('formats Nuxt install instructions with the Nuxt adapter package', () => {
@@ -42,8 +43,9 @@ describe(TemplateBuilder, () => {
 
         expect(oneLiner).toContain('@danceroutine/tango-adapters-nuxt@');
         expect(oneLiner).toContain('better-sqlite3@^12.10.0');
-        expect(oneLiner).toContain('pg@^8.20.0');
         expect(oneLiner).toContain('@types/better-sqlite3@^7.6.12');
+        expect(oneLiner).not.toContain('pg@^8.20.0');
+        expect(oneLiner).not.toContain('@types/pg@^8.20.0');
     });
 
     it('formats npm script forwarding with an explicit separator', () => {

--- a/packages/codegen/src/frameworks/strategies/express/templates/packageJson.ts
+++ b/packages/codegen/src/frameworks/strategies/express/templates/packageJson.ts
@@ -44,7 +44,7 @@ export class PackageJsonTemplateBuilder extends TemplateBuilder {
                     typescript: '^5.6.3',
                 },
                 pnpm: {
-                    onlyBuiltDependencies: ['better-sqlite3', 'esbuild'],
+                    onlyBuiltDependencies: this.getPnpmOnlyBuiltDependencies(context),
                 },
             },
             null,

--- a/packages/codegen/src/frameworks/strategies/express/tests/ExpressScaffoldStrategy.test.ts
+++ b/packages/codegen/src/frameworks/strategies/express/tests/ExpressScaffoldStrategy.test.ts
@@ -34,24 +34,34 @@ describe(ExpressScaffoldStrategy, () => {
             const packageJson = renderTemplate(templates, 'package.json', context);
             const config = renderTemplate(templates, 'tango.config.ts', context);
             const tsconfig = renderTemplate(templates, 'tsconfig.json', context);
+            const modelSource = renderTemplate(templates, 'src/models/TodoModel.ts', context);
             const indexSource = renderTemplate(templates, 'src/index.ts', context);
             const openapiSource = renderTemplate(templates, 'src/openapi.ts', context);
             const serializerSource = renderTemplate(templates, 'src/serializers/TodoSerializer.ts', context);
             const viewsetSource = renderTemplate(templates, 'src/viewsets/TodoViewSet.ts', context);
             const readme = renderTemplate(templates, 'README.md', context);
             const migrationsKeep = renderTemplate(templates, 'migrations/.gitkeep', context);
-            const scripts = JSON.parse(packageJson).scripts as Record<string, string>;
+            const packageMetadata = JSON.parse(packageJson) as {
+                scripts: Record<string, string>;
+                dependencies: Record<string, string>;
+                devDependencies: Record<string, string>;
+                pnpm: { onlyBuiltDependencies: string[] };
+            };
+            const scripts = packageMetadata.scripts;
 
-            expect(packageJson).toContain('"better-sqlite3"');
-            expect(packageJson).toContain('"esbuild"');
-            expect(packageJson).toContain('"pg"');
-            expect(packageJson).toContain('"@types/better-sqlite3"');
+            expect(packageMetadata.dependencies).toHaveProperty('better-sqlite3');
+            expect(packageMetadata.dependencies).not.toHaveProperty('pg');
+            expect(packageMetadata.devDependencies).toHaveProperty('@types/better-sqlite3');
+            expect(packageMetadata.devDependencies).not.toHaveProperty('@types/pg');
+            expect(packageMetadata.pnpm.onlyBuiltDependencies).toEqual(['better-sqlite3', 'esbuild']);
             expect(packageJson).toContain('"@danceroutine/tango-openapi"');
             expect(packageJson).toContain('"codegen:relations"');
             expect(scripts['make:migrations']).not.toContain('--name');
             expect(scripts['make:migrations']).not.toContain('npm_config_name');
             expect(config).toContain("adapter: 'sqlite'");
             expect(config).toContain('./.data/express-sqlite.sqlite');
+            expect(modelSource).toContain('id: t.primaryKey(z.number().int())');
+            expect(modelSource).not.toContain('fields:');
             expect((JSON.parse(tsconfig) as { include: string[] }).include).toContain('migrations/**/*.ts');
             expect((JSON.parse(tsconfig) as { include: string[] }).include).toContain('.tango/**/*.d.ts');
             expect(indexSource).toContain("from './tango.js'");
@@ -85,11 +95,17 @@ describe(ExpressScaffoldStrategy, () => {
             const templates = strategy.getTemplates();
             const packageJson = renderTemplate(templates, 'package.json', context);
             const config = renderTemplate(templates, 'tango.config.ts', context);
+            const packageMetadata = JSON.parse(packageJson) as {
+                dependencies: Record<string, string>;
+                devDependencies: Record<string, string>;
+                pnpm: { onlyBuiltDependencies: string[] };
+            };
 
-            expect(packageJson).toContain('"pg"');
-            expect(packageJson).toContain('"better-sqlite3"');
-            expect(packageJson).toContain('"esbuild"');
-            expect(packageJson).toContain('"@types/better-sqlite3"');
+            expect(packageMetadata.dependencies).toHaveProperty('pg');
+            expect(packageMetadata.dependencies).not.toHaveProperty('better-sqlite3');
+            expect(packageMetadata.devDependencies).toHaveProperty('@types/pg');
+            expect(packageMetadata.devDependencies).not.toHaveProperty('@types/better-sqlite3');
+            expect(packageMetadata.pnpm.onlyBuiltDependencies).toEqual(['esbuild']);
             expect(config).toContain("adapter: 'postgres'");
             expect(config).toContain('TANGO_DATABASE_URL');
         });

--- a/packages/codegen/src/frameworks/strategies/next/templates/packageJson.ts
+++ b/packages/codegen/src/frameworks/strategies/next/templates/packageJson.ts
@@ -47,7 +47,7 @@ export class PackageJsonTemplateBuilder extends TemplateBuilder {
                     typescript: '^5.6.3',
                 },
                 pnpm: {
-                    onlyBuiltDependencies: ['better-sqlite3', 'esbuild'],
+                    onlyBuiltDependencies: this.getPnpmOnlyBuiltDependencies(context),
                 },
             },
             null,

--- a/packages/codegen/src/frameworks/strategies/next/tests/NextScaffoldStrategy.test.ts
+++ b/packages/codegen/src/frameworks/strategies/next/tests/NextScaffoldStrategy.test.ts
@@ -42,6 +42,7 @@ describe(NextScaffoldStrategy, () => {
             const templates = strategy.getTemplates();
             const packageJson = renderTemplate(templates, 'package.json', context);
             const tsconfig = renderTemplate(templates, 'tsconfig.json', context);
+            const modelSource = renderTemplate(templates, 'src/lib/models/TodoModel.ts', context);
             const layout = renderTemplate(templates, 'src/app/layout.tsx', context);
             const route = renderTemplate(templates, 'src/app/api/health/route.ts', context);
             const openapiRoute = renderTemplate(templates, 'src/app/api/openapi/route.ts', context);
@@ -50,15 +51,24 @@ describe(NextScaffoldStrategy, () => {
             const viewsetSource = renderTemplate(templates, 'src/viewsets/TodoViewSet.ts', context);
             const readme = renderTemplate(templates, 'README.md', context);
             const migrationsKeep = renderTemplate(templates, 'migrations/.gitkeep', context);
-            const scripts = JSON.parse(packageJson).scripts as Record<string, string>;
+            const packageMetadata = JSON.parse(packageJson) as {
+                scripts: Record<string, string>;
+                dependencies: Record<string, string>;
+                devDependencies: Record<string, string>;
+                pnpm: { onlyBuiltDependencies: string[] };
+            };
+            const scripts = packageMetadata.scripts;
 
-            expect(packageJson).toContain('"better-sqlite3"');
-            expect(packageJson).toContain('"esbuild"');
-            expect(packageJson).toContain('"pg"');
-            expect(packageJson).toContain('"@types/better-sqlite3"');
+            expect(packageMetadata.dependencies).toHaveProperty('better-sqlite3');
+            expect(packageMetadata.dependencies).not.toHaveProperty('pg');
+            expect(packageMetadata.devDependencies).toHaveProperty('@types/better-sqlite3');
+            expect(packageMetadata.devDependencies).not.toHaveProperty('@types/pg');
+            expect(packageMetadata.pnpm.onlyBuiltDependencies).toEqual(['better-sqlite3', 'esbuild']);
             expect(packageJson).toContain('"codegen:relations"');
             expect(scripts['make:migrations']).not.toContain('--name');
             expect(scripts['make:migrations']).not.toContain('npm_config_name');
+            expect(modelSource).toContain('id: t.primaryKey(z.number().int())');
+            expect(modelSource).not.toContain('fields:');
             expect(tsconfig).toContain('"migrations/**/*.ts"');
             expect(tsconfig).toContain('".tango/**/*.d.ts"');
             expect(layout).toContain('RootLayout');
@@ -94,11 +104,17 @@ describe(NextScaffoldStrategy, () => {
             const templates = strategy.getTemplates();
             const packageJson = renderTemplate(templates, 'package.json', context);
             const config = renderTemplate(templates, 'tango.config.ts', context);
+            const packageMetadata = JSON.parse(packageJson) as {
+                dependencies: Record<string, string>;
+                devDependencies: Record<string, string>;
+                pnpm: { onlyBuiltDependencies: string[] };
+            };
 
-            expect(packageJson).toContain('"pg"');
-            expect(packageJson).toContain('"better-sqlite3"');
-            expect(packageJson).toContain('"esbuild"');
-            expect(packageJson).toContain('"@types/better-sqlite3"');
+            expect(packageMetadata.dependencies).toHaveProperty('pg');
+            expect(packageMetadata.dependencies).not.toHaveProperty('better-sqlite3');
+            expect(packageMetadata.devDependencies).toHaveProperty('@types/pg');
+            expect(packageMetadata.devDependencies).not.toHaveProperty('@types/better-sqlite3');
+            expect(packageMetadata.pnpm.onlyBuiltDependencies).toEqual(['esbuild']);
             expect(config).toContain("adapter: 'postgres'");
         });
 

--- a/packages/codegen/src/frameworks/strategies/nuxt/templates/packageJson.ts
+++ b/packages/codegen/src/frameworks/strategies/nuxt/templates/packageJson.ts
@@ -44,7 +44,7 @@ export class PackageJsonTemplateBuilder extends TemplateBuilder {
                     'vue-tsc': '^3.1.2',
                 },
                 pnpm: {
-                    onlyBuiltDependencies: ['better-sqlite3', 'esbuild'],
+                    onlyBuiltDependencies: this.getPnpmOnlyBuiltDependencies(context),
                 },
             },
             null,

--- a/packages/codegen/src/frameworks/strategies/nuxt/tests/NuxtScaffoldStrategy.test.ts
+++ b/packages/codegen/src/frameworks/strategies/nuxt/tests/NuxtScaffoldStrategy.test.ts
@@ -44,6 +44,7 @@ describe(NuxtScaffoldStrategy, () => {
             const packageJson = renderTemplate(templates, 'package.json', context);
             const nuxtConfig = renderTemplate(templates, 'nuxt.config.ts', context);
             const tsconfig = renderTemplate(templates, 'tsconfig.json', context);
+            const modelSource = renderTemplate(templates, 'lib/models/TodoModel.ts', context);
             const page = renderTemplate(templates, 'app/pages/index.server.vue', context);
             const route = renderTemplate(templates, 'server/tango/health.ts', context);
             const openapiRoute = renderTemplate(templates, 'server/tango/openapi.ts', context);
@@ -52,16 +53,25 @@ describe(NuxtScaffoldStrategy, () => {
             const viewsetSource = renderTemplate(templates, 'viewsets/TodoViewSet.ts', context);
             const readme = renderTemplate(templates, 'README.md', context);
             const migrationsKeep = renderTemplate(templates, 'migrations/.gitkeep', context);
-            const scripts = JSON.parse(packageJson).scripts as Record<string, string>;
+            const packageMetadata = JSON.parse(packageJson) as {
+                scripts: Record<string, string>;
+                dependencies: Record<string, string>;
+                devDependencies: Record<string, string>;
+                pnpm: { onlyBuiltDependencies: string[] };
+            };
+            const scripts = packageMetadata.scripts;
 
             expect(packageJson).toContain('"nuxt"');
-            expect(packageJson).toContain('"better-sqlite3"');
-            expect(packageJson).toContain('"esbuild"');
-            expect(packageJson).toContain('"pg"');
-            expect(packageJson).toContain('"@types/better-sqlite3"');
+            expect(packageMetadata.dependencies).toHaveProperty('better-sqlite3');
+            expect(packageMetadata.dependencies).not.toHaveProperty('pg');
+            expect(packageMetadata.devDependencies).toHaveProperty('@types/better-sqlite3');
+            expect(packageMetadata.devDependencies).not.toHaveProperty('@types/pg');
+            expect(packageMetadata.pnpm.onlyBuiltDependencies).toEqual(['better-sqlite3', 'esbuild']);
             expect(packageJson).toContain('"codegen:relations"');
             expect(scripts['make:migrations']).not.toContain('--name');
             expect(scripts['make:migrations']).not.toContain('npm_config_name');
+            expect(modelSource).toContain('id: t.primaryKey(z.number().int())');
+            expect(modelSource).not.toContain('fields:');
             expect(packageJson).toContain('"start": "NUXT_TELEMETRY_DISABLED=1 nuxt preview"');
             expect(nuxtConfig).toContain("route: '/api/todos/**:tango'");
             expect(tsconfig).toContain('".tango/**/*.d.ts"');
@@ -99,11 +109,17 @@ describe(NuxtScaffoldStrategy, () => {
             const templates = strategy.getTemplates();
             const packageJson = renderTemplate(templates, 'package.json', context);
             const config = renderTemplate(templates, 'tango.config.ts', context);
+            const packageMetadata = JSON.parse(packageJson) as {
+                dependencies: Record<string, string>;
+                devDependencies: Record<string, string>;
+                pnpm: { onlyBuiltDependencies: string[] };
+            };
 
-            expect(packageJson).toContain('"pg"');
-            expect(packageJson).toContain('"better-sqlite3"');
-            expect(packageJson).toContain('"esbuild"');
-            expect(packageJson).toContain('"@types/better-sqlite3"');
+            expect(packageMetadata.dependencies).toHaveProperty('pg');
+            expect(packageMetadata.dependencies).not.toHaveProperty('better-sqlite3');
+            expect(packageMetadata.devDependencies).toHaveProperty('@types/pg');
+            expect(packageMetadata.devDependencies).not.toHaveProperty('@types/better-sqlite3');
+            expect(packageMetadata.pnpm.onlyBuiltDependencies).toEqual(['esbuild']);
             expect(config).toContain("adapter: 'postgres'");
         });
 

--- a/packages/migrations/src/commands/cli.ts
+++ b/packages/migrations/src/commands/cli.ts
@@ -407,7 +407,9 @@ export function registerMigrationsCommands(yargsBuilder: Argv): Argv {
                     env: argv.env as ConfigEnvironment | undefined,
                 });
                 const loaded = await loadModels(argv.models);
-                const projectedModels = buildMigrationModelMetadataProjection(loaded.registry);
+                const projectedModels = buildMigrationModelMetadataProjection(loaded.registry, {
+                    dialect: resolved.dialect,
+                });
                 logger.info(
                     `Found ${loaded.models.length} exported model(s); ${projectedModels.length} model(s) after projection: ${projectedModels.map((m) => m.table).join(', ')}`
                 );

--- a/packages/migrations/src/schema/buildMigrationModelMetadataProjection.ts
+++ b/packages/migrations/src/schema/buildMigrationModelMetadataProjection.ts
@@ -1,22 +1,18 @@
 import type { ModelRegistry } from '@danceroutine/tango-schema';
-import type { Field } from '@danceroutine/tango-schema/domain';
-import type { ColumnType } from '../builder/contracts/ColumnType';
+import type { Dialect } from '../domain/Dialect';
 import type { ModelMetadataLike } from '../diff/diffSchema';
+import { createModelFieldMapperStrategy } from './field/strategy/createModelFieldMapperStrategy';
 
-function fieldToModelField(field: Field): ModelMetadataLike['fields'][number] {
-    return {
-        name: field.name,
-        type: field.type as ColumnType,
-        notNull: field.notNull,
-        default: field.default,
-        primaryKey: field.primaryKey,
-        unique: field.unique,
-        references: field.references as ModelMetadataLike['fields'][number]['references'],
-    };
-}
+export type BuildMigrationModelMetadataProjectionOptions = {
+    dialect?: Dialect;
+};
 
-export function buildMigrationModelMetadataProjection(registry: ModelRegistry): ModelMetadataLike[] {
+export function buildMigrationModelMetadataProjection(
+    registry: ModelRegistry,
+    options?: BuildMigrationModelMetadataProjectionOptions
+): ModelMetadataLike[] {
     registry.finalizeStorageArtifacts();
+    const fieldMapperStrategy = createModelFieldMapperStrategy(options?.dialect);
     const projection: ModelMetadataLike[] = [];
     for (const model of registry.values()) {
         const finalized = registry.getFinalizedFields(model.metadata.key);
@@ -24,7 +20,7 @@ export function buildMigrationModelMetadataProjection(registry: ModelRegistry): 
             name: model.metadata.name,
             table: model.metadata.table,
             managed: model.metadata.managed ?? true,
-            fields: finalized.map(fieldToModelField),
+            fields: finalized.map((field) => fieldMapperStrategy.mapField(field)),
             indexes: model.metadata.indexes?.map((index) => ({
                 name: index.name,
                 on: [...index.on],

--- a/packages/migrations/src/schema/field/strategy/ModelFieldMapperStrategy.ts
+++ b/packages/migrations/src/schema/field/strategy/ModelFieldMapperStrategy.ts
@@ -1,0 +1,21 @@
+import type { Field } from '@danceroutine/tango-schema/domain';
+import type { ColumnType } from '../../../builder/contracts/ColumnType';
+import type { ModelMetadataLike } from '../../../diff/diffSchema';
+
+export class ModelFieldMapperStrategy {
+    mapField(field: Field): ModelMetadataLike['fields'][number] {
+        return {
+            name: field.name,
+            type: this.mapType(field),
+            notNull: field.notNull,
+            default: field.default,
+            primaryKey: field.primaryKey,
+            unique: field.unique,
+            references: field.references as ModelMetadataLike['fields'][number]['references'],
+        };
+    }
+
+    protected mapType(field: Field): ColumnType {
+        return field.type as ColumnType;
+    }
+}

--- a/packages/migrations/src/schema/field/strategy/PostgresModelFieldMapperStrategy.ts
+++ b/packages/migrations/src/schema/field/strategy/PostgresModelFieldMapperStrategy.ts
@@ -1,0 +1,16 @@
+import type { Field } from '@danceroutine/tango-schema/domain';
+import type { ColumnType } from '../../../builder/contracts/ColumnType';
+import { InternalColumnType } from '../../../domain/internal/InternalColumnType';
+import { ModelFieldMapperStrategy } from './ModelFieldMapperStrategy';
+
+export class PostgresModelFieldMapperStrategy extends ModelFieldMapperStrategy {
+    protected override mapType(field: Field): ColumnType {
+        // Postgres auto-incrementing primary keys are modeled as serial in migrations,
+        // while SQLite must preserve the schema-level integer type to avoid churn.
+        if (field.primaryKey && field.type === InternalColumnType.INT) {
+            return InternalColumnType.SERIAL;
+        }
+
+        return super.mapType(field);
+    }
+}

--- a/packages/migrations/src/schema/field/strategy/SqliteModelFieldMapperStrategy.ts
+++ b/packages/migrations/src/schema/field/strategy/SqliteModelFieldMapperStrategy.ts
@@ -1,0 +1,3 @@
+import { ModelFieldMapperStrategy } from './ModelFieldMapperStrategy';
+
+export class SqliteModelFieldMapperStrategy extends ModelFieldMapperStrategy {}

--- a/packages/migrations/src/schema/field/strategy/createModelFieldMapperStrategy.ts
+++ b/packages/migrations/src/schema/field/strategy/createModelFieldMapperStrategy.ts
@@ -1,0 +1,15 @@
+import type { Dialect } from '../../../domain/Dialect';
+import { InternalDialect } from '../../../domain/internal/InternalDialect';
+import { ModelFieldMapperStrategy } from './ModelFieldMapperStrategy';
+import { PostgresModelFieldMapperStrategy } from './PostgresModelFieldMapperStrategy';
+import { SqliteModelFieldMapperStrategy } from './SqliteModelFieldMapperStrategy';
+
+export function createModelFieldMapperStrategy(dialect?: Dialect): ModelFieldMapperStrategy {
+    switch (dialect) {
+        case undefined:
+        case InternalDialect.SQLITE:
+            return new SqliteModelFieldMapperStrategy();
+        case InternalDialect.POSTGRES:
+            return new PostgresModelFieldMapperStrategy();
+    }
+}

--- a/packages/migrations/src/schema/tests/buildMigrationModelMetadataProjection.test.ts
+++ b/packages/migrations/src/schema/tests/buildMigrationModelMetadataProjection.test.ts
@@ -1,11 +1,50 @@
 import { beforeEach, describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { Model, ModelRegistry, t } from '@danceroutine/tango-schema';
+import { InternalDialect } from '../../domain/internal/InternalDialect';
 import { buildMigrationModelMetadataProjection } from '../buildMigrationModelMetadataProjection';
 
 describe(buildMigrationModelMetadataProjection, () => {
     beforeEach(() => {
         ModelRegistry.clear();
+    });
+
+    it('preserves integer schema primary keys for SQLite projections', () => {
+        Model({
+            namespace: 'app',
+            name: 'Todo',
+            schema: z.object({
+                id: t.primaryKey(z.number().int()),
+                title: z.string(),
+            }),
+        });
+
+        const projection = buildMigrationModelMetadataProjection(ModelRegistry.global(), {
+            dialect: InternalDialect.SQLITE,
+        });
+        const todoProjection = projection.find((entry) => entry.table === 'todos');
+        const idField = todoProjection?.fields.find((field) => field.name === 'id');
+
+        expect(idField).toMatchObject({ name: 'id', type: 'int', primaryKey: true });
+    });
+
+    it('projects Postgres integer schema primary keys as serial columns', () => {
+        Model({
+            namespace: 'app',
+            name: 'Todo',
+            schema: z.object({
+                id: t.primaryKey(z.number().int()),
+                title: z.string(),
+            }),
+        });
+
+        const projection = buildMigrationModelMetadataProjection(ModelRegistry.global(), {
+            dialect: InternalDialect.POSTGRES,
+        });
+        const todoProjection = projection.find((entry) => entry.table === 'todos');
+        const idField = todoProjection?.fields.find((field) => field.name === 'id');
+
+        expect(idField).toMatchObject({ name: 'id', type: 'serial', primaryKey: true });
     });
 
     it('includes index metadata from registered models in the migration projection', () => {

--- a/packages/orm/src/connection/adapters/dialects/PostgresAdapter.ts
+++ b/packages/orm/src/connection/adapters/dialects/PostgresAdapter.ts
@@ -1,10 +1,8 @@
-import pg from 'pg';
 import type { Adapter, AdapterConfig, SqlPlaceholders } from '../Adapter';
 import type { DBClient } from '../../clients/DBClient';
 import { PostgresClient } from '../../clients/dialects/PostgresClient';
+import { PostgresPoolProvider } from '../../clients/dialects/PostgresPoolProvider';
 import { InternalDialect } from '../../../query/domain/internal/InternalDialect';
-
-const { Pool } = pg;
 
 /**
  * Postgres adapter that turns adapter config into a transactional `DBClient`.
@@ -14,6 +12,7 @@ export class PostgresAdapter implements Adapter {
     readonly __tangoBrand: typeof PostgresAdapter.BRAND = PostgresAdapter.BRAND;
     readonly name = 'postgres';
     readonly dialect: Adapter['dialect'] = InternalDialect.POSTGRES;
+
     /**
      * Declares capabilities of this database adapter.
      * Used by the migration runner and query compiler to determine which
@@ -40,6 +39,7 @@ export class PostgresAdapter implements Adapter {
             return Array.from({ length: count }, (_value, index) => `$${startOffset + index + 1}`).join(', ');
         },
     };
+    private readonly poolProvider = new PostgresPoolProvider();
 
     /**
      * Narrow an unknown value to `PostgresAdapter`.
@@ -56,16 +56,7 @@ export class PostgresAdapter implements Adapter {
      * Open a Postgres connection pool and return a client-backed DB abstraction.
      */
     async connect(config: AdapterConfig): Promise<DBClient> {
-        const pool = new Pool({
-            connectionString: config.url,
-            host: config.host,
-            port: config.port,
-            database: config.database,
-            user: config.user,
-            password: config.password,
-            max: config.maxConnections || 10,
-        });
-
+        const pool = await this.poolProvider.createPool(config);
         const client = await pool.connect();
         return new PostgresClient(client);
     }

--- a/packages/orm/src/connection/adapters/dialects/SqliteAdapter.ts
+++ b/packages/orm/src/connection/adapters/dialects/SqliteAdapter.ts
@@ -1,11 +1,9 @@
 import { createRequire } from 'node:module';
-import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
 import type { Adapter, AdapterConfig, SqlPlaceholders } from '../Adapter';
 import type { DBClient } from '../../clients/DBClient';
 import { SqliteClient } from '../../clients/dialects/SqliteClient';
+import type { SqliteDatabaseConstructor } from '../../clients/dialects/SqliteDatabaseLike';
 import { InternalDialect } from '../../../query/domain/internal/InternalDialect';
-
-type BetterSqliteCtor = new (filename: string, options?: unknown) => BetterSqliteDatabase;
 
 /**
  * SQLite adapter that creates a `better-sqlite3` backed `DBClient`.
@@ -59,16 +57,16 @@ export class SqliteAdapter implements Adapter {
         return new SqliteClient(db);
     }
 
-    private getDatabaseCtor(): BetterSqliteCtor {
+    private getDatabaseCtor(): SqliteDatabaseConstructor {
         const require = createRequire(import.meta.url);
         const moduleValue = require('better-sqlite3') as unknown;
         if (typeof moduleValue === 'function') {
-            return moduleValue as BetterSqliteCtor;
+            return moduleValue as SqliteDatabaseConstructor;
         }
 
         const defaultExport = (moduleValue as { default?: unknown }).default;
         if (typeof defaultExport === 'function') {
-            return defaultExport as BetterSqliteCtor;
+            return defaultExport as SqliteDatabaseConstructor;
         }
 
         throw new TypeError('Failed to load better-sqlite3 constructor.');

--- a/packages/orm/src/connection/adapters/dialects/tests/PostgresAdapter.branches.test.ts
+++ b/packages/orm/src/connection/adapters/dialects/tests/PostgresAdapter.branches.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('PostgresAdapter driver resolution branches', () => {
+    afterEach(() => {
+        vi.doUnmock('pg');
+        vi.resetModules();
+    });
+
+    it('loads the Pool constructor from a named pg export', async () => {
+        const connect = vi.fn(async () => ({
+            query: vi.fn(async () => ({ rows: [] })),
+            release: vi.fn(),
+        }));
+
+        vi.doMock('pg', () => ({
+            Pool: class {
+                connect = connect;
+            },
+        }));
+
+        const { PostgresAdapter } = await import('../PostgresAdapter');
+        const adapter = new PostgresAdapter();
+        const client = await adapter.connect({ url: 'postgres://example' });
+
+        expect(connect).toHaveBeenCalledOnce();
+        await client.close();
+    });
+
+    it('rejects malformed pg modules', async () => {
+        vi.doMock('pg', () => ({}));
+
+        const { PostgresAdapter } = await import('../PostgresAdapter');
+        const adapter = new PostgresAdapter();
+
+        await expect(adapter.connect({ url: 'postgres://example' })).rejects.toThrow(
+            'Failed to load pg Pool constructor.'
+        );
+    });
+});

--- a/packages/orm/src/connection/clients/dialects/PostgresPoolProvider.ts
+++ b/packages/orm/src/connection/clients/dialects/PostgresPoolProvider.ts
@@ -1,0 +1,68 @@
+import type { PostgresPoolClientLike } from './PostgresClient';
+
+export type PostgresPoolLike = {
+    query(sql: string, params?: readonly unknown[]): Promise<{ rows: unknown[] }>;
+    connect(): Promise<PostgresPoolClientLike>;
+    end(): Promise<void>;
+};
+
+type PostgresPoolConstructor = new (config: {
+    connectionString?: string;
+    host?: string;
+    port?: number;
+    database?: string;
+    user?: string;
+    password?: string;
+    max: number;
+}) => PostgresPoolLike;
+
+export type PostgresPoolConfig = {
+    url?: string;
+    host?: string;
+    port?: number;
+    database?: string;
+    user?: string;
+    password?: string;
+    maxConnections?: number;
+};
+
+export class PostgresPoolProvider {
+    async createPool(config: PostgresPoolConfig): Promise<PostgresPoolLike> {
+        const Pool = await this.loadPostgresPoolConstructor();
+        return new Pool({
+            connectionString: config.url,
+            host: config.host,
+            port: config.port,
+            database: config.database,
+            user: config.user,
+            password: config.password,
+            max: config.maxConnections || 10,
+        });
+    }
+
+    private async loadPostgresPoolConstructor(): Promise<PostgresPoolConstructor> {
+        return this.resolvePostgresPoolConstructor(await import('pg'));
+    }
+
+    private resolvePostgresPoolConstructor(moduleValue: unknown): PostgresPoolConstructor {
+        const defaultPool = this.readProperty(this.readProperty(moduleValue, 'default'), 'Pool');
+        if (typeof defaultPool === 'function') {
+            return defaultPool as PostgresPoolConstructor;
+        }
+
+        const directPool = this.readProperty(moduleValue, 'Pool');
+        if (typeof directPool === 'function') {
+            return directPool as PostgresPoolConstructor;
+        }
+
+        throw new TypeError('Failed to load pg Pool constructor.');
+    }
+
+    private readProperty(value: unknown, key: string): unknown {
+        if (typeof value !== 'object' || value === null || !(key in value)) {
+            return undefined;
+        }
+
+        return (value as Record<string, unknown>)[key];
+    }
+}

--- a/packages/orm/src/connection/clients/dialects/SqliteClient.ts
+++ b/packages/orm/src/connection/clients/dialects/SqliteClient.ts
@@ -1,5 +1,5 @@
-import type Database from 'better-sqlite3';
 import type { DBClient } from '../DBClient';
+import type { SqliteDatabaseLike } from './SqliteDatabaseLike';
 
 /**
  * Transaction-capable client backed by a synchronous `better-sqlite3` handle.
@@ -9,7 +9,7 @@ export class SqliteClient implements DBClient {
     readonly __tangoBrand: typeof SqliteClient.BRAND = SqliteClient.BRAND;
     private inTransaction = false;
 
-    constructor(private db: Database.Database) {}
+    constructor(private db: SqliteDatabaseLike) {}
 
     /**
      * Narrow an unknown value to `SqliteClient`.

--- a/packages/orm/src/connection/clients/dialects/SqliteDatabaseLike.ts
+++ b/packages/orm/src/connection/clients/dialects/SqliteDatabaseLike.ts
@@ -1,0 +1,13 @@
+export type SqliteStatementLike = {
+    readonly reader: boolean;
+    all(...params: unknown[]): unknown[];
+    run(...params: unknown[]): unknown;
+};
+
+export type SqliteDatabaseLike = {
+    prepare(sql: string): SqliteStatementLike;
+    pragma(sql: string): unknown;
+    close(): void;
+};
+
+export type SqliteDatabaseConstructor = new (filename: string, options?: unknown) => SqliteDatabaseLike;

--- a/packages/orm/src/runtime/internal/PostgresDBClientProvider.ts
+++ b/packages/orm/src/runtime/internal/PostgresDBClientProvider.ts
@@ -1,33 +1,24 @@
-import pg from 'pg';
 import type { AdapterConfig } from '../../connection/adapters/Adapter';
 import { PostgresClient } from '../../connection/clients/dialects/PostgresClient';
+import { PostgresPoolProvider, type PostgresPoolLike } from '../../connection/clients/dialects/PostgresPoolProvider';
 import type { DBClientProvider, TransactionClientLease } from './DBClientProvider';
 
-const { Pool } = pg;
-
 export class PostgresDBClientProvider implements DBClientProvider {
-    private readonly pool: pg.Pool;
+    private readonly poolProvider = new PostgresPoolProvider();
+    private poolPromise: Promise<PostgresPoolLike> | null = null;
     private activeLeaseCount = 0;
 
-    constructor(config: AdapterConfig) {
-        this.pool = new Pool({
-            connectionString: config.url,
-            host: config.host,
-            port: config.port,
-            database: config.database,
-            user: config.user,
-            password: config.password,
-            max: config.maxConnections || 10,
-        });
-    }
+    constructor(private readonly config: AdapterConfig) {}
 
     async query<T = unknown>(sql: string, params?: readonly unknown[]): Promise<{ rows: T[] }> {
-        const result = await this.pool.query(sql, params as unknown[]);
+        const pool = await this.getPool();
+        const result = await pool.query(sql, params);
         return { rows: result.rows as T[] };
     }
 
     async leaseTransactionClient(): Promise<TransactionClientLease> {
-        const client = await this.pool.connect();
+        const pool = await this.getPool();
+        const client = await pool.connect();
         this.activeLeaseCount += 1;
         let released = false;
 
@@ -50,6 +41,24 @@ export class PostgresDBClientProvider implements DBClientProvider {
             throw new Error('Cannot reset Tango runtime while transaction leases are still active.');
         }
 
-        await this.pool.end();
+        if (!this.poolPromise) {
+            return;
+        }
+
+        const pool = await this.poolPromise;
+        this.poolPromise = null;
+        await pool.end();
+    }
+
+    private async getPool(): Promise<PostgresPoolLike> {
+        if (!this.poolPromise) {
+            this.poolPromise = this.createPool();
+        }
+
+        return this.poolPromise;
+    }
+
+    private async createPool(): Promise<PostgresPoolLike> {
+        return this.poolProvider.createPool(this.config);
     }
 }

--- a/packages/orm/src/runtime/internal/SqliteDBClientProvider.ts
+++ b/packages/orm/src/runtime/internal/SqliteDBClientProvider.ts
@@ -1,14 +1,12 @@
 import { createRequire } from 'node:module';
-import type { Database as BetterSqliteDatabase } from 'better-sqlite3';
 import type { AdapterConfig } from '../../connection/adapters/Adapter';
 import { SqliteClient } from '../../connection/clients/dialects/SqliteClient';
+import type { SqliteDatabaseConstructor } from '../../connection/clients/dialects/SqliteDatabaseLike';
 import type { DBClientProvider, TransactionClientLease } from './DBClientProvider';
-
-type BetterSqliteCtor = new (filename: string, options?: unknown) => BetterSqliteDatabase;
 
 export class SqliteDBClientProvider implements DBClientProvider {
     private readonly filename: string;
-    private readonly Database: BetterSqliteCtor;
+    private readonly Database: SqliteDatabaseConstructor;
     private readonly autocommitClient: SqliteClient;
     private activeLeaseCount = 0;
     private exclusiveTail: Promise<void> = Promise.resolve();
@@ -94,16 +92,16 @@ export class SqliteDBClientProvider implements DBClientProvider {
         };
     }
 
-    private getDatabaseCtor(): BetterSqliteCtor {
+    private getDatabaseCtor(): SqliteDatabaseConstructor {
         const require = createRequire(import.meta.url);
         const moduleValue = require('better-sqlite3') as unknown;
         if (typeof moduleValue === 'function') {
-            return moduleValue as BetterSqliteCtor;
+            return moduleValue as SqliteDatabaseConstructor;
         }
 
         const defaultExport = (moduleValue as { default?: unknown }).default;
         if (typeof defaultExport === 'function') {
-            return defaultExport as BetterSqliteCtor;
+            return defaultExport as SqliteDatabaseConstructor;
         }
 
         throw new TypeError('Failed to load better-sqlite3 constructor.');

--- a/packages/orm/src/runtime/internal/tests/PostgresDBClientProvider.branches.test.ts
+++ b/packages/orm/src/runtime/internal/tests/PostgresDBClientProvider.branches.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+describe('PostgresDBClientProvider driver resolution branches', () => {
+    afterEach(() => {
+        vi.doUnmock('pg');
+        vi.resetModules();
+    });
+
+    it('loads the Pool constructor from a named pg export', async () => {
+        const poolQuery = vi.fn(async () => ({ rows: [{ ok: true }] }));
+        const poolEnd = vi.fn(async () => {});
+
+        vi.doMock('pg', () => ({
+            Pool: class {
+                query = poolQuery;
+                end = poolEnd;
+            },
+        }));
+
+        const { PostgresDBClientProvider } = await import('../PostgresDBClientProvider');
+        const provider = new PostgresDBClientProvider({ url: 'postgres://example' });
+
+        await expect(provider.query('SELECT 1')).resolves.toEqual({ rows: [{ ok: true }] });
+        await expect(provider.query('SELECT 2')).resolves.toEqual({ rows: [{ ok: true }] });
+        await provider.reset();
+
+        expect(poolQuery).toHaveBeenCalledTimes(2);
+        expect(poolEnd).toHaveBeenCalledOnce();
+    });
+
+    it('rejects malformed pg modules', async () => {
+        vi.doMock('pg', () => ({}));
+
+        const { PostgresDBClientProvider } = await import('../PostgresDBClientProvider');
+        const provider = new PostgresDBClientProvider({ url: 'postgres://example' });
+
+        await expect(provider.query('SELECT 1')).rejects.toThrow('Failed to load pg Pool constructor.');
+    });
+});

--- a/packages/orm/src/runtime/tests/TangoRuntime.optionalDrivers.test.ts
+++ b/packages/orm/src/runtime/tests/TangoRuntime.optionalDrivers.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { loadConfig } from '@danceroutine/tango-config';
+
+describe('TangoRuntime optional driver loading', () => {
+    afterEach(() => {
+        vi.doUnmock('pg');
+        vi.resetModules();
+    });
+
+    it('does not load the Postgres driver when resolving a SQLite runtime adapter', async () => {
+        vi.doMock('pg', () => {
+            throw new Error('pg should not be loaded for a SQLite runtime.');
+        });
+
+        const { TangoRuntime } = await import('../TangoRuntime');
+        const runtime = new TangoRuntime(() =>
+            loadConfig(() => ({
+                current: 'development',
+                environments: {
+                    development: {
+                        name: 'development',
+                        db: { adapter: 'sqlite', filename: ':memory:' },
+                        migrations: { dir: './migrations' },
+                    },
+                    test: {
+                        name: 'test',
+                        db: { adapter: 'sqlite', filename: ':memory:' },
+                        migrations: { dir: './migrations' },
+                    },
+                    production: {
+                        name: 'production',
+                        db: { adapter: 'sqlite', filename: ':memory:' },
+                        migrations: { dir: './migrations' },
+                    },
+                },
+            }))
+        );
+
+        expect(runtime.getAdapter().name).toBe('sqlite');
+    });
+});


### PR DESCRIPTION
## Summary

- install scaffold database driver dependencies from the selected dialect, including TypeScript driver types
- keep `better-sqlite3` in generated `pnpm.onlyBuiltDependencies` only for SQLite scaffolds
- project Postgres integer schema primary keys as `serial` during migration generation while preserving SQLite integer primary keys
- lazily load the optional `pg` package so SQLite runtime adapter setup works with SQLite-only dependencies

## Validation

- `pnpm run lint:ci`
- `pnpm --filter @danceroutine/tango-codegen test`
- `pnpm --filter @danceroutine/tango-migrations test`
- `pnpm --filter @danceroutine/tango-orm test`
- `pnpm --filter @danceroutine/tango-codegen exec tsc --noEmit -p tsconfig.json --ignoreDeprecations 5.0`
- `pnpm --filter @danceroutine/tango-codegen exec tsc --noEmit -p tsconfig.tests.json --ignoreDeprecations 5.0`
- `pnpm --filter @danceroutine/tango-migrations exec tsc --noEmit -p tsconfig.json --ignoreDeprecations 5.0`
- `pnpm --filter @danceroutine/tango-migrations exec tsc --noEmit -p tsconfig.tests.json --ignoreDeprecations 5.0`
- `pnpm --filter @danceroutine/tango-orm exec tsc --noEmit -p tsconfig.json --ignoreDeprecations 5.0`
- `pnpm --filter @danceroutine/tango-orm exec tsc --noEmit -p tsconfig.tests.json --ignoreDeprecations 5.0`
- `pnpm --filter @danceroutine/tango-schema exec tsc --noEmit -p tsconfig.json --ignoreDeprecations 5.0`
- `pnpm --filter @danceroutine/tango-schema exec tsc --noEmit -p tsconfig.tests.json --ignoreDeprecations 5.0`