### PR TITLE
fix: validate QuerySet limit and offset bounds

### DIFF
--- a/.changeset/safe-query-window-bounds.md
+++ b/.changeset/safe-query-window-bounds.md
@@ -1,0 +1,5 @@
+---
+"@danceroutine/tango-orm": patch
+---
+
+Validate `QuerySet.limit()` and `QuerySet.offset()` bounds before storing query state. Both methods now accept safe non-negative integers, preserve explicit zero values in compiled SQL, and reject invalid JavaScript runtime inputs such as negative numbers, fractions, infinities, and `NaN`.

--- a/packages/orm/src/query/QuerySet.ts
+++ b/packages/orm/src/query/QuerySet.ts
@@ -163,6 +163,18 @@ export abstract class QuerySet<
         });
     }
 
+    private static validateQueryWindowBound(kind: 'limit' | 'offset', value: unknown): number {
+        if (typeof value !== 'number') {
+            throw new TypeError(`QuerySet.${kind}() expects a number.`);
+        }
+
+        if (!Number.isSafeInteger(value) || value < 0) {
+            throw new RangeError(`QuerySet.${kind}() expects a non-negative safe integer.`);
+        }
+
+        return value;
+    }
+
     private static invertOrderSpec<T extends Record<string, unknown>>(
         order: QuerySetState<T>['order']
     ): NonNullable<QuerySetState<T>['order']> {
@@ -216,14 +228,14 @@ export abstract class QuerySet<
      * Limit the maximum number of rows returned.
      */
     limit(n: number): QuerySet<TModel, TBaseResult, TSourceModel, THydrated> {
-        return this.spawn({ ...this.state, limit: n });
+        return this.spawn({ ...this.state, limit: QuerySet.validateQueryWindowBound('limit', n) });
     }
 
     /**
      * Skip the first `n` rows.
      */
     offset(n: number): QuerySet<TModel, TBaseResult, TSourceModel, THydrated> {
-        return this.spawn({ ...this.state, offset: n });
+        return this.spawn({ ...this.state, offset: QuerySet.validateQueryWindowBound('offset', n) });
     }
 
     /**

--- a/packages/orm/src/query/compiler/QueryCompiler.ts
+++ b/packages/orm/src/query/compiler/QueryCompiler.ts
@@ -133,8 +133,8 @@ export class QueryCompiler {
                       .join(', ')
                 : `${table}.${validatedPlan.meta.pk} ASC`
         }`;
-        const limitSQL = state.limit ? ` LIMIT ${state.limit}` : '';
-        const offsetSQL = state.offset ? ` OFFSET ${state.offset}` : '';
+        const limitSQL = state.limit !== undefined ? ` LIMIT ${state.limit}` : '';
+        const offsetSQL = state.offset !== undefined ? ` OFFSET ${state.offset}` : '';
         const sql = `SELECT ${select} FROM ${table}${joinCollection.joins.length ? ` ${joinCollection.joins.join(' ')}` : ''}${whereSQL}${orderSQL}${limitSQL}${offsetSQL}`;
 
         const compiledHydrationPlan: CompiledHydrationPlanRoot | undefined =

--- a/packages/orm/src/query/compiler/QueryCompiler.ts
+++ b/packages/orm/src/query/compiler/QueryCompiler.ts
@@ -133,7 +133,13 @@ export class QueryCompiler {
                       .join(', ')
                 : `${table}.${validatedPlan.meta.pk} ASC`
         }`;
-        const limitSQL = state.limit !== undefined ? ` LIMIT ${state.limit}` : '';
+        const hasOffset = state.offset !== undefined;
+        const limitSQL =
+            state.limit !== undefined
+                ? ` LIMIT ${state.limit}`
+                : hasOffset && this.adapter.dialect === InternalDialect.SQLITE
+                  ? ' LIMIT -1'
+                  : '';
         const offsetSQL = state.offset !== undefined ? ` OFFSET ${state.offset}` : '';
         const sql = `SELECT ${select} FROM ${table}${joinCollection.joins.length ? ` ${joinCollection.joins.join(' ')}` : ''}${whereSQL}${orderSQL}${limitSQL}${offsetSQL}`;
 

--- a/packages/orm/src/query/compiler/tests/QueryCompiler.test.ts
+++ b/packages/orm/src/query/compiler/tests/QueryCompiler.test.ts
@@ -617,6 +617,16 @@ describe(QueryCompiler, () => {
         expect(result.sql).toContain('LIMIT 10');
     });
 
+    it('compiles zero limit', () => {
+        const state = {
+            limit: 0,
+        };
+
+        const result = new QueryCompiler(mockMeta, postgresAdapter).compile(state);
+
+        expect(result.sql).toContain('LIMIT 0');
+    });
+
     it('compiles offset', () => {
         const state = {
             offset: 20,
@@ -625,6 +635,16 @@ describe(QueryCompiler, () => {
         const result = new QueryCompiler(mockMeta, postgresAdapter).compile(state);
 
         expect(result.sql).toContain('OFFSET 20');
+    });
+
+    it('compiles zero offset', () => {
+        const state = {
+            offset: 0,
+        };
+
+        const result = new QueryCompiler(mockMeta, postgresAdapter).compile(state);
+
+        expect(result.sql).toContain('OFFSET 0');
     });
 
     it('compiles existence probes from scalar query state', () => {

--- a/packages/orm/src/query/compiler/tests/QueryCompiler.test.ts
+++ b/packages/orm/src/query/compiler/tests/QueryCompiler.test.ts
@@ -712,6 +712,27 @@ describe(QueryCompiler, () => {
             expect(result.params).toEqual([1, 2]);
         });
 
+        it('uses SQLite unlimited limit syntax when offset is set without a limit', () => {
+            const state = {
+                offset: 0,
+            };
+
+            const result = new QueryCompiler(mockMeta, sqliteAdapter).compile(state);
+
+            expect(result.sql).toContain('LIMIT -1 OFFSET 0');
+        });
+
+        it('keeps the requested SQLite limit when limit and offset are set', () => {
+            const state = {
+                limit: 10,
+                offset: 0,
+            };
+
+            const result = new QueryCompiler(mockMeta, sqliteAdapter).compile(state);
+
+            expect(result.sql).toContain('LIMIT 10 OFFSET 0');
+        });
+
         it('normalizes sqlite booleans and supports non-array IN values', () => {
             const result = new QueryCompiler(mockMeta, sqliteAdapter).compile({
                 q: Q.and<UserModel>({ isActive: true }, { id__in: 9 }),

--- a/packages/orm/src/query/tests/QuerySet.test.ts
+++ b/packages/orm/src/query/tests/QuerySet.test.ts
@@ -174,6 +174,49 @@ describe(QuerySet, () => {
         expect(QuerySet.isQuerySet({})).toBe(false);
     });
 
+    it('preserves an explicit zero limit when fetching rows', async () => {
+        const { queryExecutor, run } = createQueryExecutorFixture();
+        const qs = new ModelQuerySet<User>(queryExecutor);
+
+        await qs.limit(0).fetch();
+
+        expect(run).toHaveBeenCalledWith(expect.objectContaining({ sql: expect.stringContaining('LIMIT 0') }));
+    });
+
+    it('preserves an explicit zero offset when fetching rows', async () => {
+        const { queryExecutor, run } = createQueryExecutorFixture();
+        const qs = new ModelQuerySet<User>(queryExecutor);
+
+        await qs.offset(0).fetch();
+
+        expect(run).toHaveBeenCalledWith(expect.objectContaining({ sql: expect.stringContaining('OFFSET 0') }));
+    });
+
+    it('rejects invalid limit and offset values', () => {
+        const { queryExecutor } = createQueryExecutorFixture();
+        const methods = [
+            { name: 'limit', apply: (queryset: ModelQuerySet<User>, value: number) => queryset.limit(value) },
+            { name: 'offset', apply: (queryset: ModelQuerySet<User>, value: number) => queryset.offset(value) },
+        ] as const;
+        const invalidNumericValues = [-1, 1.5, Number.NaN, Number.POSITIVE_INFINITY, Number.MAX_SAFE_INTEGER + 1];
+        const nonNumberValues: unknown[] = ['10', null, true, {}, []];
+
+        for (const method of methods) {
+            for (const value of invalidNumericValues) {
+                expect(() => method.apply(new ModelQuerySet<User>(queryExecutor), value), method.name).toThrow(
+                    RangeError
+                );
+            }
+
+            for (const value of nonNumberValues) {
+                expect(
+                    () => method.apply(new ModelQuerySet<User>(queryExecutor), value as number),
+                    method.name
+                ).toThrow(TypeError);
+            }
+        }
+    });
+
     it('clones the current queryset state when all() is called', async () => {
         const { queryExecutor, run } = createQueryExecutorFixture([{ id: 1, email: 'all@a.com', active: true }]);
         const base = new ModelQuerySet<User>(queryExecutor).filter({ active: true }).orderBy('-id');


### PR DESCRIPTION
## Summary
- validate QuerySet.limit() and QuerySet.offset() inputs before storing query state
- preserve explicit zero limit and offset values during SQL compilation
- add a patch changeset for @danceroutine/tango-orm

## Validation
- pnpm exec vitest run packages/orm/src/query/compiler/tests/QueryCompiler.test.ts packages/orm/src/query/tests/QuerySet.test.ts
- pnpm --filter @danceroutine/tango-orm typecheck
- pnpm exec prettier --check .changeset/safe-query-window-bounds.md packages/orm/src/query/QuerySet.ts packages/orm/src/query/compiler/QueryCompiler.ts packages/orm/src/query/tests/QuerySet.test.ts packages/orm/src/query/compiler/tests/QueryCompiler.test.ts
- pnpm exec changeset status