### PR TITLE
fix: use platform paths in codegen new and init commands

### DIFF
--- a/.changeset/windows-codegen-paths.md
+++ b/.changeset/windows-codegen-paths.md
@@ -1,0 +1,5 @@
+---
+"@danceroutine/tango-codegen": patch
+---
+
+`tango new` and `tango init` now resolve target directories with platform-native path handling, so scaffolding works correctly on Windows when users pass relative paths or drive-letter paths.

--- a/packages/codegen/src/commands/runInitCommand.ts
+++ b/packages/codegen/src/commands/runInitCommand.ts
@@ -1,6 +1,6 @@
 import { getLogger } from '@danceroutine/tango-core';
 import { readdir, readFile } from 'fs/promises';
-import { resolve, basename, join } from 'path/posix';
+import { basename, join, resolve } from 'node:path';
 import {
     type PackageManager,
     type SupportedFramework,

--- a/packages/codegen/src/commands/runNewCommand.ts
+++ b/packages/codegen/src/commands/runNewCommand.ts
@@ -1,5 +1,5 @@
 import { getLogger } from '@danceroutine/tango-core';
-import { basename, resolve } from 'path/posix';
+import { basename, resolve } from 'node:path';
 import {
     type SupportedFramework,
     type PackageManager,


### PR DESCRIPTION
## Summary

- Switch `runNewCommand` and `runInitCommand` from `path/posix` to `node:path` for filesystem path resolution
- Fixes scaffolding on Windows when users pass relative paths or drive-letter paths via `tango new` and `tango init`
- Adds a patch changeset for `@danceroutine/tango-codegen`

## Test plan

- [x] `pnpm --filter @danceroutine/tango-codegen test -- runInitCommand --coverage.enabled=false` (8/8 passed)