### PR TITLE
fix: standardize methodNotAllowed error envelope

### DIFF
--- a/.changeset/method-not-allowed-envelope.md
+++ b/.changeset/method-not-allowed-envelope.md
@@ -1,0 +1,5 @@
+---
+'@danceroutine/tango-core': patch
+---
+
+Standardize `TangoResponse.methodNotAllowed()` and framework adapter 405/404 responses on the Tango error envelope so clients receive `{ error: { code, message } }` with `application/problem+json` instead of legacy `{ error: string }` JSON.

--- a/packages/adapters/next/src/adapter/NextAdapter.ts
+++ b/packages/adapters/next/src/adapter/NextAdapter.ts
@@ -433,21 +433,11 @@ export class NextAdapter implements FrameworkAdapter<Response, NextRouteHandler,
     }
 
     private methodNotAllowedResponse(): TangoResponse {
-        return TangoResponse.json(
-            {
-                error: 'Method not allowed for this route.',
-            },
-            { status: 405 }
-        );
+        return TangoResponse.methodNotAllowed(undefined, 'Method not allowed for this route.');
     }
 
     private notFoundResponse(): TangoResponse {
-        return TangoResponse.json(
-            {
-                error: 'Not found.',
-            },
-            { status: 404 }
-        );
+        return TangoResponse.notFound('Not found.');
     }
 
     private resolveActionMatch(viewset: NextCrudViewSet, method: HttpMethod, segments: string[]): ActionMatch | null {

--- a/packages/adapters/next/src/adapter/tests/NextAdapter.test.ts
+++ b/packages/adapters/next/src/adapter/tests/NextAdapter.test.ts
@@ -250,6 +250,9 @@ describe(NextAdapter, () => {
 
         const putWithoutId = await handlers.PUT(req, { params: Promise.resolve({}) });
         expect(putWithoutId.status).toBe(405);
+        expect(await putWithoutId.json()).toEqual({
+            error: { code: 'method_not_allowed', message: 'Method not allowed for this route.' },
+        });
 
         const retrieveByDirectId = await handlers.GET(req, {
             params: Promise.resolve({ id: '321' }),

--- a/packages/adapters/nuxt/src/adapter/NuxtAdapter.ts
+++ b/packages/adapters/nuxt/src/adapter/NuxtAdapter.ts
@@ -424,21 +424,11 @@ export class NuxtAdapter implements FrameworkAdapter<Response, NuxtEventHandler,
     }
 
     private methodNotAllowedResponse(): TangoResponse {
-        return TangoResponse.json(
-            {
-                error: 'Method not allowed for this route.',
-            },
-            { status: 405 }
-        );
+        return TangoResponse.methodNotAllowed(undefined, 'Method not allowed for this route.');
     }
 
     private notFoundResponse(): TangoResponse {
-        return TangoResponse.json(
-            {
-                error: 'Not found.',
-            },
-            { status: 404 }
-        );
+        return TangoResponse.notFound('Not found.');
     }
 
     private resolveActionMatch(viewset: NuxtCrudViewSet, method: HttpMethod, segments: string[]): ActionMatch | null {

--- a/packages/adapters/nuxt/src/adapter/tests/NuxtAdapter.test.ts
+++ b/packages/adapters/nuxt/src/adapter/tests/NuxtAdapter.test.ts
@@ -339,6 +339,9 @@ describe(NuxtAdapter, () => {
 
         const putWithoutId = await handler(createEvent({ method: 'PUT' }));
         expect(putWithoutId.status).toBe(405);
+        expect(await putWithoutId.json()).toEqual({
+            error: { code: 'method_not_allowed', message: 'Method not allowed for this route.' },
+        });
 
         const putWithNestedPath = await handler(createEvent({ method: 'PUT', params: { tango: '789/typo' } }));
         expect(putWithNestedPath.status).toBe(404);

--- a/packages/core/src/http/TangoResponse.ts
+++ b/packages/core/src/http/TangoResponse.ts
@@ -214,9 +214,9 @@ export class TangoResponse implements Response {
     /**
      * Create a `405 Method Not Allowed` response and optionally populate `Allow`.
      */
-    static methodNotAllowed(
+    static methodNotAllowed<TDetails extends ErrorDetails = null>(
         allow?: readonly string[],
-        detail: string = 'Method not allowed.',
+        detail?: string | TangoError | ProblemDetails<TDetails>,
         init?: Omit<TangoResponseInit, 'body' | 'status' | 'headers'> & {
             headers?: HeadersInit;
         }
@@ -225,15 +225,27 @@ export class TangoResponse implements Response {
         if (allow && allow.length > 0) {
             headers.set('Allow', allow.join(', '));
         }
-        return TangoResponse.json(
+
+        if (TangoError.isTangoError(detail) || TangoError.isProblemDetails(detail)) {
+            return TangoResponse.error(detail, { ...init, status: 405, headers });
+        }
+
+        if (typeof detail === 'string') {
+            return TangoResponse.error(
+                {
+                    code: 'method_not_allowed',
+                    message: detail,
+                },
+                { ...init, status: 405, headers }
+            );
+        }
+
+        return TangoResponse.error(
             {
-                error: detail,
+                code: 'method_not_allowed',
+                message: 'Method not allowed.',
             },
-            {
-                ...init,
-                status: 405,
-                headers,
-            }
+            { ...init, status: 405, headers }
         );
     }
 

--- a/packages/core/src/http/tests/TangoResponse.test.ts
+++ b/packages/core/src/http/tests/TangoResponse.test.ts
@@ -141,11 +141,18 @@ describe(TangoResponse, () => {
         const methodNotAllowed = TangoResponse.methodNotAllowed(['GET', 'POST']);
         expect(methodNotAllowed.status).toBe(405);
         expect(methodNotAllowed.headers.get('Allow')).toBe('GET, POST');
-        expect(await methodNotAllowed.json()).toEqual({ error: 'Method not allowed.' });
+        expect(methodNotAllowed.headers.get('Content-Type')).toContain('application/problem+json');
+        expect(await methodNotAllowed.json()).toEqual({
+            error: { code: 'method_not_allowed', message: 'Method not allowed.' },
+        });
 
         const methodNotAllowedWithoutAllow = TangoResponse.methodNotAllowed();
         expect(methodNotAllowedWithoutAllow.status).toBe(405);
         expect(methodNotAllowedWithoutAllow.headers.get('Allow')).toBeNull();
+        expect(methodNotAllowedWithoutAllow.headers.get('Content-Type')).toContain('application/problem+json');
+        expect(await methodNotAllowedWithoutAllow.json()).toEqual({
+            error: { code: 'method_not_allowed', message: 'Method not allowed.' },
+        });
     });
 
     it('turns TangoError subclasses into problem responses', async () => {
@@ -214,6 +221,30 @@ describe(TangoResponse, () => {
         const response = (TangoResponse[method] as (arg?: unknown) => TangoResponse)(input);
         expect(response.status).toBe(expectedStatus);
         expect(await response.json()).toEqual({ error: input });
+    });
+
+    it('methodNotAllowed with ProblemDetails returns 405 with the given body', async () => {
+        const input = { code: 'method_not_allowed', message: 'blocked' };
+        const response = TangoResponse.methodNotAllowed(undefined, input);
+        expect(response.status).toBe(405);
+        expect(await response.json()).toEqual({ error: input });
+    });
+
+    it('methodNotAllowed with TangoError uses the error status and envelope', async () => {
+        const response = TangoResponse.methodNotAllowed(['GET'], new TestTangoError('gone'));
+        expect(response.status).toBe(418);
+        expect(response.headers.get('Allow')).toBe('GET');
+        expect(await response.json()).toEqual({
+            error: { code: 'teapot', message: 'gone', details: { foo: ['bar'] } },
+        });
+    });
+
+    it('methodNotAllowed with a custom message returns 405 with the envelope', async () => {
+        const response = TangoResponse.methodNotAllowed(undefined, 'wrong verb');
+        expect(response.status).toBe(405);
+        expect(await response.json()).toEqual({
+            error: { code: 'method_not_allowed', message: 'wrong verb' },
+        });
     });
 
     it.each([

--- a/packages/resources/src/view/tests/APIView.test.ts
+++ b/packages/resources/src/view/tests/APIView.test.ts
@@ -87,7 +87,9 @@ describe(APIView, () => {
         const payload = await response.json();
 
         expect(response.status).toBe(405);
-        expect(payload).toEqual({ error: 'Method not allowed.' });
+        expect(payload).toEqual({
+            error: { code: 'method_not_allowed', message: 'Method not allowed.' },
+        });
         expect(response.headers.get('allow')).toBe('GET');
     });
 


### PR DESCRIPTION
## Summary

- Route `TangoResponse.methodNotAllowed()` through `error()` / `problem()` so 405 responses use the standard Tango envelope (`{ error: { code, message } }`) and `application/problem+json` content type.
- Delegate Next/Nuxt adapter `methodNotAllowedResponse()` and `notFoundResponse()` helpers to the core response builders instead of returning legacy `{ error: string }` JSON.

## Why

Framework-generated 405 errors were inconsistent with other helpers (`badRequest`, `notFound`, `conflict`, etc.), which would leak two different error shapes to API clients.

## Test plan

- [x] `pnpm --filter @danceroutine/tango-core test`
- [x] `pnpm --filter @danceroutine/tango-resources test`
- [x] `pnpm --filter @danceroutine/tango-adapters-next test`
- [x] `pnpm --filter @danceroutine/tango-adapters-nuxt test`