### PR TITLE
refactor: extract queryset hydration internals

### DIFF
--- a/.changeset/wild-yaks-sip.md
+++ b/.changeset/wild-yaks-sip.md
@@ -1,0 +1,6 @@
+---
+"@danceroutine/tango-orm": patch
+"@danceroutine/tango-testing": patch
+---
+
+Refactored the QuerySet internal surface in preparation for expanding M2M functionality

--- a/packages/orm/src/query/QuerySet.ts
+++ b/packages/orm/src/query/QuerySet.ts
@@ -9,7 +9,6 @@ import type { OrderToken } from './domain/OrderToken';
 import type { OrderSpec } from './domain/OrderSpec';
 import type { FilterInput } from './domain/FilterInput';
 import type { CompiledQuery } from './domain/CompiledQuery';
-import type { CompiledHydrationNode } from './domain/CompiledQuery';
 import type {
     GeneratedHydratedRelationMap,
     GeneratedPrefetchRelatedPathKeys,
@@ -22,15 +21,16 @@ import type {
     SelectRelatedRelations,
     SingleRelationHydrationCardinality,
 } from './domain/RelationTyping';
-import { InternalRelationHydrationCardinality } from './domain/RelationTyping';
 import { InternalQNodeType } from './domain/internal/InternalQNodeType';
 import { InternalDirection } from './domain/internal/InternalDirection';
-import { InternalDialect } from './domain/internal/InternalDialect';
-import { InternalPrefetchQueryKind } from './domain/internal/InternalPrefetchQueryKind';
 import { QBuilder as Q } from './QBuilder';
 import { QueryCompiler } from './compiler';
 import { isQNodeLike } from './internal/isQNodeLike';
-// TODO revisit this later. QuerySet is getting very heavy between handling query building, prefetching, canonicalization, and hydration, and caching.
+import { QueryHydrator } from './hydration/QueryHydrator';
+import {
+    createQueryRowNormalizerStrategy,
+    type QueryRowNormalizerStrategy,
+} from './hydration/QueryRowNormalizerStrategy';
 /**
  * Query execution seam consumed by `QuerySet`.
  *
@@ -74,10 +74,6 @@ type QueryShapeOutput<TInput, TShape> =
           ? TOutput
           : never;
 
-type TargetColumnMetadata = {
-    targetColumns: Record<string, string>;
-};
-
 type ProjectedResult<
     TModel extends Record<string, unknown>,
     TKeys extends readonly (keyof TModel)[],
@@ -113,11 +109,16 @@ export abstract class QuerySet<
     static readonly BRAND = 'tango.orm.query_set' as const;
     readonly __tangoBrand: typeof QuerySet.BRAND = QuerySet.BRAND;
     private evaluationCache?: Promise<QueryResult<HydratedQueryResult<TBaseResult, THydrated>>>;
+    private readonly hydrator: QueryHydrator<TModel>;
+    private readonly rowNormalizer: QueryRowNormalizerStrategy;
 
     constructor(
         protected executor: QueryExecutor<TModel>,
         protected state: QuerySetState<TModel, TSourceModel> = {}
-    ) {}
+    ) {
+        this.rowNormalizer = createQueryRowNormalizerStrategy(executor.adapter.dialect);
+        this.hydrator = new QueryHydrator(executor, this.rowNormalizer);
+    }
 
     /**
      * Create another queryset of the same runtime family with the supplied
@@ -398,7 +399,9 @@ export abstract class QuerySet<
         const results: Array<HydratedQueryResult<TBaseResult, THydrated> | Out> =
             typeof shape === 'function'
                 ? baseResult.items.map(shape)
-                : this.normalizeHydratedRowsForParserShape(baseResult.items).map((row) => shape.parse(row));
+                : this.rowNormalizer
+                      .normalizeHydratedRowsForParserShape(baseResult.items, this.executor.meta.columns)
+                      .map((row) => shape.parse(row));
 
         return new QueryResult(results);
     }
@@ -565,7 +568,10 @@ export abstract class QuerySet<
             return shape(row);
         }
 
-        const normalizedRow = this.normalizeHydratedRowsForParserShape([row])[0] ?? row;
+        const normalizedRow = this.rowNormalizer.normalizeHydratedRowsForParserShape(
+            [row],
+            this.executor.meta.columns
+        )[0]!;
         return shape.parse(normalizedRow);
     }
 
@@ -583,439 +589,10 @@ export abstract class QuerySet<
         const compiler = new QueryCompiler(this.executor.meta, this.executor.adapter);
         const compiled = compiler.compile(this.state);
         const rows = await this.executor.run(compiled);
-        const normalizedRows = this.normalizeRowsForSchemaParsing(rows);
-        const hydratedRows = await this.hydrateRows(normalizedRows as unknown as Record<string, unknown>[], compiled);
-        this.attachRootRecordAccessors(hydratedRows);
+        const normalizedRows = this.rowNormalizer.normalizeRootRows(rows, this.executor.meta.columns);
+        const hydratedRows = await this.hydrator.materializeRows(normalizedRows, compiled);
         const projectedRows = hydratedRows as Array<HydratedQueryResult<TBaseResult, THydrated>>;
         return new QueryResult(projectedRows);
-    }
-
-    private normalizeRowsForSchemaParsing(rows: readonly TModel[]): TModel[] {
-        if (this.executor.adapter.dialect !== InternalDialect.SQLITE) {
-            return [...rows];
-        }
-
-        const booleanColumns = Object.entries(this.executor.meta.columns)
-            .filter(([, value]) => this.isBooleanColumnType(value))
-            .map(([column]) => column);
-
-        if (booleanColumns.length === 0) {
-            return [...rows];
-        }
-
-        return rows.map((row) => this.normalizeBooleanColumns(row, booleanColumns));
-    }
-
-    private normalizeHydratedRowsForParserShape(
-        rows: readonly HydratedQueryResult<TBaseResult, THydrated>[]
-    ): Array<HydratedQueryResult<TBaseResult, THydrated>> {
-        if (this.executor.adapter.dialect !== InternalDialect.SQLITE) {
-            return [...rows];
-        }
-
-        const booleanColumns = Object.entries(this.executor.meta.columns)
-            .filter(([, value]) => this.isBooleanColumnType(value))
-            .map(([column]) => column);
-
-        if (booleanColumns.length === 0) {
-            return [...rows];
-        }
-
-        return rows.map((row) => this.normalizeBooleanColumns(row, booleanColumns));
-    }
-
-    private async hydrateRows(
-        rows: Record<string, unknown>[],
-        compiled: CompiledQuery
-    ): Promise<Record<string, unknown>[]> {
-        if (!compiled.hydrationPlan) {
-            return rows;
-        }
-
-        // Hydration mutates row objects by attaching related entities and
-        // stripping internal alias columns. Copy once here so the executor's
-        // raw rows remain untouched throughout the recursive hydration pass.
-        const hydratedRows = rows.map((row) => ({ ...row }));
-        // Canonicalize by model key and primary key so one database row maps to
-        // one in-memory object even when multiple hydration paths reach it.
-        this.attachRootRecordAccessors(hydratedRows);
-        const canonicalEntities = new Map<string, Map<string | number, Record<string, unknown>>>();
-        const queuedJoinPrefetchOwners = new Map<CompiledHydrationNode, Set<Record<string, unknown>>>();
-        const compiler = new QueryCompiler(this.executor.meta, this.executor.adapter);
-
-        for (const row of hydratedRows) {
-            this.hydrateJoinNodesForOwner(
-                row,
-                row,
-                compiled.hydrationPlan.joinNodes,
-                canonicalEntities,
-                queuedJoinPrefetchOwners
-            );
-        }
-
-        for (const node of compiled.hydrationPlan.prefetchNodes) {
-            await this.hydratePrefetchNode(node, hydratedRows, canonicalEntities, compiler);
-        }
-
-        for (const [node, owners] of queuedJoinPrefetchOwners.entries()) {
-            await this.hydratePrefetchNode(node, [...owners], canonicalEntities, compiler);
-        }
-
-        for (const row of hydratedRows) {
-            for (const alias of compiled.hydrationPlan.hiddenRootAliases) {
-                delete row[alias];
-            }
-        }
-
-        return hydratedRows;
-    }
-
-    private primeManyToManyOwnerCache(
-        owner: Record<string, unknown>,
-        relationName: string,
-        bucket: readonly Record<string, unknown>[]
-    ): void {
-        const existing = owner[relationName];
-        if (existing && typeof (existing as { primePrefetchCache?: unknown }).primePrefetchCache === 'function') {
-            (existing as { primePrefetchCache: (rows: readonly Record<string, unknown>[]) => void }).primePrefetchCache(
-                bucket
-            );
-            return;
-        }
-        owner[relationName] = bucket.slice();
-    }
-
-    private attachRootRecordAccessors(rows: readonly Record<string, unknown>[]): void {
-        if (!this.executor.attachPersistedRecordAccessors) {
-            return;
-        }
-        const sourceModelKey = this.executor.meta.modelKey;
-        for (const row of rows) {
-            this.executor.attachPersistedRecordAccessors(row, sourceModelKey);
-        }
-    }
-
-    private hydrateJoinNodesForOwner(
-        owner: Record<string, unknown>,
-        rawRow: Record<string, unknown>,
-        nodes: readonly CompiledHydrationNode[],
-        canonicalEntities: Map<string, Map<string | number, Record<string, unknown>>>,
-        queuedJoinPrefetchOwners?: Map<CompiledHydrationNode, Set<Record<string, unknown>>>
-    ): void {
-        // Join-backed descendants already live on the current SQL row. This
-        // pass reads the aliased columns, materializes the related entity, and
-        // then recurses into any join-backed children on the same row payload.
-        for (const node of nodes) {
-            if (!node.join) {
-                continue;
-            }
-
-            const target: Record<string, unknown> = {};
-            let hasTargetValue = false;
-
-            for (const [column, alias] of Object.entries(node.join.columns)) {
-                const value = rawRow[alias];
-                delete rawRow[alias];
-                target[column] = this.normalizeColumnValue(node.targetColumns[column], value);
-                if (value !== null && value !== undefined) {
-                    hasTargetValue = true;
-                }
-            }
-
-            if (!hasTargetValue) {
-                owner[node.relationName] = null;
-                continue;
-            }
-
-            const canonical = this.canonicalizeEntity(node, target, canonicalEntities);
-            owner[node.relationName] = canonical;
-            for (const childNode of node.prefetchChildren) {
-                const queuedOwners = queuedJoinPrefetchOwners?.get(childNode);
-                if (queuedOwners) {
-                    queuedOwners.add(canonical);
-                    continue;
-                }
-
-                queuedJoinPrefetchOwners?.set(childNode, new Set([canonical]));
-            }
-            this.hydrateJoinNodesForOwner(
-                canonical,
-                rawRow,
-                node.joinChildren,
-                canonicalEntities,
-                queuedJoinPrefetchOwners
-            );
-        }
-    }
-
-    private async hydratePrefetchNode(
-        node: CompiledHydrationNode,
-        owners: readonly Record<string, unknown>[],
-        canonicalEntities: Map<string, Map<string | number, Record<string, unknown>>>,
-        compiler: QueryCompiler
-    ): Promise<void> {
-        if (owners.length === 0) {
-            return;
-        }
-
-        // Prefetch-backed descendants run as follow-up queries keyed by the
-        // owner rows produced so far. Initialize defaults first so missing
-        // children still hydrate to [] or null deterministically.
-        const groupedOwners = this.groupOwnersByAccessor(owners, node.ownerSourceAccessor);
-        const sourceValues = [...groupedOwners.keys()];
-        const isManyToMany = !!node.throughTable;
-        if (!isManyToMany) {
-            for (const owner of owners) {
-                owner[node.relationName] = node.cardinality === InternalRelationHydrationCardinality.MANY ? [] : null;
-            }
-        }
-
-        if (sourceValues.length === 0) {
-            return;
-        }
-
-        const sourceChunks = this.chunkValues(sourceValues, 500);
-        const compiledPrefetch = compiler.compilePrefetch(node, sourceChunks[0]!);
-        if (compiledPrefetch.kind === InternalPrefetchQueryKind.MANY_TO_MANY) {
-            const idsByOwner = new Map<string | number, Array<string | number>>();
-            const uniqueTargetIds = new Set<string | number>();
-
-            for (const chunk of sourceChunks) {
-                const chunkCompiled = compiler.compilePrefetch(node, chunk) as Extract<
-                    typeof compiledPrefetch,
-                    { kind: typeof InternalPrefetchQueryKind.MANY_TO_MANY }
-                >;
-                const throughResult = await this.executor.client.query<Record<string, unknown>>(
-                    chunkCompiled.throughSql,
-                    chunkCompiled.throughParams
-                );
-
-                for (const row of throughResult.rows) {
-                    const ownerId = row[chunkCompiled.ownerAlias];
-                    const targetId = row[chunkCompiled.targetAlias];
-                    if (
-                        (typeof ownerId !== 'string' && typeof ownerId !== 'number') ||
-                        (typeof targetId !== 'string' && typeof targetId !== 'number')
-                    ) {
-                        continue;
-                    }
-                    const bucket = idsByOwner.get(ownerId) ?? [];
-                    bucket.push(targetId);
-                    idsByOwner.set(ownerId, bucket);
-                    uniqueTargetIds.add(targetId);
-                }
-            }
-
-            const targets: Record<string | number, Record<string, unknown>> = {};
-            const targetIds = [...uniqueTargetIds.values()];
-            if (targetIds.length > 0) {
-                for (const targetChunk of this.chunkValues(targetIds, 500)) {
-                    const targetQuery = compiler.compileManyToManyTargets(node, targetChunk);
-                    const targetResult = await this.executor.client.query<Record<string, unknown>>(
-                        targetQuery.sql,
-                        targetQuery.params
-                    );
-
-                    for (const rawTargetRow of targetResult.rows) {
-                        const normalized = this.normalizeTargetRow(
-                            { targetColumns: compiledPrefetch.targetColumns },
-                            rawTargetRow
-                        );
-                        const canonical = this.canonicalizeEntity(node, normalized, canonicalEntities);
-                        this.hydrateJoinNodesForOwner(canonical, normalized, node.joinChildren, canonicalEntities);
-                        const primaryKey = canonical[node.targetPrimaryKey];
-                        if (typeof primaryKey === 'string' || typeof primaryKey === 'number') {
-                            targets[primaryKey] = canonical;
-                        }
-                    }
-                }
-            }
-
-            const canonicalChildren = new Map<string | number, Record<string, unknown>>();
-            const handledOwners = new Set<Record<string, unknown>>();
-            for (const [ownerId, ids] of idsByOwner.entries()) {
-                const bucket = ids
-                    .map((id) => targets[id])
-                    .filter((value): value is Record<string, unknown> => !!value);
-                for (const owner of groupedOwners.get(ownerId) ?? []) {
-                    this.primeManyToManyOwnerCache(owner, node.relationName, bucket);
-                    handledOwners.add(owner);
-                }
-                for (const child of bucket) {
-                    canonicalChildren.set(child[node.targetPrimaryKey] as string | number, child);
-                }
-            }
-            for (const owner of owners) {
-                if (!handledOwners.has(owner)) {
-                    this.primeManyToManyOwnerCache(owner, node.relationName, []);
-                }
-            }
-
-            const childOwners = [...canonicalChildren.values()];
-            for (const childNode of node.prefetchChildren) {
-                await this.hydratePrefetchNode(childNode, childOwners, canonicalEntities, compiler);
-            }
-            return;
-        }
-
-        const canonicalChildren = new Map<string | number, Record<string, unknown>>();
-        for (const chunk of sourceChunks) {
-            const chunkCompiled = compiler.compilePrefetch(node, chunk) as Extract<
-                typeof compiledPrefetch,
-                { kind: typeof InternalPrefetchQueryKind.DIRECT }
-            >;
-            const result = await this.executor.client.query<Record<string, unknown>>(
-                chunkCompiled.sql,
-                chunkCompiled.params
-            );
-
-            for (const rawResultRow of result.rows) {
-                const normalized = this.normalizeTargetRow(chunkCompiled, rawResultRow);
-                const canonical = this.canonicalizeEntity(node, normalized, canonicalEntities);
-                this.hydrateJoinNodesForOwner(canonical, normalized, node.joinChildren, canonicalEntities);
-
-                const key = normalized[chunkCompiled.targetKey];
-                if (typeof key !== 'string' && typeof key !== 'number') {
-                    continue;
-                }
-
-                for (const owner of groupedOwners.get(key) ?? []) {
-                    if (node.cardinality === InternalRelationHydrationCardinality.MANY) {
-                        (owner[node.relationName] as Record<string, unknown>[]).push(canonical);
-                    } else if (owner[node.relationName] === null) {
-                        owner[node.relationName] = canonical;
-                    }
-                }
-
-                const childPrimaryKey = canonical[node.targetPrimaryKey];
-                if (typeof childPrimaryKey === 'string' || typeof childPrimaryKey === 'number') {
-                    canonicalChildren.set(childPrimaryKey, canonical);
-                }
-            }
-        }
-
-        const childOwners = [...canonicalChildren.values()];
-        for (const childNode of node.prefetchChildren) {
-            await this.hydratePrefetchNode(childNode, childOwners, canonicalEntities, compiler);
-        }
-    }
-
-    private chunkValues<T>(values: readonly T[], size: number): T[][] {
-        if (values.length === 0) {
-            return [];
-        }
-        if (values.length <= size) {
-            return [Array.from(values)];
-        }
-        const chunks: T[][] = [];
-        for (let i = 0; i < values.length; i += size) {
-            chunks.push(values.slice(i, i + size) as T[]);
-        }
-        return chunks;
-    }
-
-    private groupOwnersByAccessor(
-        owners: readonly Record<string, unknown>[],
-        accessor: string
-    ): Map<string | number, Record<string, unknown>[]> {
-        const grouped = new Map<string | number, Record<string, unknown>[]>();
-
-        for (const owner of owners) {
-            const key = owner[accessor];
-            if (typeof key !== 'string' && typeof key !== 'number') {
-                continue;
-            }
-            const bucket = grouped.get(key) ?? [];
-            bucket.push(owner);
-            grouped.set(key, bucket);
-        }
-
-        return grouped;
-    }
-
-    private canonicalizeEntity(
-        node: CompiledHydrationNode,
-        row: Record<string, unknown>,
-        canonicalEntities: Map<string, Map<string | number, Record<string, unknown>>>
-    ): Record<string, unknown> {
-        // Mixed join/prefetch traversal can encounter the same related row more
-        // than once. Canonicalization ensures all later descendants attach to
-        // one stable object graph instead of competing copies.
-        const primaryKeyValue = row[node.targetPrimaryKey];
-        if (typeof primaryKeyValue !== 'string' && typeof primaryKeyValue !== 'number') {
-            return row;
-        }
-
-        const byModel =
-            canonicalEntities.get(node.targetModelKey) ?? new Map<string | number, Record<string, unknown>>();
-        const existing = byModel.get(primaryKeyValue);
-        if (existing) {
-            Object.assign(existing, row);
-            return existing;
-        }
-
-        byModel.set(primaryKeyValue, row);
-        canonicalEntities.set(node.targetModelKey, byModel);
-        this.executor.attachPersistedRecordAccessors?.(row, node.targetModelKey);
-        return row;
-    }
-
-    private normalizeTargetRow(prefetch: TargetColumnMetadata, row: Record<string, unknown>): Record<string, unknown> {
-        if (this.executor.adapter.dialect !== InternalDialect.SQLITE) {
-            return row;
-        }
-
-        let normalized: Record<string, unknown> | null = null;
-        for (const [column, type] of Object.entries(prefetch.targetColumns)) {
-            if (!this.isBooleanColumnType(type)) {
-                continue;
-            }
-            const next = this.normalizeSqliteBoolean(row[column]);
-            if (next === row[column]) {
-                continue;
-            }
-            normalized ??= { ...row };
-            normalized[column] = next;
-        }
-        return normalized ?? row;
-    }
-
-    private normalizeColumnValue(columnType: string | undefined, value: unknown): unknown {
-        return this.executor.adapter.dialect === InternalDialect.SQLITE && this.isBooleanColumnType(columnType)
-            ? this.normalizeSqliteBoolean(value)
-            : value;
-    }
-
-    private isBooleanColumnType(value: unknown): boolean {
-        return typeof value === 'string' && ['bool', 'boolean'].includes(value.trim().toLowerCase());
-    }
-
-    private normalizeSqliteBoolean(value: unknown): unknown {
-        if (value === 0 || value === '0') {
-            return false;
-        }
-        if (value === 1 || value === '1') {
-            return true;
-        }
-        return value;
-    }
-
-    private normalizeBooleanColumns<TRow extends Record<string, unknown>>(row: TRow, columns: readonly string[]): TRow {
-        let normalized: TRow | null = null;
-
-        for (const column of columns) {
-            const current = (row as Record<string, unknown>)[column];
-            const next = this.normalizeSqliteBoolean(current);
-            if (next === current) {
-                continue;
-            }
-            if (!normalized) {
-                normalized = { ...row };
-            }
-            (normalized as Record<string, unknown>)[column] = next;
-        }
-
-        return normalized ?? row;
     }
 
     private withoutHydrationState(): QuerySetState<TModel, TSourceModel> {

--- a/packages/orm/src/query/hydration/HydrationEntityRegistry.ts
+++ b/packages/orm/src/query/hydration/HydrationEntityRegistry.ts
@@ -1,0 +1,47 @@
+import type { CompiledHydrationNode } from '../domain/CompiledQuery';
+
+type AccessorAttachment = (record: Record<string, unknown>, modelKey?: string) => void;
+
+/**
+ * Tracks hydrated related records so repeated rows point at one canonical
+ * object per model primary key.
+ */
+export class HydrationEntityRegistry {
+    static readonly BRAND = 'tango.orm.hydration_entity_registry' as const;
+    readonly __tangoBrand: typeof HydrationEntityRegistry.BRAND = HydrationEntityRegistry.BRAND;
+
+    private readonly recordsByModel = new Map<string, Map<string | number, Record<string, unknown>>>();
+
+    constructor(private readonly attachPersistedRecordAccessors?: AccessorAttachment) {}
+
+    static isHydrationEntityRegistry(value: unknown): value is HydrationEntityRegistry {
+        return (
+            typeof value === 'object' &&
+            value !== null &&
+            (value as { __tangoBrand?: unknown }).__tangoBrand === HydrationEntityRegistry.BRAND
+        );
+    }
+
+    canonicalize(node: CompiledHydrationNode, row: Record<string, unknown>): Record<string, unknown> {
+        // Mixed join/prefetch traversal can encounter the same related row more
+        // than once. Canonicalization ensures all later descendants attach to
+        // one stable object graph instead of competing copies.
+        const primaryKeyValue = row[node.targetPrimaryKey];
+        if (typeof primaryKeyValue !== 'string' && typeof primaryKeyValue !== 'number') {
+            return row;
+        }
+
+        const byModel =
+            this.recordsByModel.get(node.targetModelKey) ?? new Map<string | number, Record<string, unknown>>();
+        const existing = byModel.get(primaryKeyValue);
+        if (existing) {
+            Object.assign(existing, row);
+            return existing;
+        }
+
+        byModel.set(primaryKeyValue, row);
+        this.recordsByModel.set(node.targetModelKey, byModel);
+        this.attachPersistedRecordAccessors?.(row, node.targetModelKey);
+        return row;
+    }
+}

--- a/packages/orm/src/query/hydration/QueryHydrator.ts
+++ b/packages/orm/src/query/hydration/QueryHydrator.ts
@@ -1,0 +1,336 @@
+import type { QueryExecutor } from '../QuerySet';
+import type { CompiledHydrationNode, CompiledQuery } from '../domain/CompiledQuery';
+import { InternalPrefetchQueryKind } from '../domain/internal/InternalPrefetchQueryKind';
+import { InternalRelationHydrationCardinality } from '../domain/RelationTyping';
+import { QueryCompiler } from '../compiler';
+import { HydrationEntityRegistry } from './HydrationEntityRegistry';
+import { createQueryRowNormalizerStrategy, type QueryRowNormalizerStrategy } from './QueryRowNormalizerStrategy';
+
+/**
+ * Coordinates compiled relation hydration for `QuerySet` evaluation.
+ */
+export class QueryHydrator<TModel extends Record<string, unknown>> {
+    static readonly BRAND = 'tango.orm.query_hydrator' as const;
+    readonly __tangoBrand: typeof QueryHydrator.BRAND = QueryHydrator.BRAND;
+
+    private readonly normalizer: QueryRowNormalizerStrategy;
+
+    constructor(
+        private readonly executor: QueryExecutor<TModel>,
+        normalizer?: QueryRowNormalizerStrategy
+    ) {
+        this.normalizer = normalizer ?? createQueryRowNormalizerStrategy(executor.adapter.dialect);
+    }
+
+    static isQueryHydrator(value: unknown): value is QueryHydrator<Record<string, unknown>> {
+        return (
+            typeof value === 'object' &&
+            value !== null &&
+            (value as { __tangoBrand?: unknown }).__tangoBrand === QueryHydrator.BRAND
+        );
+    }
+
+    async materializeRows(rows: readonly TModel[], compiled: CompiledQuery): Promise<Record<string, unknown>[]> {
+        const hydratedRows = await this.hydrateRows(rows as unknown as Record<string, unknown>[], compiled);
+        this.attachRootRecordAccessors(hydratedRows);
+        return hydratedRows;
+    }
+
+    private async hydrateRows(
+        rows: Record<string, unknown>[],
+        compiled: CompiledQuery
+    ): Promise<Record<string, unknown>[]> {
+        if (!compiled.hydrationPlan) {
+            return rows;
+        }
+
+        // Hydration mutates row objects by attaching related entities and
+        // stripping internal alias columns. Copy once here so the executor's
+        // raw rows remain untouched throughout the recursive hydration pass.
+        const hydratedRows = rows.map((row) => ({ ...row }));
+        this.attachRootRecordAccessors(hydratedRows);
+        const registry = new HydrationEntityRegistry(this.executor.attachPersistedRecordAccessors);
+        const queuedJoinPrefetchOwners = new Map<CompiledHydrationNode, Set<Record<string, unknown>>>();
+        const compiler = new QueryCompiler(this.executor.meta, this.executor.adapter);
+
+        for (const row of hydratedRows) {
+            this.hydrateJoinNodesForOwner(
+                row,
+                row,
+                compiled.hydrationPlan.joinNodes,
+                registry,
+                queuedJoinPrefetchOwners
+            );
+        }
+
+        for (const node of compiled.hydrationPlan.prefetchNodes) {
+            await this.hydratePrefetchNode(node, hydratedRows, registry, compiler);
+        }
+
+        for (const [node, owners] of queuedJoinPrefetchOwners.entries()) {
+            await this.hydratePrefetchNode(node, [...owners], registry, compiler);
+        }
+
+        for (const row of hydratedRows) {
+            for (const alias of compiled.hydrationPlan.hiddenRootAliases) {
+                delete row[alias];
+            }
+        }
+
+        return hydratedRows;
+    }
+
+    private attachRootRecordAccessors(rows: readonly Record<string, unknown>[]): void {
+        if (!this.executor.attachPersistedRecordAccessors) {
+            return;
+        }
+        const sourceModelKey = this.executor.meta.modelKey;
+        for (const row of rows) {
+            this.executor.attachPersistedRecordAccessors(row, sourceModelKey);
+        }
+    }
+
+    private hydrateJoinNodesForOwner(
+        owner: Record<string, unknown>,
+        rawRow: Record<string, unknown>,
+        nodes: readonly CompiledHydrationNode[],
+        registry: HydrationEntityRegistry,
+        queuedJoinPrefetchOwners?: Map<CompiledHydrationNode, Set<Record<string, unknown>>>
+    ): void {
+        // Join-backed descendants already live on the current SQL row. This
+        // pass reads the aliased columns, materializes the related entity, and
+        // then recurses into any join-backed children on the same row payload.
+        for (const node of nodes) {
+            if (!node.join) {
+                continue;
+            }
+
+            const target: Record<string, unknown> = {};
+            let hasTargetValue = false;
+
+            for (const [column, alias] of Object.entries(node.join.columns)) {
+                const value = rawRow[alias];
+                delete rawRow[alias];
+                target[column] = this.normalizer.normalizeColumnValue(node.targetColumns[column], value);
+                if (value !== null && value !== undefined) {
+                    hasTargetValue = true;
+                }
+            }
+
+            if (!hasTargetValue) {
+                owner[node.relationName] = null;
+                continue;
+            }
+
+            const canonical = registry.canonicalize(node, target);
+            owner[node.relationName] = canonical;
+            for (const childNode of node.prefetchChildren) {
+                const queuedOwners = queuedJoinPrefetchOwners?.get(childNode);
+                if (queuedOwners) {
+                    queuedOwners.add(canonical);
+                    continue;
+                }
+
+                queuedJoinPrefetchOwners?.set(childNode, new Set([canonical]));
+            }
+            this.hydrateJoinNodesForOwner(canonical, rawRow, node.joinChildren, registry, queuedJoinPrefetchOwners);
+        }
+    }
+
+    private async hydratePrefetchNode(
+        node: CompiledHydrationNode,
+        owners: readonly Record<string, unknown>[],
+        registry: HydrationEntityRegistry,
+        compiler: QueryCompiler
+    ): Promise<void> {
+        if (owners.length === 0) {
+            return;
+        }
+
+        // Prefetch-backed descendants run as follow-up queries keyed by the
+        // owner rows produced so far. Initialize defaults first so missing
+        // children still hydrate to [] or null deterministically.
+        const groupedOwners = this.groupOwnersByAccessor(owners, node.ownerSourceAccessor);
+        const sourceValues = [...groupedOwners.keys()];
+        const isManyToMany = !!node.throughTable;
+        if (!isManyToMany) {
+            for (const owner of owners) {
+                owner[node.relationName] = node.cardinality === InternalRelationHydrationCardinality.MANY ? [] : null;
+            }
+        }
+
+        if (sourceValues.length === 0) {
+            return;
+        }
+
+        const sourceChunks = this.chunkValues(sourceValues, 500);
+        const compiledPrefetch = compiler.compilePrefetch(node, sourceChunks[0]!);
+        if (compiledPrefetch.kind === InternalPrefetchQueryKind.MANY_TO_MANY) {
+            const idsByOwner = new Map<string | number, Array<string | number>>();
+            const uniqueTargetIds = new Set<string | number>();
+
+            for (const chunk of sourceChunks) {
+                const chunkCompiled = compiler.compilePrefetch(node, chunk) as Extract<
+                    typeof compiledPrefetch,
+                    { kind: typeof InternalPrefetchQueryKind.MANY_TO_MANY }
+                >;
+                const throughResult = await this.executor.client.query<Record<string, unknown>>(
+                    chunkCompiled.throughSql,
+                    chunkCompiled.throughParams
+                );
+
+                for (const row of throughResult.rows) {
+                    const ownerId = row[chunkCompiled.ownerAlias];
+                    const targetId = row[chunkCompiled.targetAlias];
+                    if (
+                        (typeof ownerId !== 'string' && typeof ownerId !== 'number') ||
+                        (typeof targetId !== 'string' && typeof targetId !== 'number')
+                    ) {
+                        continue;
+                    }
+                    const bucket = idsByOwner.get(ownerId) ?? [];
+                    bucket.push(targetId);
+                    idsByOwner.set(ownerId, bucket);
+                    uniqueTargetIds.add(targetId);
+                }
+            }
+
+            const targets: Record<string | number, Record<string, unknown>> = {};
+            const targetIds = [...uniqueTargetIds.values()];
+            if (targetIds.length > 0) {
+                for (const targetChunk of this.chunkValues(targetIds, 500)) {
+                    const targetQuery = compiler.compileManyToManyTargets(node, targetChunk);
+                    const targetResult = await this.executor.client.query<Record<string, unknown>>(
+                        targetQuery.sql,
+                        targetQuery.params
+                    );
+
+                    for (const rawTargetRow of targetResult.rows) {
+                        const normalized = this.normalizer.normalizeTargetRow(
+                            rawTargetRow,
+                            compiledPrefetch.targetColumns
+                        );
+                        const canonical = registry.canonicalize(node, normalized);
+                        this.hydrateJoinNodesForOwner(canonical, normalized, node.joinChildren, registry);
+                        const primaryKey = canonical[node.targetPrimaryKey];
+                        if (typeof primaryKey === 'string' || typeof primaryKey === 'number') {
+                            targets[primaryKey] = canonical;
+                        }
+                    }
+                }
+            }
+
+            const canonicalChildren = new Map<string | number, Record<string, unknown>>();
+            const handledOwners = new Set<Record<string, unknown>>();
+            for (const [ownerId, ids] of idsByOwner.entries()) {
+                const bucket = ids
+                    .map((id) => targets[id])
+                    .filter((value): value is Record<string, unknown> => !!value);
+                for (const owner of groupedOwners.get(ownerId) ?? []) {
+                    this.primeManyToManyOwnerCache(owner, node.relationName, bucket);
+                    handledOwners.add(owner);
+                }
+                for (const child of bucket) {
+                    canonicalChildren.set(child[node.targetPrimaryKey] as string | number, child);
+                }
+            }
+            for (const owner of owners) {
+                if (!handledOwners.has(owner)) {
+                    this.primeManyToManyOwnerCache(owner, node.relationName, []);
+                }
+            }
+
+            const childOwners = [...canonicalChildren.values()];
+            for (const childNode of node.prefetchChildren) {
+                await this.hydratePrefetchNode(childNode, childOwners, registry, compiler);
+            }
+            return;
+        }
+
+        const canonicalChildren = new Map<string | number, Record<string, unknown>>();
+        for (const chunk of sourceChunks) {
+            const chunkCompiled = compiler.compilePrefetch(node, chunk) as Extract<
+                typeof compiledPrefetch,
+                { kind: typeof InternalPrefetchQueryKind.DIRECT }
+            >;
+            const result = await this.executor.client.query<Record<string, unknown>>(
+                chunkCompiled.sql,
+                chunkCompiled.params
+            );
+
+            for (const rawResultRow of result.rows) {
+                const normalized = this.normalizer.normalizeTargetRow(rawResultRow, chunkCompiled.targetColumns);
+                const canonical = registry.canonicalize(node, normalized);
+                this.hydrateJoinNodesForOwner(canonical, normalized, node.joinChildren, registry);
+
+                const key = normalized[chunkCompiled.targetKey];
+                if (typeof key !== 'string' && typeof key !== 'number') {
+                    continue;
+                }
+
+                for (const owner of groupedOwners.get(key) ?? []) {
+                    if (node.cardinality === InternalRelationHydrationCardinality.MANY) {
+                        (owner[node.relationName] as Record<string, unknown>[]).push(canonical);
+                    } else if (owner[node.relationName] === null) {
+                        owner[node.relationName] = canonical;
+                    }
+                }
+
+                const childPrimaryKey = canonical[node.targetPrimaryKey];
+                if (typeof childPrimaryKey === 'string' || typeof childPrimaryKey === 'number') {
+                    canonicalChildren.set(childPrimaryKey, canonical);
+                }
+            }
+        }
+
+        const childOwners = [...canonicalChildren.values()];
+        for (const childNode of node.prefetchChildren) {
+            await this.hydratePrefetchNode(childNode, childOwners, registry, compiler);
+        }
+    }
+
+    private primeManyToManyOwnerCache(
+        owner: Record<string, unknown>,
+        relationName: string,
+        bucket: readonly Record<string, unknown>[]
+    ): void {
+        const existing = owner[relationName];
+        if (existing && typeof (existing as { primePrefetchCache?: unknown }).primePrefetchCache === 'function') {
+            (existing as { primePrefetchCache: (rows: readonly Record<string, unknown>[]) => void }).primePrefetchCache(
+                bucket
+            );
+            return;
+        }
+        owner[relationName] = bucket.slice();
+    }
+
+    private chunkValues<T>(values: readonly T[], size: number): T[][] {
+        if (values.length <= size) {
+            return [Array.from(values)];
+        }
+        const chunks: T[][] = [];
+        for (let i = 0; i < values.length; i += size) {
+            chunks.push(values.slice(i, i + size) as T[]);
+        }
+        return chunks;
+    }
+
+    private groupOwnersByAccessor(
+        owners: readonly Record<string, unknown>[],
+        accessor: string
+    ): Map<string | number, Record<string, unknown>[]> {
+        const grouped = new Map<string | number, Record<string, unknown>[]>();
+
+        for (const owner of owners) {
+            const key = owner[accessor];
+            if (typeof key !== 'string' && typeof key !== 'number') {
+                continue;
+            }
+            const bucket = grouped.get(key) ?? [];
+            bucket.push(owner);
+            grouped.set(key, bucket);
+        }
+
+        return grouped;
+    }
+}

--- a/packages/orm/src/query/hydration/QueryRowNormalizerStrategy.ts
+++ b/packages/orm/src/query/hydration/QueryRowNormalizerStrategy.ts
@@ -1,0 +1,113 @@
+import type { Dialect } from '../domain/Dialect';
+import { InternalDialect as InternalDialectValue } from '../domain/internal/InternalDialect';
+
+export type QueryRowColumnMap = Record<string, string>;
+
+export interface QueryRowNormalizerStrategy {
+    normalizeRootRows<TRow extends Record<string, unknown>>(rows: readonly TRow[], columns: QueryRowColumnMap): TRow[];
+    normalizeHydratedRowsForParserShape<TRow extends Record<string, unknown>>(
+        rows: readonly TRow[],
+        columns: QueryRowColumnMap
+    ): TRow[];
+    normalizeTargetRow(row: Record<string, unknown>, targetColumns: QueryRowColumnMap): Record<string, unknown>;
+    normalizeColumnValue(columnType: string | undefined, value: unknown): unknown;
+}
+
+export class PassthroughQueryRowNormalizerStrategy implements QueryRowNormalizerStrategy {
+    normalizeRootRows<TRow extends Record<string, unknown>>(
+        rows: readonly TRow[],
+        _columns: QueryRowColumnMap
+    ): TRow[] {
+        return [...rows];
+    }
+
+    normalizeHydratedRowsForParserShape<TRow extends Record<string, unknown>>(
+        rows: readonly TRow[],
+        _columns: QueryRowColumnMap
+    ): TRow[] {
+        return [...rows];
+    }
+
+    normalizeTargetRow(row: Record<string, unknown>, _targetColumns: QueryRowColumnMap): Record<string, unknown> {
+        return row;
+    }
+
+    normalizeColumnValue(_columnType: string | undefined, value: unknown): unknown {
+        return value;
+    }
+}
+
+export function createQueryRowNormalizerStrategy(dialect: Dialect): QueryRowNormalizerStrategy {
+    return dialect === InternalDialectValue.SQLITE
+        ? new SqliteRowNormalizerStrategy()
+        : new PassthroughQueryRowNormalizerStrategy();
+}
+
+export class SqliteRowNormalizerStrategy implements QueryRowNormalizerStrategy {
+    normalizeRootRows<TRow extends Record<string, unknown>>(rows: readonly TRow[], columns: QueryRowColumnMap): TRow[] {
+        return this.normalizeRows(rows, columns);
+    }
+
+    normalizeHydratedRowsForParserShape<TRow extends Record<string, unknown>>(
+        rows: readonly TRow[],
+        columns: QueryRowColumnMap
+    ): TRow[] {
+        return this.normalizeRows(rows, columns);
+    }
+
+    normalizeTargetRow(row: Record<string, unknown>, targetColumns: QueryRowColumnMap): Record<string, unknown> {
+        return this.normalizeRow(row, this.booleanColumns(targetColumns));
+    }
+
+    normalizeColumnValue(columnType: string | undefined, value: unknown): unknown {
+        return this.isBooleanColumnType(columnType) ? this.normalizeSqliteBoolean(value) : value;
+    }
+
+    private normalizeRows<TRow extends Record<string, unknown>>(
+        rows: readonly TRow[],
+        columns: QueryRowColumnMap
+    ): TRow[] {
+        const booleanColumns = this.booleanColumns(columns);
+        if (booleanColumns.length === 0) {
+            return [...rows];
+        }
+
+        return rows.map((row) => this.normalizeRow(row, booleanColumns));
+    }
+
+    private normalizeRow<TRow extends Record<string, unknown>>(row: TRow, columns: readonly string[]): TRow {
+        let normalized: TRow | null = null;
+
+        for (const column of columns) {
+            const current = row[column];
+            const next = this.normalizeSqliteBoolean(current);
+            if (next === current) {
+                continue;
+            }
+            normalized ??= { ...row };
+            (normalized as Record<string, unknown>)[column] = next;
+        }
+
+        return normalized ?? row;
+    }
+
+    private booleanColumns(columns: QueryRowColumnMap): string[] {
+        return Object.entries(columns)
+            .filter(([, value]) => this.isBooleanColumnType(value))
+            .map(([column]) => column);
+    }
+
+    private isBooleanColumnType(value: unknown): boolean {
+        return typeof value === 'string' && ['bool', 'boolean'].includes(value.trim().toLowerCase());
+    }
+
+    private normalizeSqliteBoolean(value: unknown): unknown {
+        if (value === 0 || value === '0') {
+            return false;
+        }
+        if (value === 1 || value === '1') {
+            return true;
+        }
+        return value;
+    }
+}

--- a/packages/orm/src/query/hydration/tests/HydrationEntityRegistry.test.ts
+++ b/packages/orm/src/query/hydration/tests/HydrationEntityRegistry.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import { InternalRelationHydrationLoadMode } from '../../domain/RelationMeta';
+import { InternalRelationHydrationCardinality } from '../../domain/RelationTyping';
+import type { CompiledHydrationNode } from '../../domain/CompiledQuery';
+import { HydrationEntityRegistry } from '../HydrationEntityRegistry';
+
+const baseNode = {
+    nodeId: 'team',
+    relationName: 'team',
+    relationPath: 'team',
+    ownerModelKey: 'tests/User',
+    targetModelKey: 'tests/Team',
+    loadMode: InternalRelationHydrationLoadMode.JOIN,
+    cardinality: InternalRelationHydrationCardinality.SINGLE,
+    sourceKey: 'team_id',
+    ownerSourceAccessor: 'team_id',
+    targetKey: 'id',
+    targetTable: 'teams',
+    targetPrimaryKey: 'id',
+    targetColumns: { id: 'int', name: 'text' },
+    provenance: ['team'],
+    joinChildren: [],
+    prefetchChildren: [],
+} satisfies CompiledHydrationNode;
+
+describe(HydrationEntityRegistry, () => {
+    it('reuses records by target model and primary key', () => {
+        const attachPersistedRecordAccessors = vi.fn();
+        const registry = new HydrationEntityRegistry(attachPersistedRecordAccessors);
+
+        const first = registry.canonicalize(baseNode, { id: 1, name: 'Core' });
+        const second = registry.canonicalize(baseNode, { id: 1, name: 'Platform' });
+
+        expect(second).toBe(first);
+        expect(first).toEqual({ id: 1, name: 'Platform' });
+        expect(attachPersistedRecordAccessors).toHaveBeenCalledOnce();
+        expect(attachPersistedRecordAccessors).toHaveBeenCalledWith(first, 'tests/Team');
+    });
+
+    it('leaves records without stable primary keys uncached', () => {
+        const attachPersistedRecordAccessors = vi.fn();
+        const registry = new HydrationEntityRegistry(attachPersistedRecordAccessors);
+        const first = { id: null, name: 'Draft' };
+        const second = { id: null, name: 'Draft' };
+
+        expect(registry.canonicalize(baseNode, first)).toBe(first);
+        expect(registry.canonicalize(baseNode, second)).toBe(second);
+        expect(attachPersistedRecordAccessors).not.toHaveBeenCalled();
+    });
+
+    it('narrows unknown values with a brand guard', () => {
+        expect(HydrationEntityRegistry.isHydrationEntityRegistry(new HydrationEntityRegistry())).toBe(true);
+        expect(HydrationEntityRegistry.isHydrationEntityRegistry({})).toBe(false);
+    });
+});

--- a/packages/orm/src/query/hydration/tests/QueryHydrator.test.ts
+++ b/packages/orm/src/query/hydration/tests/QueryHydrator.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from 'vitest';
+import { aQueryExecutor } from '@danceroutine/tango-testing';
+import type { CompiledHydrationNode, CompiledQuery } from '../../domain/CompiledQuery';
+import { InternalRelationHydrationLoadMode } from '../../domain/RelationMeta';
+import { InternalRelationHydrationCardinality } from '../../domain/RelationTyping';
+import type { TableMeta } from '../../domain/TableMeta';
+import { QueryHydrator } from '../QueryHydrator';
+
+const meta: TableMeta = {
+    table: 'users',
+    pk: 'id',
+    columns: {
+        id: 'int',
+        email: 'text',
+    },
+};
+
+function compiledWithHydration(hydrationPlan: NonNullable<CompiledQuery['hydrationPlan']>): CompiledQuery {
+    return {
+        sql: 'SELECT * FROM users',
+        params: [],
+        hydrationPlan,
+    };
+}
+
+function prefetchNode(overrides: Partial<CompiledHydrationNode> = {}): CompiledHydrationNode {
+    return {
+        nodeId: 'profile',
+        relationName: 'profile',
+        relationPath: 'profile',
+        ownerModelKey: 'tests/User',
+        targetModelKey: 'tests/Profile',
+        loadMode: InternalRelationHydrationLoadMode.PREFETCH,
+        cardinality: InternalRelationHydrationCardinality.SINGLE,
+        sourceKey: 'id',
+        ownerSourceAccessor: 'id',
+        targetKey: 'owner_id',
+        targetTable: 'profiles',
+        targetPrimaryKey: 'id',
+        targetColumns: { id: 'int', owner_id: 'int', email: 'text' },
+        provenance: ['profile'],
+        joinChildren: [],
+        prefetchChildren: [],
+        ...overrides,
+    };
+}
+
+describe(QueryHydrator, () => {
+    it('materializes unhydrated rows and attaches root accessors', async () => {
+        const attachPersistedRecordAccessors = vi.fn();
+        const queryExecutor = aQueryExecutor<Record<string, unknown>>({
+            meta,
+            attachPersistedRecordAccessors,
+        });
+        const hydrator = new QueryHydrator(queryExecutor);
+
+        const rows = await hydrator.materializeRows([{ id: 1, email: 'a@example.com' }], {
+            sql: 'SELECT * FROM users',
+            params: [],
+        });
+
+        expect(rows).toEqual([{ id: 1, email: 'a@example.com' }]);
+        expect(attachPersistedRecordAccessors).toHaveBeenCalledWith(rows[0], undefined);
+    });
+
+    it('skips join nodes without compiled join descriptors', async () => {
+        const queryExecutor = aQueryExecutor<Record<string, unknown>>({ meta });
+        const hydrator = new QueryHydrator(queryExecutor);
+
+        const rows = await hydrator.materializeRows(
+            [{ id: 1, email: 'a@example.com' }],
+            compiledWithHydration({
+                requestedPaths: ['team'],
+                hiddenRootAliases: [],
+                joinNodes: [
+                    prefetchNode({
+                        nodeId: 'team',
+                        relationName: 'team',
+                        relationPath: 'team',
+                        loadMode: InternalRelationHydrationLoadMode.JOIN,
+                    }),
+                ],
+                prefetchNodes: [],
+            })
+        );
+
+        expect(rows).toEqual([{ id: 1, email: 'a@example.com' }]);
+    });
+
+    it('no-ops empty prefetch owner batches', async () => {
+        const query = vi.fn(async () => ({ rows: [] as Record<string, unknown>[] }));
+        const queryExecutor = aQueryExecutor<Record<string, unknown>>({ meta, query });
+        const hydrator = new QueryHydrator(queryExecutor);
+
+        const rows = await hydrator.materializeRows(
+            [],
+            compiledWithHydration({
+                requestedPaths: ['profile'],
+                hiddenRootAliases: [],
+                joinNodes: [],
+                prefetchNodes: [prefetchNode()],
+            })
+        );
+
+        expect(rows).toEqual([]);
+        expect(query).not.toHaveBeenCalled();
+    });
+
+    it('hydrates a single-valued prefetch node with the first matching child', async () => {
+        const query = vi.fn(async () => ({
+            rows: [
+                { id: 10, owner_id: 1, email: 'team@example.com' },
+                { id: 11, owner_id: 1, email: 'other@example.com' },
+                { id: null, owner_id: 1, email: 'ignored@example.com' },
+            ],
+        }));
+        const queryExecutor = aQueryExecutor<Record<string, unknown>>({ meta, query });
+        const hydrator = new QueryHydrator(queryExecutor);
+
+        const rows = await hydrator.materializeRows(
+            [{ id: 1, email: 'a@example.com' }],
+            compiledWithHydration({
+                requestedPaths: ['profile'],
+                hiddenRootAliases: [],
+                joinNodes: [],
+                prefetchNodes: [prefetchNode()],
+            })
+        );
+
+        expect(rows).toEqual([
+            {
+                id: 1,
+                email: 'a@example.com',
+                profile: { id: 10, owner_id: 1, email: 'team@example.com' },
+            },
+        ]);
+    });
+
+    it('chunks prefetch owner ids deterministically', async () => {
+        const owners = Array.from({ length: 501 }, (_, index) => ({ id: index + 1 }));
+        const query = vi.fn(async () => ({ rows: [] as Record<string, unknown>[] }));
+        const queryExecutor = aQueryExecutor<Record<string, unknown>>({ meta, query });
+        const hydrator = new QueryHydrator(queryExecutor);
+
+        const rows = await hydrator.materializeRows(
+            owners,
+            compiledWithHydration({
+                requestedPaths: ['posts'],
+                hiddenRootAliases: [],
+                joinNodes: [],
+                prefetchNodes: [
+                    prefetchNode({
+                        nodeId: 'posts',
+                        relationName: 'posts',
+                        relationPath: 'posts',
+                        cardinality: InternalRelationHydrationCardinality.MANY,
+                        targetTable: 'posts',
+                        targetPrimaryKey: 'id',
+                        targetColumns: { id: 'int', owner_id: 'int' },
+                    }),
+                ],
+            })
+        );
+
+        expect(rows[0]).toEqual({ id: 1, posts: [] });
+        expect(rows.at(-1)).toEqual({ id: 501, posts: [] });
+        expect(query).toHaveBeenCalledTimes(2);
+    });
+
+    it('narrows unknown values with a brand guard', () => {
+        const queryExecutor = aQueryExecutor<Record<string, unknown>>({ meta });
+
+        expect(QueryHydrator.isQueryHydrator(new QueryHydrator(queryExecutor))).toBe(true);
+        expect(QueryHydrator.isQueryHydrator({})).toBe(false);
+    });
+});

--- a/packages/orm/src/query/hydration/tests/SqliteRowNormalizerStrategy.test.ts
+++ b/packages/orm/src/query/hydration/tests/SqliteRowNormalizerStrategy.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+    createQueryRowNormalizerStrategy,
+    PassthroughQueryRowNormalizerStrategy,
+    SqliteRowNormalizerStrategy,
+} from '../QueryRowNormalizerStrategy';
+
+describe(SqliteRowNormalizerStrategy, () => {
+    it('normalizes root and parser rows from sqlite boolean storage values', () => {
+        const strategy = new SqliteRowNormalizerStrategy();
+        const rows = [{ id: 1, active: 1, archived: '0', count: 2 }];
+        const columns = { id: 'int', active: 'bool', archived: 'boolean', count: 'int' };
+
+        expect(strategy.normalizeRootRows(rows, columns)).toEqual([{ id: 1, active: true, archived: false, count: 2 }]);
+        expect(strategy.normalizeHydratedRowsForParserShape(rows, columns)).toEqual([
+            { id: 1, active: true, archived: false, count: 2 },
+        ]);
+    });
+
+    it('normalizes joined and prefetched target rows from target column metadata', () => {
+        const strategy = new SqliteRowNormalizerStrategy();
+
+        expect(strategy.normalizeTargetRow({ id: 1, enabled: '1' }, { id: 'int', enabled: 'bool' })).toEqual({
+            id: 1,
+            enabled: true,
+        });
+        expect(strategy.normalizeColumnValue('boolean', 0)).toBe(false);
+        expect(strategy.normalizeColumnValue('text', 1)).toBe(1);
+    });
+
+    it('returns copies when there are no sqlite boolean columns', () => {
+        const strategy = new SqliteRowNormalizerStrategy();
+        const rows = [{ id: 1, active: 1 }];
+        const normalized = strategy.normalizeRootRows(rows, { id: 'int', active: 'int' });
+
+        expect(normalized).toEqual(rows);
+        expect(normalized).not.toBe(rows);
+        expect(normalized[0]).toBe(rows[0]);
+    });
+});
+
+describe(PassthroughQueryRowNormalizerStrategy, () => {
+    it('preserves row objects for non-sqlite dialects', () => {
+        const strategy = new PassthroughQueryRowNormalizerStrategy();
+        const rows = [{ id: 1, active: 1 }];
+
+        expect(strategy.normalizeRootRows(rows, { active: 'bool' })).toEqual(rows);
+        expect(strategy.normalizeRootRows(rows, { active: 'bool' })[0]).toBe(rows[0]);
+        expect(strategy.normalizeTargetRow(rows[0]!, { active: 'bool' })).toBe(rows[0]);
+        expect(strategy.normalizeColumnValue('bool', 1)).toBe(1);
+    });
+});
+
+describe(createQueryRowNormalizerStrategy, () => {
+    it('selects a sqlite strategy only for sqlite adapters', () => {
+        expect(createQueryRowNormalizerStrategy('sqlite')).toBeInstanceOf(SqliteRowNormalizerStrategy);
+        expect(createQueryRowNormalizerStrategy('postgres')).toBeInstanceOf(PassthroughQueryRowNormalizerStrategy);
+    });
+});

--- a/packages/orm/src/query/tests/QuerySet.test.ts
+++ b/packages/orm/src/query/tests/QuerySet.test.ts
@@ -8,7 +8,6 @@ import { QBuilder as Q } from '../QBuilder';
 import type { HydratedQueryResult } from '../domain/RelationTyping';
 import type { TableMeta } from '../domain/TableMeta';
 import type { CompiledQuery } from '../domain/CompiledQuery';
-import { InternalPrefetchQueryKind } from '../domain/internal/InternalPrefetchQueryKind';
 import { InternalRelationKind } from '../domain/internal/InternalRelationKind';
 
 type User = {
@@ -627,103 +626,6 @@ describe(QuerySet, () => {
         expect(result.results).toEqual([{ id: 1, author: { id: 99, email: 'a@a.com' } }]);
     });
 
-    it('skips join nodes without compiled join descriptors and no-ops empty prefetch owner batches', async () => {
-        const queryExecutor = aQueryExecutor<Record<string, unknown>>({ meta: relatedMeta });
-        const querySet = new ModelQuerySet<Record<string, unknown>>(queryExecutor) as unknown as {
-            hydrateJoinNodesForOwner: (
-                owner: Record<string, unknown>,
-                rawRow: Record<string, unknown>,
-                nodes: readonly Record<string, unknown>[],
-                canonicalEntities: Map<string, Map<string | number, Record<string, unknown>>>
-            ) => void;
-            hydratePrefetchNode: (
-                node: Record<string, unknown>,
-                owners: readonly Record<string, unknown>[],
-                canonicalEntities: Map<string, Map<string | number, Record<string, unknown>>>,
-                compiler: unknown
-            ) => Promise<void>;
-        };
-        const owner = { id: 1 };
-
-        querySet.hydrateJoinNodesForOwner(
-            owner,
-            { ...owner },
-            [
-                {
-                    relationName: 'team',
-                    targetColumns: {},
-                },
-            ],
-            new Map()
-        );
-        await expect(
-            querySet.hydratePrefetchNode(
-                {
-                    relationName: 'posts',
-                    cardinality: 'many',
-                    ownerSourceAccessor: 'id',
-                },
-                [],
-                new Map(),
-                {}
-            )
-        ).resolves.toBeUndefined();
-        expect(owner).toEqual({ id: 1 });
-    });
-
-    it('can attach a private single-valued prefetch node for internal recursion branches', async () => {
-        const query = vi.fn(async () => ({
-            rows: [
-                { id: 10, owner_id: 1, email: 'team@example.com' },
-                { id: 11, owner_id: 1, email: 'other@example.com' },
-                { id: null, owner_id: 1, email: 'ignored@example.com' },
-            ],
-        }));
-        const queryExecutor = aQueryExecutor<Record<string, unknown>>({ meta: relatedMeta, query });
-        const querySet = new ModelQuerySet<Record<string, unknown>>(queryExecutor) as unknown as {
-            hydratePrefetchNode: (
-                node: Record<string, unknown>,
-                owners: readonly Record<string, unknown>[],
-                canonicalEntities: Map<string, Map<string | number, Record<string, unknown>>>,
-                compiler: {
-                    compilePrefetch: () => {
-                        kind: typeof InternalPrefetchQueryKind.DIRECT;
-                        sql: string;
-                        params: readonly unknown[];
-                        targetKey: string;
-                        targetColumns: Record<string, string>;
-                    };
-                }
-            ) => Promise<void>;
-        };
-        const owners = [{ id: 1 }] as Record<string, unknown>[];
-
-        await querySet.hydratePrefetchNode(
-            {
-                relationName: 'profile',
-                cardinality: 'single',
-                ownerSourceAccessor: 'id',
-                targetPrimaryKey: 'id',
-                targetModelKey: 'tests/Profile',
-                joinChildren: [],
-                prefetchChildren: [],
-            },
-            owners,
-            new Map(),
-            {
-                compilePrefetch: () => ({
-                    kind: InternalPrefetchQueryKind.DIRECT,
-                    sql: 'SELECT * FROM profiles WHERE owner_id IN ($1)',
-                    params: [1],
-                    targetKey: 'owner_id',
-                    targetColumns: { id: 'int', owner_id: 'int', email: 'text' },
-                }),
-            }
-        );
-
-        expect(owners).toEqual([{ id: 1, profile: { id: 10, owner_id: 1, email: 'team@example.com' } }]);
-    });
-
     it('rejects relation hydration collisions and unsupported hydration paths', async () => {
         const collisionMeta: TableMeta = {
             ...relatedMeta,
@@ -864,17 +766,6 @@ describe(QuerySet, () => {
         expect(first.map((tag) => tag.id)).toEqual([10, 10, 11]);
         expect(first[0]).toBe(first[1]);
         expect(query).toHaveBeenCalledWith(expect.stringContaining('FROM posts'), expect.anything());
-    });
-
-    it('chunks prefetch owner ids deterministically', async () => {
-        const queryExecutor = aQueryExecutor<Record<string, unknown>>({ meta: relatedMeta });
-        const querySet = new ModelQuerySet<Record<string, unknown>>(queryExecutor) as unknown as {
-            chunkValues: <T>(values: readonly T[], size: number) => T[][];
-        };
-
-        expect(querySet.chunkValues([], 2)).toEqual([]);
-        expect(querySet.chunkValues([1, 2], 2)).toEqual([[1, 2]]);
-        expect(querySet.chunkValues([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
     });
 
     it('primes the prefetch cache on attached managers when many-to-many rows are hydrated', async () => {
@@ -1322,47 +1213,6 @@ describe(QuerySet, () => {
         expect(await qs.first((row) => row.email)).toBe('first@a.com');
         expect(await qs.first(parser)).toEqual({ id: 1 });
         expect(parser.parse).toHaveBeenCalledWith({ id: 1, email: 'first@a.com', active: true });
-    });
-
-    it('falls back to the hydrated row when parser-shape normalization yields no replacement row', async () => {
-        const { queryExecutor } = createQueryExecutorFixture(
-            [{ id: 9, email: 'fallback@a.com', active: true }],
-            'sqlite'
-        );
-        const qs = new ModelQuerySet<User>(queryExecutor);
-        const parser = { parse: vi.fn((row: User) => ({ id: row.id, email: row.email })) };
-
-        (
-            qs as unknown as {
-                normalizeHydratedRowsForParserShape: (rows: readonly User[]) => Array<User>;
-            }
-        ).normalizeHydratedRowsForParserShape = vi.fn(() => []);
-
-        expect(await qs.first(parser)).toEqual({ id: 9, email: 'fallback@a.com' });
-        expect(parser.parse).toHaveBeenCalledWith({ id: 9, email: 'fallback@a.com', active: true });
-    });
-
-    it('uses the original row when shapeFetchedRow cannot read a normalized parser row', () => {
-        const { queryExecutor } = createQueryExecutorFixture(
-            [{ id: 10, email: 'direct@a.com', active: true }],
-            'sqlite'
-        );
-        const qs = new ModelQuerySet<User>(queryExecutor);
-        const parser = { parse: vi.fn((row: User) => row.email) };
-
-        (
-            qs as unknown as {
-                normalizeHydratedRowsForParserShape: (rows: readonly User[]) => Array<User>;
-                shapeFetchedRow: (row: User, shape: typeof parser) => string;
-            }
-        ).normalizeHydratedRowsForParserShape = vi.fn(() => []);
-
-        const shaped = (
-            qs as unknown as { shapeFetchedRow: (row: User, shape: typeof parser) => string }
-        ).shapeFetchedRow({ id: 10, email: 'direct@a.com', active: true }, parser);
-
-        expect(shaped).toBe('direct@a.com');
-        expect(parser.parse).toHaveBeenCalledWith({ id: 10, email: 'direct@a.com', active: true });
     });
 
     it('returns last() from the current page when limit or offset are already applied', async () => {

--- a/packages/testing/src/mocks/aManyToManyRelatedManager.ts
+++ b/packages/testing/src/mocks/aManyToManyRelatedManager.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest';
 import type { QueryExecutor } from '@danceroutine/tango-orm';
 import { ManyToManyRelatedManager } from '@danceroutine/tango-orm';
+import { aQueryExecutor } from './aQueryExecutor';
 
 type ManagerConstructorInputs = ConstructorParameters<typeof ManyToManyRelatedManager>[0];
 
@@ -91,7 +92,7 @@ export function aManyToManyRelatedManager<TTarget extends Record<string, unknown
         targetPrimaryKeyField: overrides.targetPrimaryKeyField ?? 'id',
         throughTableManager,
         targetExecutorProvider: () =>
-            overrides.targetExecutor === undefined ? ({} as QueryExecutor<TTarget>) : overrides.targetExecutor,
+            overrides.targetExecutor === undefined ? aQueryExecutor<TTarget>() : overrides.targetExecutor,
         createTarget,
         runAtomic: runAtomicSpy as ManagerConstructorInputs['runAtomic'],
     });


### PR DESCRIPTION
## Summary
- Move QuerySet relation hydration, canonicalization, and prefetch execution into internal hydration collaborators
- Keep root/parser row normalization strategy ownership in QuerySet while sharing the strategy with hydration for target rows
- Move private-method coverage into symbol-scoped hydration tests

## Validation
- pnpm --filter @danceroutine/tango-orm exec vitest run src/query/tests/QuerySet.test.ts src/query/hydration/tests
- pnpm --filter @danceroutine/tango-orm exec tsc --noEmit --ignoreDeprecations 5.0 -p tsconfig.json
- pnpm --filter @danceroutine/tango-orm exec tsc --noEmit --ignoreDeprecations 5.0 -p tsconfig.tests.json
- pnpm --filter @danceroutine/tango-orm test
- pnpm exec prettier --check packages/orm/src/query/QuerySet.ts packages/orm/src/query/tests/QuerySet.test.ts packages/orm/src/query/hydration/QueryHydrator.ts packages/orm/src/query/hydration/HydrationEntityRegistry.ts packages/orm/src/query/hydration/QueryRowNormalizerStrategy.ts packages/orm/src/query/hydration/tests/QueryHydrator.test.ts packages/orm/src/query/hydration/tests/HydrationEntityRegistry.test.ts packages/orm/src/query/hydration/tests/SqliteRowNormalizerStrategy.test.ts