### PR TITLE
fix(core): clarify TangoResponse file helpers accept body bytes

### DIFF
--- a/.changeset/tangoresponse-file-body-clarity.md
+++ b/.changeset/tangoresponse-file-body-clarity.md
@@ -1,0 +1,5 @@
+---
+'@danceroutine/tango-core': minor
+---
+
+Clarify `TangoResponse.file()` and `TangoResponse.download()` so the first argument is response body bytes, not a filesystem path. Remove `string` from the accepted body type, rename the parameter to `body`, and add `TangoHeaders.setContentTypeForBody()` as the preferred helper. `setContentTypeByFile()` remains as a deprecated proxy.

--- a/packages/core/src/http/TangoHeaders.ts
+++ b/packages/core/src/http/TangoHeaders.ts
@@ -277,18 +277,15 @@ export class TangoHeaders extends Headers {
     }
 
     /**
-     * Attempt to guess and set the Content-Type header from a file (string or Blob) and optional filename.
+     * Attempt to guess and set the Content-Type header from response body bytes and an optional filename.
      *
-     * @param file File-like input (string or Blob)
-     * @param filename Optional filename to help guess mime type by extension
+     * @param body Response body bytes (for example a Blob or Uint8Array)
+     * @param filename Optional filename used to guess mime type by extension
      */
-    setContentTypeByFile(file: unknown, filename?: string): void {
-        // do not overwrite explicit content-type
+    setContentTypeForBody(body: unknown, filename?: string): void {
         if (this.has('Content-Type')) return;
 
-        // If file is a string and a filename is provided or can be guessed from file path
-        if (typeof file === 'string' && filename) {
-            // Guess type by extension
+        if (filename) {
             const dotIndex = filename.lastIndexOf('.');
             const ext = dotIndex >= 0 ? filename.slice(dotIndex + 1).toLowerCase() : '';
             const map: Record<string, string> = {
@@ -311,24 +308,27 @@ export class TangoHeaders extends Headers {
             const mime = map[ext];
             if (mime) {
                 this.set('Content-Type', mime);
+                return;
+            }
+        }
+
+        if (isBlob(body)) {
+            if (body.type && body.type !== '') {
+                this.set('Content-Type', body.type);
             } else {
                 this.set('Content-Type', 'application/octet-stream');
             }
             return;
         }
 
-        // If it's a Blob, use its type, or fallback
-        if (isBlob(file)) {
-            if (file.type && file.type !== '') {
-                this.set('Content-Type', file.type);
-            } else {
-                this.set('Content-Type', 'application/octet-stream');
-            }
-            return;
-        }
-
-        // Fallback
         this.set('Content-Type', 'application/octet-stream');
+    }
+
+    /**
+     * @deprecated Use {@link TangoHeaders.setContentTypeForBody} instead.
+     */
+    setContentTypeByFile(body: unknown, filename?: string): void {
+        this.setContentTypeForBody(body, filename);
     }
 
     /**

--- a/packages/core/src/http/TangoResponse.ts
+++ b/packages/core/src/http/TangoResponse.ts
@@ -567,10 +567,21 @@ export class TangoResponse implements Response {
     }
 
     /**
-     * Returns a response for serving a file.
+     * Create a response with inline Content-Disposition for file-like body content.
+     *
+     * The first argument is response body bytes, not a filesystem path. To serve bytes
+     * from disk, read the file first and pass the result here.
+     *
+     * @example
+     * ```ts
+     * import { readFile } from 'node:fs/promises';
+     *
+     * const bytes = await readFile('/data/report.pdf');
+     * return TangoResponse.file(bytes, { filename: 'report.pdf' });
+     * ```
      */
     static file(
-        file: Blob | Uint8Array | ArrayBuffer | ReadableStream<Uint8Array> | string,
+        body: Blob | Uint8Array | ArrayBuffer | ReadableStream<Uint8Array>,
         opts?: {
             filename?: string;
             contentType?: string;
@@ -579,29 +590,39 @@ export class TangoResponse implements Response {
     ): TangoResponse {
         const headers = new TangoHeaders(opts?.init?.headers ?? {});
         if (opts?.filename) {
-            // Serve as an attachment by default, but not 'download'
             headers.setContentDispositionInline(opts.filename);
         }
         if (opts?.contentType && !headers.has('Content-Type')) {
             headers.set('Content-Type', opts.contentType);
         } else if (!headers.has('Content-Type')) {
-            headers.setContentTypeByFile(file, opts?.filename);
+            headers.setContentTypeForBody(body, opts?.filename);
         }
         if (!headers.has('Content-Length')) {
-            headers.setContentLengthFromBody(file);
+            headers.setContentLengthFromBody(body);
         }
         return new TangoResponse({
             ...opts?.init,
-            body: file as BodyInit,
+            body: body as BodyInit,
             headers,
         });
     }
 
     /**
-     * Returns a response that prompts the user to download the file.
+     * Create a response with attachment Content-Disposition for file-like body content.
+     *
+     * The first argument must be the response body bytes, not a filesystem path. To serve bytes
+     * from disk, read the file first and pass the result here.
+     *
+     * @example
+     * ```ts
+     * import { readFile } from 'node:fs/promises';
+     *
+     * const bytes = await readFile('/data/report.pdf');
+     * return TangoResponse.download(bytes, { filename: 'report.pdf' });
+     * ```
      */
     static download(
-        file: Blob | Uint8Array | ArrayBuffer | ReadableStream<Uint8Array> | string,
+        body: Blob | Uint8Array | ArrayBuffer | ReadableStream<Uint8Array>,
         opts?: {
             filename?: string;
             contentType?: string;
@@ -617,14 +638,14 @@ export class TangoResponse implements Response {
         if (opts?.contentType && !headers.has('Content-Type')) {
             headers.set('Content-Type', opts.contentType);
         } else if (!headers.has('Content-Type')) {
-            headers.setContentTypeByFile(file, opts?.filename);
+            headers.setContentTypeForBody(body, opts?.filename);
         }
         if (!headers.has('Content-Length')) {
-            headers.setContentLengthFromBody(file);
+            headers.setContentLengthFromBody(body);
         }
         return new TangoResponse({
             ...opts?.init,
-            body: file as BodyInit,
+            body: body as BodyInit,
             headers,
         });
     }

--- a/packages/core/src/http/tests/TangoHeaders.test.ts
+++ b/packages/core/src/http/tests/TangoHeaders.test.ts
@@ -79,34 +79,39 @@ describe(TangoHeaders, () => {
     });
 
     it('infers content metadata and preserves trace headers', () => {
+        const bodyBytes = new Uint8Array([120]);
         const headers = new TangoHeaders();
-        headers.setContentTypeByFile('x', 'a.txt');
+        headers.setContentTypeForBody(bodyBytes, 'a.txt');
         expect(headers.get('Content-Type')).toBe('text/plain');
 
         const unknown = new TangoHeaders();
-        unknown.setContentTypeByFile('x', 'a.unknown');
+        unknown.setContentTypeForBody(bodyBytes, 'a.unknown');
         expect(unknown.get('Content-Type')).toBe('application/octet-stream');
 
         const noExtension = new TangoHeaders();
-        noExtension.setContentTypeByFile('x', 'README');
+        noExtension.setContentTypeForBody(bodyBytes, 'README');
         expect(noExtension.get('Content-Type')).toBe('application/octet-stream');
 
         const blob = new Blob(['abc'], { type: 'text/custom' });
         const blobHeaders = new TangoHeaders();
-        blobHeaders.setContentTypeByFile(blob);
+        blobHeaders.setContentTypeForBody(blob);
         expect(blobHeaders.get('Content-Type')).toBe('text/custom');
 
         const emptyBlobHeaders = new TangoHeaders();
-        emptyBlobHeaders.setContentTypeByFile(new Blob(['abc']));
+        emptyBlobHeaders.setContentTypeForBody(new Blob(['abc']));
         expect(emptyBlobHeaders.get('Content-Type')).toBe('application/octet-stream');
 
         const fallbackHeaders = new TangoHeaders();
-        fallbackHeaders.setContentTypeByFile({});
+        fallbackHeaders.setContentTypeForBody({});
         expect(fallbackHeaders.get('Content-Type')).toBe('application/octet-stream');
 
         const keepTypeHeaders = new TangoHeaders({ 'Content-Type': 'keep/me' });
-        keepTypeHeaders.setContentTypeByFile('x', 'a.json');
+        keepTypeHeaders.setContentTypeForBody(bodyBytes, 'a.json');
         expect(keepTypeHeaders.get('Content-Type')).toBe('keep/me');
+
+        const deprecatedHeaders = new TangoHeaders();
+        deprecatedHeaders.setContentTypeByFile(bodyBytes, 'a.txt');
+        expect(deprecatedHeaders.get('Content-Type')).toBe('text/plain');
 
         const lenHeaders = new TangoHeaders();
         lenHeaders.setContentLengthFromBody('hello');

--- a/packages/core/src/http/tests/TangoResponse.test.ts
+++ b/packages/core/src/http/tests/TangoResponse.test.ts
@@ -288,33 +288,38 @@ describe(TangoResponse, () => {
         const form = await formRes.formData();
         expect(form.get('a')).toBe('1');
 
-        const fileInline = TangoResponse.file('abc', { filename: 'a.txt' });
+        const fileBody = new Blob(['abc']);
+        const fileInline = TangoResponse.file(fileBody, { filename: 'a.txt' });
         expect(fileInline.headers.get('Content-Disposition')).toContain('inline');
 
-        const fileWithType = TangoResponse.file('abc', { contentType: 'text/custom' });
+        const fileWithType = TangoResponse.file(fileBody, { contentType: 'text/custom' });
         expect(fileWithType.headers.get('Content-Type')).toBe('text/custom');
 
-        const fileWithHeaderType = TangoResponse.file('abc', { init: { headers: { 'Content-Type': 'x/preferred' } } });
+        const fileWithHeaderType = TangoResponse.file(fileBody, {
+            init: { headers: { 'Content-Type': 'x/preferred' } },
+        });
         expect(fileWithHeaderType.headers.get('Content-Type')).toBe('x/preferred');
 
-        const fileWithHeaderLength = TangoResponse.file('abc', { init: { headers: { 'Content-Length': '99' } } });
+        const fileWithHeaderLength = TangoResponse.file(fileBody, {
+            init: { headers: { 'Content-Length': '99' } },
+        });
         expect(fileWithHeaderLength.headers.get('Content-Length')).toBe('99');
 
         const downloadNamed = TangoResponse.download(new Blob(['abc']), { filename: 'a.txt' });
         expect(downloadNamed.headers.get('Content-Disposition')).toContain('attachment');
 
-        const downloadUnnamed = TangoResponse.download('abc');
+        const downloadUnnamed = TangoResponse.download(fileBody);
         expect(downloadUnnamed.headers.get('Content-Disposition')).toBe('attachment');
 
-        const downloadWithType = TangoResponse.download('abc', { contentType: 'text/custom' });
+        const downloadWithType = TangoResponse.download(fileBody, { contentType: 'text/custom' });
         expect(downloadWithType.headers.get('Content-Type')).toBe('text/custom');
 
-        const downloadWithHeaderType = TangoResponse.download('abc', {
+        const downloadWithHeaderType = TangoResponse.download(fileBody, {
             init: { headers: { 'Content-Type': 'x/preferred' } },
         });
         expect(downloadWithHeaderType.headers.get('Content-Type')).toBe('x/preferred');
 
-        const downloadWithHeaderLength = TangoResponse.download('abc', {
+        const downloadWithHeaderLength = TangoResponse.download(fileBody, {
             init: { headers: { 'Content-Length': '101' } },
         });
         expect(downloadWithHeaderLength.headers.get('Content-Length')).toBe('101');


### PR DESCRIPTION
## Summary
- Clarify `TangoResponse.file()` and `TangoResponse.download()` so the first argument is response body bytes, not a filesystem path
- Remove `string` from the accepted body type and rename the parameter to `body`
- Add `TangoHeaders.setContentTypeForBody()` as the preferred helper; keep `setContentTypeByFile()` as a deprecated proxy

## Test plan
- [x] `pnpm run lint:ox && pnpm run lint:eslint && pnpm run format:check`
- [x] `pnpm --filter @danceroutine/tango-core typecheck`
- [x] `pnpm --filter @danceroutine/tango-core test`
- [x] `pnpm --filter @danceroutine/tango-core build`