### PR TITLE
fix(orm): align exists() limit and offset with fetch window

### DIFF
--- a/.changeset/exists-query-window.md
+++ b/.changeset/exists-query-window.md
@@ -1,0 +1,5 @@
+---
+'@danceroutine/tango-orm': patch
+---
+
+Fix `QuerySet.exists()` so `limit(0)` and `offset` use the same query window as `fetch()` and `count()`, while keeping the `SELECT 1 ... LIMIT 1` existence probe for performance optimization.

--- a/packages/orm/src/query/compiler/QueryCompiler.ts
+++ b/packages/orm/src/query/compiler/QueryCompiler.ts
@@ -21,7 +21,11 @@ import { InternalLookupType } from '../domain/internal/InternalLookupType';
 import { InternalSqlValidationPlanKind as SqlPlanKind } from '../../validation/internal/InternalSqlValidationPlanKind';
 import { InternalValidatedFilterDescriptorKind } from '../../validation/internal/InternalValidatedFilterDescriptorKind';
 import { OrmSqlSafetyAdapter } from '../../validation';
-import type { ValidatedFilterDescriptor, ValidatedRelationMeta } from '../../validation/SQLValidationEngine';
+import type {
+    ValidatedFilterDescriptor,
+    ValidatedRelationMeta,
+    ValidatedSelectSqlPlan,
+} from '../../validation/SQLValidationEngine';
 import { QueryPlanner } from '../planning';
 import type { QueryHydrationPlanNode } from '../planning';
 
@@ -126,21 +130,7 @@ export class QueryCompiler {
             ...this.buildRootHiddenSelects(compiledPrefetchNodes, table),
         ].join(', ');
         const whereSQL = whereParts.length ? ` WHERE ${whereParts.join(' AND ')}` : '';
-        const orderSQL = ` ORDER BY ${
-            state.order?.length
-                ? state.order
-                      .map((order) => `${validatedPlan.orderFields[String(order.by)]!} ${order.dir.toUpperCase()}`)
-                      .join(', ')
-                : `${table}.${validatedPlan.meta.pk} ASC`
-        }`;
-        const hasOffset = state.offset !== undefined;
-        const limitSQL =
-            state.limit !== undefined
-                ? ` LIMIT ${state.limit}`
-                : hasOffset && this.adapter.dialect === InternalDialect.SQLITE
-                  ? ' LIMIT -1'
-                  : '';
-        const offsetSQL = state.offset !== undefined ? ` OFFSET ${state.offset}` : '';
+        const { orderSQL, limitSQL, offsetSQL } = this.buildQueryWindowSuffix(state, validatedPlan, table);
         const sql = `SELECT ${select} FROM ${table}${joinCollection.joins.length ? ` ${joinCollection.joins.join(' ')}` : ''}${whereSQL}${orderSQL}${limitSQL}${offsetSQL}`;
 
         const compiledHydrationPlan: CompiledHydrationPlanRoot | undefined =
@@ -194,9 +184,18 @@ export class QueryCompiler {
         });
 
         const whereSQL = whereParts.length ? ` WHERE ${whereParts.join(' AND ')}` : '';
-        const offsetSQL = state.offset ? ` OFFSET ${state.offset}` : '';
+        if (state.limit === undefined && state.offset === undefined) {
+            return {
+                sql: `SELECT 1 AS tango_exists FROM ${table}${whereSQL} LIMIT 1`,
+                params,
+            };
+        }
+
+        const { orderSQL, limitSQL, offsetSQL } = this.buildQueryWindowSuffix(state, validatedPlan, table, {
+            existsProbe: state.offset !== undefined,
+        });
         return {
-            sql: `SELECT 1 AS tango_exists FROM ${table}${whereSQL} LIMIT 1${offsetSQL}`,
+            sql: `SELECT 1 AS tango_exists FROM ${table}${whereSQL}${orderSQL}${limitSQL}${offsetSQL}`,
             params,
         };
     }
@@ -243,6 +242,33 @@ export class QueryCompiler {
             sql: `SELECT ${[...baseSelects, ...joinCollection.selects].join(', ')} FROM ${validatedTarget.table} ${baseAlias}${joinCollection.joins.length ? ` ${joinCollection.joins.join(' ')}` : ''} WHERE ${baseAlias}.${validatedTarget.primaryKey} IN (${placeholders}) ORDER BY ${baseAlias}.${validatedTarget.primaryKey} ASC`,
             params: targetIds,
         };
+    }
+
+    private buildQueryWindowSuffix<T, TSourceModel = unknown>(
+        state: Pick<QuerySetState<T, TSourceModel>, 'order' | 'limit' | 'offset'>,
+        validatedPlan: ValidatedSelectSqlPlan,
+        table: string,
+        options?: { existsProbe?: boolean }
+    ): { orderSQL: string; limitSQL: string; offsetSQL: string } {
+        const orderSQL = ` ORDER BY ${
+            state.order?.length
+                ? state.order
+                      .map((order) => `${validatedPlan.orderFields[String(order.by)]!} ${order.dir.toUpperCase()}`)
+                      .join(', ')
+                : `${table}.${validatedPlan.meta.pk} ASC`
+        }`;
+        const hasOffset = state.offset !== undefined;
+        const limitSQL = options?.existsProbe
+            ? state.limit === 0
+                ? ' LIMIT 0'
+                : ' LIMIT 1'
+            : state.limit !== undefined
+              ? ` LIMIT ${state.limit}`
+              : hasOffset && this.adapter.dialect === InternalDialect.SQLITE
+                ? ' LIMIT -1'
+                : '';
+        const offsetSQL = state.offset !== undefined ? ` OFFSET ${state.offset}` : '';
+        return { orderSQL, limitSQL, offsetSQL };
     }
 
     private compileManyToManyPrefetch(

--- a/packages/orm/src/query/compiler/tests/QueryCompiler.test.ts
+++ b/packages/orm/src/query/compiler/tests/QueryCompiler.test.ts
@@ -660,8 +660,8 @@ describe(QueryCompiler, () => {
         expect(result.sql).toContain('users.email = $1');
         expect(result.sql).toContain('NOT');
         expect(result.sql).toContain('users.name LIKE $2');
+        expect(result.sql).toContain('ORDER BY users.age DESC');
         expect(result.sql).toContain('LIMIT 1 OFFSET 20');
-        expect(result.sql).not.toContain('ORDER BY');
         expect(result.sql).not.toContain('users.*');
         expect(result.params).toEqual(['test@example.com', '%bot%']);
         expect(result.hydrationPlan).toBeUndefined();
@@ -671,6 +671,27 @@ describe(QueryCompiler, () => {
         const result = new QueryCompiler(mockMeta, postgresAdapter).compileExists({});
 
         expect(result.sql).toBe('SELECT 1 AS tango_exists FROM users LIMIT 1');
+        expect(result.params).toEqual([]);
+    });
+
+    it('compiles existence probes with zero limit', () => {
+        const result = new QueryCompiler(mockMeta, postgresAdapter).compileExists({ limit: 0 });
+
+        expect(result.sql).toBe('SELECT 1 AS tango_exists FROM users ORDER BY users.id ASC LIMIT 0');
+        expect(result.params).toEqual([]);
+    });
+
+    it('compiles existence probes with zero offset', () => {
+        const result = new QueryCompiler(mockMeta, postgresAdapter).compileExists({ offset: 0 });
+
+        expect(result.sql).toBe('SELECT 1 AS tango_exists FROM users ORDER BY users.id ASC LIMIT 1 OFFSET 0');
+        expect(result.params).toEqual([]);
+    });
+
+    it('compiles existence probes with zero limit and offset', () => {
+        const result = new QueryCompiler(mockMeta, postgresAdapter).compileExists({ limit: 0, offset: 5 });
+
+        expect(result.sql).toBe('SELECT 1 AS tango_exists FROM users ORDER BY users.id ASC LIMIT 0 OFFSET 5');
         expect(result.params).toEqual([]);
     });
 

--- a/packages/orm/src/query/tests/QuerySet.test.ts
+++ b/packages/orm/src/query/tests/QuerySet.test.ts
@@ -182,6 +182,22 @@ describe(QuerySet, () => {
         expect(run).toHaveBeenCalledWith(expect.objectContaining({ sql: expect.stringContaining('LIMIT 0') }));
     });
 
+    it('returns false from exists when limit is zero even if rows match', async () => {
+        const query = vi.fn(async (sql: string) => {
+            expect(sql).toContain('LIMIT 0');
+            expect(sql).not.toContain('COUNT(*)');
+            return { rows: [] as Array<{ tango_exists: number }> };
+        });
+        const queryExecutor = aQueryExecutor<User>({
+            meta,
+            query,
+            run: vi.fn(async () => [{ id: 1, email: 'a@a.com', active: true }]),
+        });
+        const qs = new ModelQuerySet<User>(queryExecutor).filter({ active: true });
+
+        await expect(qs.limit(0).exists()).resolves.toBe(false);
+    });
+
     it('preserves an explicit zero offset when fetching rows', async () => {
         const { queryExecutor, run } = createQueryExecutorFixture();
         const qs = new ModelQuerySet<User>(queryExecutor);


### PR DESCRIPTION
## Summary

- Fix `compileExists()` so `limit(0)` emits `LIMIT 0` and returns false when rows would match the filter.
- Apply shared `buildQueryWindowSuffix()` with `compile()` for order/limit/offset, including `offset(0)` and offset probes with `ORDER BY` + `LIMIT 1`.
- Keep the fast path (`SELECT 1 ... LIMIT 1` without `ORDER BY`) when neither limit nor offset is set, avoiding a `count()` subquery.

## Why

`exists()` was optimized to use `SELECT 1 LIMIT 1`, but the probe ignored `state.limit` and used a truthy offset check, so `limit(0).exists()` could be true while `limit(0).fetch()` returned no rows.

## Test plan

- [x] `pnpm exec vitest run src/query/compiler/tests/QueryCompiler.test.ts src/query/tests/QuerySet.test.ts` in `packages/orm` (334 tests)